### PR TITLE
[Fix #9] RSpec Required Files Outside Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+**[WIP]** Support for CI
+
+## [0.1.1] - 2021-08-28
+
+### Fixed
+
+- Failures when RSpec required files are outside of project
+
 ## [0.1.0] - 2021-08-27
 
 **Initial Release**

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     rspec-tracer (0.1.0)
       docile (~> 1.1.0)
-      rspec-core (>= 3.6.0)
+      rspec-core (~> 3.6, >= 3.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/features/step_definitions/project_steps.rb
+++ b/features/step_definitions/project_steps.rb
@@ -24,6 +24,9 @@ Given('I am working on the project {string}') do |project|
       File.join(project_dir, "../../sample_projects/#{project}/"),
       'project'
     )
+
+    FileUtils.mkdir_p('/tmp/helpers')
+    FileUtils.touch('/tmp/helpers/test.rb')
   end
 end
 

--- a/lib/rspec_tracer/runner.rb
+++ b/lib/rspec_tracer/runner.rb
@@ -208,10 +208,11 @@ module RSpecTracer
       rspec_root = RSpec::Core::RubyProject.root
       rspec_path = RSpec.configuration.default_path
 
-      RSpec.configuration.requires.map do |file_name|
+      RSpec.configuration.requires.each_with_object([]) do |file_name, required_files|
         file_name = "#{file_name}.rb" if File.extname(file_name).empty?
+        file_path = File.join(rspec_root, rspec_path, file_name)
 
-        File.join(rspec_root, rspec_path, file_name)
+        required_files << file_path if File.file?(file_path)
       end
     end
 

--- a/sample_projects/rails_app/.rspec
+++ b/sample_projects/rails_app/.rspec
@@ -1,2 +1,3 @@
+--require /tmp/helpers/test.rb
 --require spec_helper
 --format documentation

--- a/sample_projects/ruby_app/.rspec
+++ b/sample_projects/ruby_app/.rspec
@@ -1,2 +1,3 @@
 --require spec_helper
+--require /tmp/helpers/test.rb
 --format documentation


### PR DESCRIPTION
Gracefully handle the required files in the `.rspec` file which are
outside of the project. Fixes https://github.com/avmnu-sng/rspec-tracer/issues/9