### PR TITLE
[Fix #12] Docile Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 **[WIP]** Support for CI
 
-## [0.1.1] - 2021-08-28
+## [0.3.0] - 2021-08-30
+
+### Fixed
+
+- `docile` version compatability with `simplecov`
+
+## [0.2.0] - 2021-08-28
 
 ### Fixed
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rspec-tracer (0.2.0)
-      docile (~> 1.1.0)
+      docile (~> 1.1, >= 1.1.0)
       rspec-core (~> 3.6, >= 3.6.0)
 
 GEM

--- a/lib/rspec_tracer/version.rb
+++ b/lib/rspec_tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RSpecTracer
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/rspec-tracer.gemspec
+++ b/rspec-tracer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'docile', '~> 1.1.0'
+  spec.add_dependency 'docile', '~> 1.1', '>= 1.1.0'
   spec.add_dependency 'rspec-core', '~> 3.6', '>= 3.6.0'
 
   spec.files = Dir['{lib}/**/*.*', 'LICENSE', 'CHANGELOG.md', 'README.md', 'doc/*']


### PR DESCRIPTION
Fix `docile` runtime dependency for compatibility with `simplecov`.