### PR TITLE
[Fix #17] Improve Dependency Change Detection

### DIFF
--- a/features/step_definitions/report_steps.rb
+++ b/features/step_definitions/report_steps.rb
@@ -112,6 +112,13 @@ Then('The dependency report should have correct details') do
     report.each_pair do |example_id, dependency|
       expect(dependency).to contain_exactly(*data[example_id])
     end
+
+    dependency_files = Set.new
+    report.each_value { |files| dependency_files |= files }
+
+    all_files = JSON.parse(File.read("#{@cache_dir}/#{@run_id}/all_files.json")).keys.to_set
+
+    expect(dependency_files).to eq(all_files)
   end
 end
 
@@ -128,5 +135,9 @@ Then('The reverse dependency report should have correct details') do
     report.each_pair do |example_id, dependency|
       expect(dependency).to eq(data[example_id])
     end
+
+    all_files = JSON.parse(File.read("#{@cache_dir}/#{@run_id}/all_files.json")).keys.sort
+
+    expect(report.keys.sort).to eq(all_files)
   end
 end

--- a/lib/rspec_tracer/reporter.rb
+++ b/lib/rspec_tracer/reporter.rb
@@ -2,8 +2,9 @@
 
 module RSpecTracer
   class Reporter
-    attr_reader :all_examples, :pending_examples, :all_files, :dependency,
-                :reverse_dependency, :examples_coverage, :last_run
+    attr_reader :all_examples, :pending_examples, :all_files, :modified_files,
+                :deleted_files, :dependency, :reverse_dependency, :examples_coverage,
+                :last_run
 
     def initialize
       initialize_examples


### PR DESCRIPTION
Check for all the files in one go and then find all the examples to run
because the dependent files changed.