### PR TITLE
[Fix #20] Filter vendor from coverage

### DIFF
--- a/lib/rspec_tracer/defaults.rb
+++ b/lib/rspec_tracer/defaults.rb
@@ -2,7 +2,13 @@
 
 RSpecTracer.configure do
   add_filter '/vendor/bundle/'
-  add_coverage_filter %w[/autotest/ /features/ /spec/ /test/].freeze
+  add_coverage_filter %w[
+    /autotest/
+    /features/
+    /spec/
+    /test/
+    /vendor/bundle/
+  ].freeze
 end
 
 at_exit do


### PR DESCRIPTION
The examples coverage report will not include `vendor` files.