### PR TITLE
MessagePack version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,9 @@ source 'https://rubygems.org'
 
 group :development do
   gem 'aruba', '~> 2.0.0'
+  gem 'contracts', '< 0.17'
   gem 'cucumber', '~> 7.0.0'
+  gem 'msgpack', '~> 1.3'
   gem 'pry', '~> 0.14.0'
   gem 'rake', '~> 13.0.0'
   gem 'rspec', '~> 3.10.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0901)
+    msgpack (1.4.2)
     multi_test (0.1.2)
     parallel (1.20.1)
     parser (3.0.2.0)
@@ -124,10 +125,13 @@ GEM
 
 PLATFORMS
   x86_64-darwin-19
+  x86_64-darwin-20
 
 DEPENDENCIES
   aruba (~> 2.0.0)
+  contracts (< 0.17)
   cucumber (~> 7.0.0)
+  msgpack (~> 1.3)
   pry (~> 0.14.0)
   rake (~> 13.0.0)
   rspec (~> 3.10.0)

--- a/README.md
+++ b/README.md
@@ -150,8 +150,7 @@ browser of your choice.
 
 ## Environment Variables
 
-To get better control on execution, you can use the following environment variables
-whenever required.
+To get better control on execution, you can use the following two environment variables:
 
 ### BUNDLE_PATH
 
@@ -214,7 +213,7 @@ export TEST_SUITES=8
 
 If you have a large set of tests to run, it is recommended to run them in
 separate groups. This way, RSpec Tracer is not overwhelmed with loading massive
-cached data in the memory. Also, it generates and uses cache for specific test suites
+cached data in the memory. Also, it generate and use cache for specific test suites
 and not merge them.
 
 ```ruby
@@ -236,6 +235,45 @@ make sure to provide the test suite id.
 ```sh
 $ TEST_SUITE_ID=1 bundle exec rake rspec_tracer:remote_cache:upload
 ```
+
+## Serializers
+
+You can configure the serialization for the cache using either the `cache_serializer` option or setting `CACHE_SERIALIZER` in your ENV
+
+### JSON
+
+This is the default serializer and uses `JSON.generate` and `JSON.parse`, it has the advantage of being human readable but it is also larger and slower to read from and write to than the other two serializers. If you want to explicitly enable this serializer the value you need to set `cache_serializer` to is `json`
+
+### MessagePack
+
+This uses `MessagePack.pack` and `MessagePack.unpack` to handle serialization. It is the sweetspot when it comes to size and performance. It is lighter than `JSON` and slightly faster too.
+
+### Adding new serializers
+
+If you wish to add a new serializer you need to create a new class which will inherit `RSpecTracer::Serializer` and the class name needs to end in `Serializer`. It will need to implement a `serialize` and `deserialize` method and also set both an `EXTENSION` and a `ENCODING` constant.
+
+```ruby
+module RSpecTracer
+  class MyCustomSerializer < Serializer
+    ENCODING = Encoding::BINARY
+    EXTENSION = 'my_ext'
+
+    class << self
+      def serialize(object)
+        # converting any given object to file content
+      end
+
+      def deserialize(input)
+        # converting any given file content back to an object
+      end
+    end
+  end
+end
+```
+
+You will want this to always be true `deserialize(serialize(object)) == object` for `RSpecTracer` to work with your serializer.
+
+Then to use your custom serializer you'll need to specify your serializer's name in `camel_case`. So in the given example I would set the `cache_serializer` to `my_custom`
 
 ## Sample Reports
 

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -10,6 +10,9 @@ require 'json'
 require 'pry'
 require 'set'
 
+require_relative 'rspec_tracer/messagepack/time_extension'
+
+require_relative 'rspec_tracer/serializer'
 require_relative 'rspec_tracer/configuration'
 RSpecTracer.extend RSpecTracer::Configuration
 

--- a/lib/rspec_tracer/cache.rb
+++ b/lib/rspec_tracer/cache.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'msgpack'
+
 module RSpecTracer
   class Cache
     attr_reader :all_examples, :flaky_examples, :failed_examples, :pending_examples,
@@ -57,19 +59,19 @@ module RSpecTracer
     private
 
     def last_run_id
-      file_name = File.join(RSpecTracer.cache_path, 'last_run.json')
+      file_name = File.join(RSpecTracer.cache_path, "last_run.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      JSON.parse(File.read(file_name))['run_id']
+      RSpecTracer.cache_serializer.deserialize(File.read(file_name))['run_id']
     end
 
     def load_all_examples_cache
-      file_name = File.join(@cache_dir, 'all_examples.json')
+      file_name = File.join(@cache_dir, "all_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @all_examples = JSON.parse(File.read(file_name)).transform_values do |examples|
+      @all_examples = RSpecTracer.cache_serializer.deserialize(File.read(file_name)).transform_values do |examples|
         examples.transform_keys(&:to_sym)
       end
 
@@ -81,53 +83,53 @@ module RSpecTracer
     end
 
     def load_flaky_examples_cache
-      file_name = File.join(@cache_dir, 'flaky_examples.json')
+      file_name = File.join(@cache_dir, "flaky_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @flaky_examples = JSON.parse(File.read(file_name)).to_set
+      @flaky_examples = RSpecTracer.cache_serializer.deserialize(File.read(file_name))&.to_set || []
     end
 
     def load_failed_examples_cache
-      file_name = File.join(@cache_dir, 'failed_examples.json')
+      file_name = File.join(@cache_dir, "failed_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @failed_examples = JSON.parse(File.read(file_name)).to_set
+      @failed_examples = RSpecTracer.cache_serializer.deserialize(File.read(file_name))&.to_set || []
     end
 
     def load_pending_examples_cache
-      file_name = File.join(@cache_dir, 'pending_examples.json')
+      file_name = File.join(@cache_dir, "pending_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @pending_examples = JSON.parse(File.read(file_name)).to_set
+      @pending_examples = RSpecTracer.cache_serializer.deserialize(File.read(file_name))&.to_set || []
     end
 
     def load_all_files_cache
-      file_name = File.join(@cache_dir, 'all_files.json')
+      file_name = File.join(@cache_dir, "all_files.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @all_files = JSON.parse(File.read(file_name)).transform_values do |files|
+      @all_files = RSpecTracer.cache_serializer.deserialize(File.read(file_name)).transform_values do |files|
         files.transform_keys(&:to_sym)
       end
     end
 
     def load_dependency_cache
-      file_name = File.join(@cache_dir, 'dependency.json')
+      file_name = File.join(@cache_dir, "dependency.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @dependency = JSON.parse(File.read(file_name)).transform_values(&:to_set)
+      @dependency = RSpecTracer.cache_serializer.deserialize(File.read(file_name)).transform_values(&:to_set)
     end
 
     def load_examples_coverage_cache
-      file_name = File.join(@cache_dir, 'examples_coverage.json')
+      file_name = File.join(@cache_dir, "examples_coverage.#{RSpecTracer.cache_serializer::EXTENSION}")
 
       return unless File.file?(file_name)
 
-      @examples_coverage = JSON.parse(File.read(file_name))
+      @examples_coverage = RSpecTracer.cache_serializer.deserialize(File.read(file_name))
     end
   end
 end

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -112,6 +112,22 @@ module RSpecTracer
       Docile.dsl_eval(self, &block)
     end
 
+    def cache_serializer
+      return @cache_serializer if @cache_serializer.is_a?(Serializer)
+
+      @cache_serializer = ENV['CACHE_SERIALIZER']
+      @cache_serializer = case @cache_serializer
+                          when nil, 'json' then JSONSerializer
+                          when 'message_pack' then MessagePackSerializer
+                          else
+                            if @cache_serializer.is_a? String
+                              "#{@cache_serializer.camelize}Serializer".constantize
+                            else
+                              JSONSerializer
+                            end
+                          end
+    end
+
     private
 
     def test_suite_id

--- a/lib/rspec_tracer/messagepack/time_extension.rb
+++ b/lib/rspec_tracer/messagepack/time_extension.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'msgpack'
+
+MessagePack::DefaultFactory.register_type(
+  MessagePack::Timestamp::TYPE,
+  Time,
+  packer: MessagePack::Time::Packer,
+  unpacker: MessagePack::Time::Unpacker
+)

--- a/lib/rspec_tracer/remote_cache/cache.rb
+++ b/lib/rspec_tracer/remote_cache/cache.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'git'
+require 'msgpack'
 
 module RSpecTracer
   module RemoteCache
@@ -176,7 +177,7 @@ module RSpecTracer
 
         return unless File.file?(file_name)
 
-        run_id = JSON.parse(File.read(file_name))['run_id']
+        run_id = RSpecTracer.cache_serializer.deserialize(File.read(file_name))['run_id']
 
         raise LocalCacheNotFoundError, 'Could not find any local cache to upload' if run_id.nil?
 

--- a/lib/rspec_tracer/reporter.rb
+++ b/lib/rspec_tracer/reporter.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'msgpack'
+
 module RSpecTracer
   class Reporter
     attr_reader :all_examples, :possibly_flaky_examples, :flaky_examples, :pending_examples,
@@ -227,58 +229,67 @@ module RSpecTracer
     end
 
     def write_all_examples_report
-      file_name = File.join(@cache_dir, 'all_examples.json')
+      file_name = File.join(@cache_dir, "all_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@all_examples))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@all_examples),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_flaky_examples_report
-      file_name = File.join(@cache_dir, 'flaky_examples.json')
+      file_name = File.join(@cache_dir, "flaky_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@flaky_examples.to_a))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@flaky_examples.to_a),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_failed_examples_report
-      file_name = File.join(@cache_dir, 'failed_examples.json')
+      file_name = File.join(@cache_dir, "failed_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@failed_examples.to_a))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@failed_examples.to_a),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_pending_examples_report
-      file_name = File.join(@cache_dir, 'pending_examples.json')
+      file_name = File.join(@cache_dir, "pending_examples.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@pending_examples.to_a))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@pending_examples.to_a),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_all_files_report
-      file_name = File.join(@cache_dir, 'all_files.json')
+      file_name = File.join(@cache_dir, "all_files.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@all_files))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@all_files),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_dependency_report
-      file_name = File.join(@cache_dir, 'dependency.json')
+      file_name = File.join(@cache_dir, "dependency.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@dependency))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@dependency),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_reverse_dependency_report
-      file_name = File.join(@cache_dir, 'reverse_dependency.json')
+      file_name = File.join(@cache_dir, "reverse_dependency.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@reverse_dependency))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@reverse_dependency),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_examples_coverage_report
-      file_name = File.join(@cache_dir, 'examples_coverage.json')
+      file_name = File.join(@cache_dir, "examples_coverage.#{RSpecTracer.cache_serializer::EXTENSION}")
 
-      File.write(file_name, JSON.generate(@examples_coverage))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(@examples_coverage),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
 
     def write_last_run_report
-      file_name = File.join(RSpecTracer.cache_path, 'last_run.json')
+      file_name = File.join(RSpecTracer.cache_path, "last_run.#{RSpecTracer.cache_serializer::EXTENSION}")
       last_run_data = @last_run.merge(run_id: @run_id, timestamp: Time.now.utc)
 
-      File.write(file_name, JSON.generate(last_run_data))
+      File.write(file_name, RSpecTracer.cache_serializer.serialize(last_run_data),
+                 encoding: RSpecTracer.cache_serializer::ENCODING)
     end
   end
 end

--- a/lib/rspec_tracer/serializer.rb
+++ b/lib/rspec_tracer/serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RSpecTracer
+  class Serializer
+    ENCODING = nil
+    EXTENSION = nil
+
+    class << self
+      def serialize(_object)
+        raise NotImplementedError, 'You must implement serialize.'
+      end
+
+      def deserialize(_input)
+        raise NotImplementedError, 'You must implement deserialize.'
+      end
+    end
+  end
+end
+
+require_relative 'serializers/json_serializer'
+require_relative 'serializers/message_pack_serializer'

--- a/lib/rspec_tracer/serializers/json_serializer.rb
+++ b/lib/rspec_tracer/serializers/json_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RSpecTracer
+  class JSONSerializer < Serializer
+    ENCODING = Encoding::UTF_8
+    EXTENSION = 'json'
+
+    class << self
+      def serialize(object)
+        JSON.generate(object)
+      end
+
+      def deserialize(input)
+        JSON.parse(input)
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/serializers/message_pack_serializer.rb
+++ b/lib/rspec_tracer/serializers/message_pack_serializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module RSpecTracer
+  class MessagePackSerializer < Serializer
+    ENCODING = Encoding::BINARY
+    EXTENSION = 'msgpack'
+
+    class << self
+      def serialize(object)
+        MessagePack.pack(object)
+      end
+
+      def deserialize(input)
+        MessagePack.unpack(input)
+      end
+    end
+  end
+end


### PR DESCRIPTION
MessagePack is more compact and slightly faster on average than `JSON.parse`/`JSON.pretty_generate`.

In my use case I had
- 5561 tests
- The cache was 66MB when using the JSON version
- Loading the cache and rerunning the pending tests I setup took ~4 minutes
- The cache generation took a fair bit of time (I did not time this unfortunately as the whole test suite takes upwards of an hour to run)

When using MessagePack
- The cache was reduced to 34MB
- Loading the cache and rerunning the pending tests I setup took ~3 minutes
- Cache generation took under 30 seconds

Did not quite know how I could add this as a configuration option but if you could point me in the right direction I was thinking of `cache_serializer` and have it be either `JSON` or `MessagePack` basically 🤔 

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Feature branch is up-to-date with the `main` branch.
* [x] Squashed related commits together.
* [ ] Added tests. (Don't know which ones to add yet since i's more of a replacement)
* [x] Run `bundle exec rake`.
