### PR TITLE
[Fix #24] Bug in format time

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ integrating the gem into your project to better understand what is happening.
   * [RSPEC_TRACER_NO_SKIP](#rspec_tracer_no_skip)
   * [RSPEC_TRACER_S3_URI](#rspec_tracer_s3_uri)
   * [RSPEC_TRACER_UPLOAD_LOCAL_CACHE](#rspec_tracer_upload_local_cache)
+  * [RSPEC_TRACER_VERBOSE](#rspec_tracer_verbose)
   * [TEST_SUITES](#test_suites)
   * [TEST_SUITE_ID](#test_suite_id)
 * [Sample Reports](#sample-reports)
@@ -191,6 +192,14 @@ export RSPEC_TRACER_S3_URI=s3://ci-artifacts-bucket/rspec-tracer-cache
 
 By default, RSpec Tracer does not upload local cache files. You can set this
 environment variable to `true` to upload the local cache to S3.
+
+### RSPEC_TRACER_VERBOSE
+
+To print the intermediate steps and time taken, use this environment variable:
+
+```sh
+export RSPEC_TRACER_VERBOSE=true
+```
 
 ### TEST_SUITES
 

--- a/features/step_definitions/report_steps.rb
+++ b/features/step_definitions/report_steps.rb
@@ -5,7 +5,7 @@ Then('The RSpecTracer should print the information') do |expected_output|
     .map(&:strip)
     .reject(&:empty?)
     .map { |line| line.sub(/\(FAILED(\s-\s\d+)\)$/, 'FAILED') }
-    .map { |line| line.sub(/\s\(took 0.\d{5}\sseconds\)$/, '') }
+    .map { |line| line.sub(/\s\(took 0(.\d{0,5})?\sseconds\)$/, '') }
 
   expected = expected_output.lines
     .map(&:strip)

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -201,7 +201,7 @@ module RSpecTracer
       ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elpased = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
-      puts "RSpec tracer processed dependency (took #{elpased})"
+      puts "RSpec tracer processed dependency (took #{elpased})" if RSpecTracer.verbose?
     end
 
     def process_coverage
@@ -214,7 +214,7 @@ module RSpecTracer
       ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elpased = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
-      puts "RSpec tracer processed coverage (took #{elpased})"
+      puts "RSpec tracer processed coverage (took #{elpased})" if RSpecTracer.verbose?
     end
 
     def run_simplecov_exit_task

--- a/lib/rspec_tracer/cache.rb
+++ b/lib/rspec_tracer/cache.rb
@@ -49,7 +49,7 @@ module RSpecTracer
       ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elpased = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
-      puts "RSpec tracer loaded cached examples coverage (took #{elpased})"
+      puts "RSpec tracer loaded cached examples coverage (took #{elpased})" if RSpecTracer.verbose?
 
       coverage
     end

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -102,6 +102,12 @@ module RSpecTracer
       @coverage_filters ||= []
     end
 
+    def verbose?
+      return @verbose if defined?(@verbose)
+
+      @verbose = ENV.fetch('RSPEC_TRACER_VERBOSE', 'false') == 'true'
+    end
+
     def configure(&block)
       Docile.dsl_eval(self, &block)
     end

--- a/lib/rspec_tracer/runner.rb
+++ b/lib/rspec_tracer/runner.rb
@@ -140,7 +140,7 @@ module RSpecTracer
         ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         elpased = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
-        puts "RSpec tracer generated #{report_type.to_s.tr('_', ' ')} report (took #{elpased})"
+        puts "RSpec tracer generated #{report_type.to_s.tr('_', ' ')} report (took #{elpased})" if RSpecTracer.verbose?
       end
 
       @reporter.write_reports
@@ -162,7 +162,7 @@ module RSpecTracer
       ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elpased = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
-      puts "RSpec tracer processed cache (took #{elpased})"
+      puts "RSpec tracer processed cache (took #{elpased})" if RSpecTracer.verbose?
     end
 
     def filter_by_example_status
@@ -270,7 +270,7 @@ module RSpecTracer
       ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elpased = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
-      puts "RSpec tracer generated flaky, failed, and pending examples report (took #{elpased})"
+      puts "RSpec tracer generated flaky, failed, and pending examples report (took #{elpased})" if RSpecTracer.verbose?
     end
 
     def generate_all_files_report

--- a/lib/rspec_tracer/time_formatter.rb
+++ b/lib/rspec_tracer/time_formatter.rb
@@ -21,11 +21,10 @@ module RSpecTracer
         next unless seconds.positive?
 
         seconds, remainder = seconds.divmod(count)
-        remainder = format_duration(remainder)
 
         next if remainder.zero?
 
-        duration << pluralize(remainder, unit)
+        duration << pluralize(format_duration(remainder), unit)
       end
 
       formatted_duration.reverse.join(' ')
@@ -36,17 +35,21 @@ module RSpecTracer
 
       precision = duration < 1 ? SECONDS_PRECISION : DEFAULT_PRECISION
 
-      format("%<duration>0.#{precision}f", duration: duration)
+      strip_trailing_zeroes(format("%<duration>0.#{precision}f", duration: duration))
+    end
+
+    def strip_trailing_zeroes(formatted_duration)
+      formatted_duration.sub(/(?:(\..*[^0])0+|\.0+)$/, '\1')
     end
 
     def pluralize(duration, unit)
-      if duration == 1
+      if (duration.to_f - 1).abs < Float::EPSILON
         "#{duration} #{unit}"
       else
         "#{duration} #{unit}s"
       end
     end
 
-    private_class_method :format_duration, :pluralize
+    private_class_method :format_duration, :strip_trailing_zeroes, :pluralize
   end
 end

--- a/spec/time_formatter_spec.rb
+++ b/spec/time_formatter_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe RSpecTracer::TimeFormatter do
+  describe '#format_time' do
+    {
+      0.03456794 => '0.03457 seconds',
+      0.005 => '0.005 seconds',
+      1 => '1 second',
+      3 => '3 seconds',
+      60 => '1 minute',
+      63.45 => '1 minute 3.45 seconds',
+      168 => '2 minutes 48 seconds',
+      180 => '3 minutes',
+      3600.0 => '1 hour'
+    }.freeze.each_pair do |seconds, formatted_time|
+      it "formats #{seconds} seconds into #{formatted_time}" do
+        expect(described_class.format_time(seconds)).to eq(formatted_time)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes checking `.zero?` on the string. Also, added support for `verbose`
environment variable to print the progress and the elapsed time.
