### PR TITLE
Improve Dependency Processing

### DIFF
--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -250,7 +250,7 @@ module RSpecTracer
         }
       }
 
-      File.write(file_name, JSON.generate(report))
+      File.write(file_name, JSON.pretty_generate(report))
     end
 
     def print_coverage_stats(file_name, elpased)

--- a/lib/rspec_tracer/coverage_reporter.rb
+++ b/lib/rspec_tracer/coverage_reporter.rb
@@ -29,11 +29,15 @@ module RSpecTracer
 
     def compute_diff(example_id)
       peek_coverage.each_pair do |file_path, current_stats|
-        if @coverage.key?(file_path)
-          existing_file_diff_coverage(example_id, file_path, current_stats)
-        else
+        unless @coverage.key?(file_path)
           missing_file_diff_coverage(example_id, file_path, current_stats)
+
+          next
         end
+
+        next if current_stats == @coverage[file_path]
+
+        existing_file_diff_coverage(example_id, file_path, current_stats)
       end
     end
 

--- a/lib/rspec_tracer/reporter.rb
+++ b/lib/rspec_tracer/reporter.rb
@@ -229,56 +229,56 @@ module RSpecTracer
     def write_all_examples_report
       file_name = File.join(@cache_dir, 'all_examples.json')
 
-      File.write(file_name, JSON.generate(@all_examples))
+      File.write(file_name, JSON.pretty_generate(@all_examples))
     end
 
     def write_flaky_examples_report
       file_name = File.join(@cache_dir, 'flaky_examples.json')
 
-      File.write(file_name, JSON.generate(@flaky_examples.to_a))
+      File.write(file_name, JSON.pretty_generate(@flaky_examples.to_a))
     end
 
     def write_failed_examples_report
       file_name = File.join(@cache_dir, 'failed_examples.json')
 
-      File.write(file_name, JSON.generate(@failed_examples.to_a))
+      File.write(file_name, JSON.pretty_generate(@failed_examples.to_a))
     end
 
     def write_pending_examples_report
       file_name = File.join(@cache_dir, 'pending_examples.json')
 
-      File.write(file_name, JSON.generate(@pending_examples.to_a))
+      File.write(file_name, JSON.pretty_generate(@pending_examples.to_a))
     end
 
     def write_all_files_report
       file_name = File.join(@cache_dir, 'all_files.json')
 
-      File.write(file_name, JSON.generate(@all_files))
+      File.write(file_name, JSON.pretty_generate(@all_files))
     end
 
     def write_dependency_report
       file_name = File.join(@cache_dir, 'dependency.json')
 
-      File.write(file_name, JSON.generate(@dependency))
+      File.write(file_name, JSON.pretty_generate(@dependency))
     end
 
     def write_reverse_dependency_report
       file_name = File.join(@cache_dir, 'reverse_dependency.json')
 
-      File.write(file_name, JSON.generate(@reverse_dependency))
+      File.write(file_name, JSON.pretty_generate(@reverse_dependency))
     end
 
     def write_examples_coverage_report
       file_name = File.join(@cache_dir, 'examples_coverage.json')
 
-      File.write(file_name, JSON.generate(@examples_coverage))
+      File.write(file_name, JSON.pretty_generate(@examples_coverage))
     end
 
     def write_last_run_report
       file_name = File.join(RSpecTracer.cache_path, 'last_run.json')
       last_run_data = @last_run.merge(run_id: @run_id, timestamp: Time.now.utc)
 
-      File.write(file_name, JSON.generate(last_run_data))
+      File.write(file_name, JSON.pretty_generate(last_run_data))
     end
   end
 end


### PR DESCRIPTION
Cache the filtered files to speed up changed dependencies per example.
Also, do not compute diff when the last example and current example coverage
is the same for a given file.