### PR TITLE
fixed SourceFile#file_path

### DIFF
--- a/lib/rspec_tracer/source_file.rb
+++ b/lib/rspec_tracer/source_file.rb
@@ -25,7 +25,9 @@ module RSpecTracer
     end
 
     def file_path(file_name)
-      File.expand_path(file_name.sub(%r{^/}, ''), RSpecTracer.root)
+      file_name = file_name.include?('/gems/') ? file_name : file_name.sub(%r{^/}, '')
+
+      File.expand_path(file_name, RSpecTracer.root)
     end
   end
 end


### PR DESCRIPTION
Fixes an error if there is spec that uses `it_has_behavior 'xxx'` where `xxx` is defined in gem. This happened because file path was changed to look in project root only

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Feature branch is up-to-date with the `main` branch.
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Run `bundle exec rake`.
