### PR TITLE
[Fix #39] Handle Interrupts

### DIFF
--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -196,6 +196,7 @@ module RSpecTracer
     def process_dependency
       starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
+      runner.register_interrupted_examples
       runner.register_deleted_examples
       runner.register_dependency(coverage_reporter.examples_coverage)
       runner.register_untraced_dependency(@traced_files)

--- a/lib/rspec_tracer/cache.rb
+++ b/lib/rspec_tracer/cache.rb
@@ -2,8 +2,8 @@
 
 module RSpecTracer
   class Cache
-    attr_reader :all_examples, :flaky_examples, :failed_examples, :pending_examples,
-                :all_files, :dependency, :run_id
+    attr_reader :all_examples, :interrupted_examples, :flaky_examples, :failed_examples,
+                :pending_examples, :all_files, :dependency, :run_id
 
     def initialize
       @run_id = last_run_id
@@ -12,6 +12,7 @@ module RSpecTracer
       @cached = false
 
       @all_examples = {}
+      @interrupted_examples = Set.new
       @flaky_examples = Set.new
       @failed_examples = Set.new
       @pending_examples = Set.new
@@ -74,7 +75,11 @@ module RSpecTracer
       end
 
       @all_examples.each_value do |example|
-        example[:execution_result].transform_keys!(&:to_sym)
+        if example.key?(:execution_result)
+          example[:execution_result].transform_keys!(&:to_sym)
+        else
+          @interrupted_examples << example[:example_id]
+        end
 
         example[:run_reason] = nil
       end

--- a/lib/rspec_tracer/html_reporter/reporter.rb
+++ b/lib/rspec_tracer/html_reporter/reporter.rb
@@ -60,7 +60,19 @@ module RSpecTracer
             id: example_id,
             description: example[:full_description],
             location: example_location(example[:rerun_file_name], example[:rerun_line_number]),
-            status: example[:run_reason] || 'Skipped',
+            status: example[:run_reason] || 'Skipped'
+          }.merge(example_result(example_id, example))
+        end
+      end
+
+      def example_result(example_id, example)
+        if example[:execution_result].nil?
+          {
+            result: @reporter.example_interrupted?(example_id) ? 'Interrupted' : '_',
+            last_run: '_'
+          }
+        else
+          {
             result: example[:execution_result][:status].capitalize,
             last_run: example_run_local_time(example[:execution_result][:finished_at])
           }
@@ -176,7 +188,7 @@ module RSpecTracer
 
       def example_status_css_class(example_status)
         case example_status.split.first
-        when 'Failed', 'Flaky'
+        when 'Failed', 'Flaky', 'Interrupted'
           'red'
         when 'Pending'
           'yellow'
@@ -189,7 +201,7 @@ module RSpecTracer
         case example_result
         when 'Passed'
           'green'
-        when 'Failed'
+        when 'Failed', 'Interrupted'
           'red'
         when 'Pending'
           'yellow'


### PR DESCRIPTION
RSpec tracer does not corrupt cache on interrupts.