### PR TITLE
Reduce JRuby Tests

### DIFF
--- a/.github/workflows/jruby-ruby-project.yml
+++ b/.github/workflows/jruby-ruby-project.yml
@@ -11,15 +11,15 @@ concurrency:
 
 jobs:
   main:
-    name: ruby-${{ matrix.ruby }} rspec-${{ matrix.rspec }} simplecov-${{ matrix.simplecov }}
+    name: ${{ matrix.ruby }} rspec-${{ matrix.rspec }} simplecov-${{ matrix.simplecov }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 'jruby-9.2.10.0', 'jruby-9.2.19.0', 'jruby-9.3.0.0' ]
-        rspec: [ '3.6.0', '3.7.0', '3.8.0', '3.9.0', '3.10.0' ]
-        simplecov: [ '0.12.0', '0.13.0', '0.14.0', '0.15.0', '0.16.0', '0.17.0', '0.18.0', '0.19.0', '0.20.0', '0.21.0' ]
+        ruby: [ 'jruby-9.2.10.0', 'jruby-9.2.14.0', 'jruby-9.2.19.0', 'jruby-9.3.0.0', 'jruby-head' ]
+        rspec: [ '3.10.0' ]
+        simplecov: [ '0.21.0' ]
 
     steps:
       - name: Checkout

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -130,6 +130,8 @@ module RSpecTracer
     private
 
     def valid_jruby_opts?
+      require 'jruby'
+
       return true if Java::OrgJruby::RubyInstanceConfig.FULL_TRACE_ENABLED &&
         JRuby.runtime.object_space_enabled?
 


### PR DESCRIPTION
These tests are time-consuming and unnecessarily flaky at times. As
GitHub actions have no support for running failed jobs only, it becomes
too time-consuming to get these tests passing.