### PR TITLE
Use GitHub Actions Artifacts

### DIFF
--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Setup Code Climate test-reporter
         run: |
-          pip3 install awscli --user
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
@@ -41,20 +40,20 @@ jobs:
       - name: Run Tests
         run: bundle exec rake
 
-      - name: Configure AWS Credentials for Coverage Upload
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-
-      - name: Upload Job Coverage
+      - name: Format Coverage Report
         env:
           GIT_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
           GIT_COMMIT_SHA: ${{ github.sha }}
         run: |
-          ./cc-test-reporter format-coverage coverage/coverage.json --output coverage/ruby-${{ matrix.ruby }}.simplecov.json --input-type simplecov
-          aws s3 cp coverage/ruby-${{ matrix.ruby }}.simplecov.json ${{ secrets.CI_ARTIFACTS_S3_URI }}/${{ github.repository }}/${{ github.run_number }}/ruby-${{ matrix.ruby }}.simplecov.json
+          mkdir -p coverage-artifacts
+          ./cc-test-reporter format-coverage coverage/coverage.json --input-type simplecov --output coverage-artifacts/ruby-${{ matrix.ruby }}-coverage.json
+
+      - name: Save Coverage Report
+        uses: actions/upload-artifact@v2
+        with:
+          name: ruby-${{ matrix.ruby }}-coverage.json
+          path: coverage-artifacts/ruby-${{ matrix.ruby }}-coverage.json
+          retention-days: 1
 
   coverage:
     needs: [ 'main' ]
@@ -67,36 +66,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-          architecture: 'x64'
-
       - name: Setup Code Climate test-reporter
         run: |
-          pip3 install awscli --user
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
 
-      - name: Configure AWS Credentials for Coverage Upload
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Download Coverage Reports
+        uses: actions/download-artifact@v2
         with:
-          aws-access-key-id: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
+          path: coverage-artifacts-temp
 
-      - name: Download Jobs Coverage
+      - name: Finalize Artifacts
         run: |
-          mkdir coverage
-          aws s3 cp --recursive ${{ secrets.CI_ARTIFACTS_S3_URI }}/${{ github.repository }}/${{ github.run_number }}/ coverage/
+          mkdir -p coverage-artifacts
+          find coverage-artifacts-temp -mindepth 2 -type f -exec mv -i '{}' coverage-artifacts ';'
 
       - name: Upload Coverage
         env:
           GIT_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
           GIT_COMMIT_SHA: ${{ github.sha }}
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          CC_TEST_REPORTER_ID: "5499f6009ecc1c84cd90aac7409351a1439946922f9405d43b81b1564afd21ed"
         run: |
-          ./cc-test-reporter sum-coverage coverage/ruby-*.simplecov.json --parts 5 --output coverage/coverage.json
-          ./cc-test-reporter upload-coverage --input coverage/coverage.json
+          ./cc-test-reporter sum-coverage coverage-artifacts/ruby-*-coverage.json --parts 5 --output coverage-artifacts/coverage.json
+          ./cc-test-reporter upload-coverage --input coverage-artifacts/coverage.json


### PR DESCRIPTION
Using GitHub actions artifacts for storing coverage reports because AWS
S3 options require setting up secrets and these secrets cannot be
shared on forks. Using the secrets in plain text is definitely not a
mindful decision.