### PR TITLE
Prevent calling `chomp` on nil

### DIFF
--- a/lib/rspec_tracer/remote_cache/repo.rb
+++ b/lib/rspec_tracer/remote_cache/repo.rb
@@ -8,10 +8,10 @@ module RSpecTracer
       attr_reader :branch_name, :branch_ref, :branch_refs, :ancestry_refs, :cache_refs
 
       def initialize(aws)
+        raise RepoError, 'GIT_BRANCH environment variable is not set' if ENV['GIT_BRANCH'].nil?
+
         @aws = aws
         @branch_name = ENV['GIT_BRANCH'].chomp
-
-        raise RepoError, 'GIT_BRANCH environment variable is not set' if @branch_name.nil?
 
         fetch_head_ref
         fetch_branch_ref

--- a/spec/lib/rspec_tracer/remote_cache/repo_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/repo_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RSpecTracer::RemoteCache::Repo do
+  subject(:service) { described_class.new(aws) }
+
+  let(:aws) { instance_double('aws') }
+
+  describe 'initialize' do
+    context 'when GIT_BRANCH is not defined' do
+      it 'raises an error' do
+        expect { service }
+          .to raise_error(RSpecTracer::RemoteCache::Repo::RepoError)
+      end
+    end
+
+    context 'when GIT_BRANCH is defined' do
+      before do
+        branch_name = 'some branch'
+        stub_const('ENV', ENV.to_hash.merge('GIT_BRANCH' => branch_name))
+        allow(aws).to receive(:branch_refs?).with(branch_name)
+      end
+
+      after { ENV.delete('GIT_BRANCH') }
+
+      it 'does not raise an error' do
+        expect { service }.not_to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change asserts raising the correct error if the environment variable is not set.

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Feature branch is up-to-date with the `main` branch.
* [x] Squashed related commits together.
* [x] Added tests.
* [x] Run `bundle exec rake`.
