### PR TITLE
Allow aws profile

### DIFF
--- a/lib/rspec_tracer/remote_cache/aws.rb
+++ b/lib/rspec_tracer/remote_cache/aws.rb
@@ -160,7 +160,7 @@ module RSpecTracer
         if ENV.fetch('LOCAL_AWS', 'false') == 'true'
           'awslocal'
         else
-          'aws'
+          "aws#{ENV['RSPEC_TRACER_AWS_PROFILE'] && ' --profile=$RSPEC_TRACER_AWS_PROFILE'}"
         end
       end
 

--- a/lib/rspec_tracer/remote_cache/repo.rb
+++ b/lib/rspec_tracer/remote_cache/repo.rb
@@ -8,10 +8,10 @@ module RSpecTracer
       attr_reader :branch_name, :branch_ref, :branch_refs, :ancestry_refs, :cache_refs
 
       def initialize(aws)
+        raise RepoError, 'GIT_BRANCH environment variable is not set' if ENV['GIT_BRANCH'].nil?
+
         @aws = aws
         @branch_name = ENV['GIT_BRANCH'].chomp
-
-        raise RepoError, 'GIT_BRANCH environment variable is not set' if @branch_name.nil?
 
         fetch_head_ref
         fetch_branch_ref

--- a/spec/lib/rspec_tracer/remote_cache/aws_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/aws_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RSpecTracer::RemoteCache::Aws do
+  subject(:service) { described_class.new }
+
+  before { stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_S3_URI' => 's3://bucket/folder')) }
+
+  after { ENV.delete('RSPEC_TRACER_S3_URI') }
+
+  describe 'initialize' do
+    context 'when RSPEC_TRACER_AWS_PROFILE is not enabled' do
+      it 'does not add a profile param to the aws_cli instance variable' do
+        expect(service.instance_variable_get(:@aws_cli)).to eq('aws')
+      end
+    end
+
+    context 'when RSPEC_TRACER_AWS_PROFILE is enabled' do
+      before { stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_AWS_PROFILE' => 'aws-profile')) }
+
+      after { ENV.delete('RSPEC_TRACER_AWS_PROFILE') }
+
+      it 'add a profile param to the aws_cli instance variable' do
+        expect(service.instance_variable_get(:@aws_cli)).to eq('aws --profile=$RSPEC_TRACER_AWS_PROFILE')
+      end
+    end
+  end
+end

--- a/spec/lib/rspec_tracer/remote_cache/repo_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/repo_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RSpecTracer::RemoteCache::Repo do
+  subject(:service) { described_class.new(aws) }
+
+  let(:aws) { instance_double('aws') }
+
+  it 'raises an error if GIT_BRANCH is not defined' do
+    expect { service }
+      .to raise_error(RSpecTracer::RemoteCache::Repo::RepoError)
+  end
+
+  it 'does not raise an error if GIT_BRANCH is defined' do
+    allow(ENV).to receive(:[]).with('GIT_BRANCH').and_return('some branch')
+    allow(aws).to receive(:branch_refs?).with(anything)
+    expect { service }.not_to raise_error(RSpecTracer::RemoteCache::Repo::RepoError)
+  end
+end


### PR DESCRIPTION
Some companies need to define an AWS profile for security purposes. Therefore, if there's a profile set on `RSPEC_TRACER_AWS_PROFILE,` we append `--profile=$RSPEC_TRACER_AWS_PROFILE` to the `aws` command. Otherwise, uploading the cache to S3 will output an `Access Denied.` error.

-----------------

Before submitting the PR, make sure the following are checked:

* [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [X] Feature branch is up-to-date with the `main` branch.
* [X] Squashed the related commits together.
* [X] Added tests.
* [X] Run `bundle exec rake.`
