### PR TITLE
Allow passing an AWS profile

### DIFF
--- a/lib/rspec_tracer/remote_cache/aws.rb
+++ b/lib/rspec_tracer/remote_cache/aws.rb
@@ -160,7 +160,7 @@ module RSpecTracer
         if ENV.fetch('LOCAL_AWS', 'false') == 'true'
           'awslocal'
         else
-          'aws'
+          "aws#{ENV['RSPEC_TRACER_AWS_PROFILE'] && ' --profile=$RSPEC_TRACER_AWS_PROFILE'}"
         end
       end
 

--- a/spec/lib/rspec_tracer/remote_cache/aws_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/aws_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RSpecTracer::RemoteCache::Aws do
+  subject(:service) { described_class.new }
+
+  before { stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_S3_URI' => 's3://bucket/folder')) }
+
+  after { ENV.delete('RSPEC_TRACER_S3_URI') }
+
+  describe 'initialize' do
+    context 'when RSPEC_TRACER_AWS_PROFILE is not enabled' do
+      it 'does not add a profile param to the aws_cli instance variable' do
+        expect(service.instance_variable_get(:@aws_cli)).to eq('aws')
+      end
+    end
+
+    context 'when RSPEC_TRACER_AWS_PROFILE is enabled' do
+      before { stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_AWS_PROFILE' => 'aws-profile')) }
+
+      after { ENV.delete('RSPEC_TRACER_AWS_PROFILE') }
+
+      it 'add a profile param to the aws_cli instance variable' do
+        expect(service.instance_variable_get(:@aws_cli)).to eq('aws --profile=$RSPEC_TRACER_AWS_PROFILE')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some companies need to define an AWS profile for security purposes. Therefore, if there's a profile set on `RSPEC_TRACER_AWS_PROFILE,` we append `--profile=$RSPEC_TRACER_AWS_PROFILE` to the `aws` command. Otherwise, uploading the cache to S3 will output an `Access Denied.` error.

![Screen Shot 2021-10-29 at 2 13 49 PM](https://user-images.githubusercontent.com/9499829/139503191-ab4f8690-401d-4027-a92c-d94d80a231c2.png)

-----------------
Before submitting the PR, make sure the following are checked:

* [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [X] Feature branch is up-to-date with the `main` branch.
* [X] Squashed the related commits together.
* [X] Added tests.
* [X] Run `bundle exec rake.`