### PR TITLE
Prevent downloading from empty bucket

### DIFF
--- a/lib/rspec_tracer/remote_cache/aws.rb
+++ b/lib/rspec_tracer/remote_cache/aws.rb
@@ -139,6 +139,24 @@ module RSpecTracer
         puts "Uploaded files from #{local_dir} to #{remote_dir}"
       end
 
+      # Lists the @s3_bucket folder and check if it's empty
+      #
+      # @return [Boolean] if the bucket is empty
+      def empty_bucket?
+        folder_bucket_content = system(
+          @aws_cli,
+          's3api',
+          'list-objects-v2',
+          '--bucket',
+          @s3_bucket,
+          '--start-after',
+          "#{@s3_path}/",
+          '--query',
+          'Contents[].Key'
+        )
+        folder_bucket_content.nil?
+      end
+
       private
 
       def setup_s3

--- a/lib/rspec_tracer/remote_cache/cache.rb
+++ b/lib/rspec_tracer/remote_cache/cache.rb
@@ -40,6 +40,8 @@ module RSpecTracer
       private
 
       def cache_ref?
+        return false if @aws.empty_bucket?
+
         cache_validator = RSpecTracer::RemoteCache::Validator.new
 
         @cache_sha = @repo.cache_refs.each_key.detect do |ref|

--- a/spec/lib/rspec_tracer/remote_cache/aws_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/aws_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RSpecTracer::RemoteCache::Aws do
+  subject(:service) { described_class.new }
+
+  before { stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_S3_URI' => 's3://bucket/folder')) }
+
+  after { ENV.delete('RSPEC_TRACER_S3_URI') }
+
+  describe '.empty_bucket?' do
+    before do
+      aws_command = %w(
+        aws
+        s3api
+        list-objects-v2
+        --bucket
+        bucket
+        --start-after
+        folder/
+        --query
+        Contents[].Key
+      )
+      # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Kernel)
+        .to receive(:system)
+          .with(*aws_command) { aws_command_result }
+      # rubocop:enable RSpec/AnyInstance
+    end
+
+    context 'when the bucket is empty' do
+      let(:aws_command_result) { nil }
+
+      it 'returns true' do
+        expect(service.empty_bucket?).to be(true)
+      end
+    end
+
+    context 'when the bucket is not empty' do
+      let(:aws_command_result) { ['something'] }
+
+      it 'returns false' do
+        expect(service.empty_bucket?).to be(false)
+      end
+    end
+  end
+end

--- a/spec/lib/rspec_tracer/remote_cache/cache_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/cache_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe RSpecTracer::RemoteCache::Cache do
+  subject(:service) { described_class.new }
+
+  let(:aws) { instance_double(RSpecTracer::RemoteCache::Aws) }
+  let(:branch_name) { 'branch' }
+
+  before do
+    allow(RSpecTracer::RemoteCache::Aws).to receive(:new) { aws }
+    allow(aws).to receive(:branch_refs?).with(branch_name)
+    stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_S3_URI' => 's3://bucket/folder'))
+    stub_const('ENV', ENV.to_hash.merge('GIT_BRANCH' => branch_name))
+  end
+
+  after do
+    ENV.delete('RSPEC_TRACER_S3_URI')
+    ENV.delete('GIT_BRANCH')
+  end
+
+  describe '.download' do
+    before do
+      allow(aws).to receive_messages(download_file: anything, download_dir: anything)
+      allow(aws).to receive(:empty_bucket?).and_return(bucket_empty?)
+    end
+
+    context 'when s3 bucket is empty' do
+      let(:bucket_empty?) { true }
+
+      it 'early returns from the method' do
+        service.download
+        expect(aws).not_to have_received(:download_file)
+      end
+    end
+
+    context 'when s3 bucket is not empty' do
+      let(:bucket_empty?) { false }
+
+      it 'early proceeds with download' do
+        allow(service).to receive(:cache_ref?).and_return(true)
+        service.download
+        expect(aws).to have_received(:download_file)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Increase the performance by checking if the bucket is empty before attempting to download the cache. 

-----------------

Before submitting the PR make sure the following are checked:

* [X] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [X] Feature branch is up-to-date with the `main` branch.
* [X] Squashed related commits together.
* [X] Added tests.
* [X] Run `bundle exec rake`.
