### PR TITLE
CI Caching Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ describing the **intention** and implementation details of **managing dependency
 * [Getting Started](#getting-started)
   * [Working with JRuby](#working-with-jruby)
   * [Working with Parallel Tests](#working-with-parallel-tests)
-* [Configuring CI](#configuring-ci-caching)
+* [Configuring CI](#configuring-ci)
 * [Advanced Configuration](#advanced-configuration)
   * [Available Settings](#available-settings)
 * [Filters](#filters)
@@ -133,6 +133,8 @@ bundle exec rake rspec_tracer:remote_cache:upload
 ```
 
 You must set the following environment variables:
+
+- **`GIT_DEFAULT_BRANCH`** is the default branch name for the repo, e.g., `main` or `master`.
 
 - **`GIT_BRANCH`** is the git branch name you are running the CI build on.
 

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -234,7 +234,7 @@ module RSpecTracer
       @traced_files = Set.new
       @examples_traced_files = {}
 
-      @trace_point = TracePoint.new(:call, :b_call, :c_call) do |tp|
+      @trace_point = TracePoint.new(:call) do |tp|
         RSpecTracer.traced_files << tp.path if tp.path.start_with?(RSpecTracer.root)
       end
     end

--- a/lib/rspec_tracer/remote_cache/aws.rb
+++ b/lib/rspec_tracer/remote_cache/aws.rb
@@ -144,7 +144,7 @@ module RSpecTracer
       def setup_s3
         s3_uri = RSpecTracer.reports_s3_path
 
-        raise AwsError, 'RSPEC_TRACER_S3_URI environment variable is not set' if s3_uri.nil?
+        raise AwsError, 'Invalid reports S3 path' if s3_uri.nil?
 
         uri_parts = s3_uri[4..-1].split('/')
 

--- a/spec/lib/rspec_tracer/remote_cache/repo_spec.rb
+++ b/spec/lib/rspec_tracer/remote_cache/repo_spec.rb
@@ -8,23 +8,28 @@ RSpec.describe RSpecTracer::RemoteCache::Repo do
   let(:aws) { instance_double('aws') }
 
   describe '#initialize' do
-    context 'when GIT_BRANCH is not defined' do
-      it 'raises an error' do
-        expect { service }
-          .to raise_error(RSpecTracer::RemoteCache::Repo::RepoError)
+    let(:envs) { %w[GIT_DEFAULT_BRANCH GIT_BRANCH] }
+
+    before { envs.each { |env| ENV.delete(env) } }
+
+    after { envs.each { |env| ENV.delete(env) } }
+
+    context 'when environment variables not defined' do
+      it 'raises error' do
+        expect { service }.to raise_error(RSpecTracer::RemoteCache::Repo::RepoError)
       end
     end
 
-    context 'when GIT_BRANCH is defined' do
+    context 'when environment variables defined' do
+      let(:branch_name) { 'a_branch' }
+
       before do
-        branch_name = 'some branch'
-        stub_const('ENV', ENV.to_hash.merge('GIT_BRANCH' => branch_name))
+        envs.each { |env| ENV[env] = branch_name }
+
         allow(aws).to receive(:branch_refs?).with(branch_name)
       end
 
-      after { ENV.delete('GIT_BRANCH') }
-
-      it 'does not raise an error' do
+      it 'does not raise error' do
         expect { service }.not_to raise_error
       end
     end


### PR DESCRIPTION
Merging the `main` branch into the PR branch before running tests. Assuming the PR branch is `feature` and the default branch is `release`, then before downloading the remote cache, the RSpecTracer creates a merge commit:
```sh
git fetch origin feature:feature
git checkout feature
git merge origin/release --no-edit --no-ff
```