### PR TITLE
Fix NoMethodError: undefined method `rm_f' for File:Class

### DIFF
--- a/lib/rspec_tracer/remote_cache/repo.rb
+++ b/lib/rspec_tracer/remote_cache/repo.rb
@@ -144,7 +144,7 @@ module RSpecTracer
         else
           @branch_refs = {}
 
-          File.rm_f(file_name)
+          FileUtils.rm_f(file_name)
 
           RSpecTracer.logger.error "Failed to fetch branch refs for #{@branch_name} branch"
         end


### PR DESCRIPTION
Fix `NoMethodError: undefined method 'rm_f' for File:Class` by changing the class name from `File` to `FileUtils`.