### PR TITLE
Update validator to check for cache only for specific TEST_SUIT_ID

### DIFF
--- a/lib/rspec_tracer/remote_cache/aws.rb
+++ b/lib/rspec_tracer/remote_cache/aws.rb
@@ -62,11 +62,7 @@ module RSpecTracer
       end
 
       def cache_files_list(ref)
-        if @use_test_suite_id_cache && !@test_suite_id.nil?
-          prefix = "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/#{@test_suite_id}/"
-        else
-          prefix = "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/"
-        end
+        prefix = @use_test_suite_id_cache && !@test_suite_id.nil? ? "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/#{@test_suite_id}/" : "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/"
 
         `#{@aws_cli} s3 ls #{prefix} --recursive`.chomp.split("\n")
       end

--- a/lib/rspec_tracer/remote_cache/aws.rb
+++ b/lib/rspec_tracer/remote_cache/aws.rb
@@ -8,6 +8,8 @@ module RSpecTracer
       def initialize
         @s3_bucket, @s3_path = setup_s3
         @aws_cli = RSpecTracer.use_local_aws ? 'awslocal' : 'aws'
+        @use_test_suite_id_cache = ENV['USE_TEST_SUITE_ID_CACHE'] == 'true'
+        @test_suite_id = ENV['TEST_SUITE_ID'] if @use_test_suite_id_cache
       end
 
       def branch_refs?(branch_name)
@@ -60,7 +62,11 @@ module RSpecTracer
       end
 
       def cache_files_list(ref)
-        prefix = "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/"
+        if @use_test_suite_id_cache && !@test_suite_id.nil?
+          prefix = "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/#{@test_suite_id}/"
+        else
+          prefix = "s3://#{@s3_bucket}/#{@s3_path}/#{ref}/"
+        end
 
         `#{@aws_cli} s3 ls #{prefix} --recursive`.chomp.split("\n")
       end

--- a/lib/rspec_tracer/remote_cache/validator.rb
+++ b/lib/rspec_tracer/remote_cache/validator.rb
@@ -8,7 +8,7 @@ module RSpecTracer
       def initialize
         @test_suite_id = ENV['TEST_SUITE_ID']
         @test_suites = ENV['TEST_SUITES']
-        @use_test_suite_id_cache = ENV['USE_TEST_SUITE_ID_CACHE']
+        @use_test_suite_id_cache = ENV['USE_TEST_SUITE_ID_CACHE'] == 'true'
 
         if @test_suite_id.nil? ^ @test_suites.nil?
           raise(

--- a/lib/rspec_tracer/remote_cache/validator.rb
+++ b/lib/rspec_tracer/remote_cache/validator.rb
@@ -8,11 +8,12 @@ module RSpecTracer
       def initialize
         @test_suite_id = ENV['TEST_SUITE_ID']
         @test_suites = ENV['TEST_SUITES']
+        @use_test_suite_id_cache = ENV['USE_TEST_SUITE_ID_CACHE']
 
         if @test_suite_id.nil? ^ @test_suites.nil?
           raise(
             ValidationError,
-            'Both the enviornment variables TEST_SUITE_ID and TEST_SUITES are not set'
+            'Both the environment variables TEST_SUITE_ID and TEST_SUITES are not set'
           )
         end
 
@@ -20,13 +21,11 @@ module RSpecTracer
       end
 
       def valid?(ref, cache_files)
-        last_run_regex = Regexp.new(format(@last_run_files_regex, ref: ref))
-
-        return false if cache_files.count { |file| file.match?(last_run_regex) } != @last_run_files_count
-
-        cache_regex = Regexp.new(format(@cached_files_regex, ref: ref))
-
-        cache_files.count { |file| file.match?(cache_regex) } == @cached_files_count
+        if @use_test_suite_id_cache
+          test_suite_id_specific_validation(ref, cache_files)
+        else
+          general_validation(ref, cache_files)
+        end
       end
 
       private
@@ -36,7 +35,7 @@ module RSpecTracer
           @last_run_files_count = 1
           @last_run_files_regex = '/%<ref>s/last_run.json$'
           @cached_files_count = CACHE_FILES_PER_TEST_SUITE
-          @cached_files_regex = '/%<ref>s/[0-9a-f]{32}/.+.json'
+          @cached_files_regex = '/%<ref>s/[0-9a-f]{32}/.+.json$'
         else
           @test_suites = @test_suites.to_i
           @test_suites_regex = (1..@test_suites).to_a.join('|')
@@ -46,6 +45,29 @@ module RSpecTracer
           @cached_files_count = CACHE_FILES_PER_TEST_SUITE * @test_suites
           @cached_files_regex = "/%<ref>s/(#{@test_suites_regex})/[0-9a-f]{32}/.+.json$"
         end
+      end
+
+      def general_validation(ref, cache_files)
+        last_run_regex = Regexp.new(format(@last_run_files_regex, ref: ref))
+
+        return false if cache_files.count { |file| file.match?(last_run_regex) } != @last_run_files_count
+
+        cache_regex = Regexp.new(format(@cached_files_regex, ref: ref))
+
+        cache_files.count { |file| file.match?(cache_regex) } == @cached_files_count
+      end
+
+      def test_suite_id_specific_validation(ref, cache_files)
+        # Here, we ensure that the regex is dynamically adjusted for the specific test suite
+        # Adjusting for specific test_suite_id in the regex patterns
+        last_run_regex = Regexp.new("/#{ref}/#{@test_suite_id}/last_run.json$")
+        cache_regex = Regexp.new("/#{ref}/#{@test_suite_id}/[0-9a-f]{32}/.+.json$")
+
+        # Validate presence of the last run file for the specific test suite
+        return false unless cache_files.any? { |file| file.match?(last_run_regex) }
+
+        # Check if any cache files for the specific test suite are present
+        cache_files.any? { |file| file.match?(cache_regex) }
       end
     end
   end


### PR DESCRIPTION
When trying to use cache from previous builds and if even one of previous TEST_SUITES fails or aborted, the upload cache is skipped, which means during the download cache in the next run, the valid function will return false and hence no cache will be used for the previously passed test suites. This just keeps going until all the test suites pass without getting aborted or failed. 

The modification in this PR proposes to check cached files count only for the particular test suit id based on `USE_TEST_SUITE_ID_CACHE ` env. This should greatly improve total tests run time in CI environments when concurrent builds are disabled (cases when new run starts, previous build gets aborted)

-----------------

Before submitting the PR make sure the following are checked:

* [x] Wrote [good commit messages](https://chris.beams.io/posts/git-commit/).
* [x] Feature branch is up-to-date with the `main` branch.
* [x] Squashed related commits together.
* [ ] Added tests.
* [ ] Run `bundle exec rake`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Enhanced performance by improving validation logic in the testing framework.
	- Added a new instance variable to control validation behavior in the `Validator` and `AwsError` classes.
	- Updated the `valid?` method in the `Validator` class to delegate based on the new instance variable.
	- Adjusted the `cache_files_list` method in the `AwsError` class to dynamically construct the prefix based on the new instance variable and environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->