### PR TITLE
Fix NoMethodError in merge_coverage Method

### DIFF
--- a/lib/rspec_tracer/coverage_reporter.rb
+++ b/lib/rspec_tracer/coverage_reporter.rb
@@ -72,6 +72,7 @@ module RSpecTracer
                             end
 
         line_coverage.each_pair do |line_number, strength|
+          next unless strength && line_coverage_dup[line_number.to_i]
           line_coverage_dup[line_number.to_i] += strength
         end
 


### PR DESCRIPTION
This pull request addresses a `NoMethodError` encountered in the `CoverageReporter` class's `merge_coverage method` when attempting to add coverage strengths for line numbers that are not initially present in the coverage data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **Bug Fixes**
	- Improved reliability of coverage reporting by skipping processing for certain conditions where data may be incomplete or missing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->