### PR TITLE
Handle missing source in dependencies

### DIFF
--- a/lib/rspec_tracer/runner.rb
+++ b/lib/rspec_tracer/runner.rb
@@ -245,6 +245,11 @@ module RSpecTracer
 
       source_file = RSpecTracer::SourceFile.from_name(file_name)
 
+      # some Gems provide functions that create their own examples
+      # e.g. rswag's 'run_test!' internally defines examples
+      # in these cases, no source file will be found
+      return if source_file.nil?
+
       @reporter.register_source_file(source_file)
       @reporter.register_dependency(example_id, file_name)
     end


### PR DESCRIPTION
### **User description**
Some GEMs provide functions that internally create their own examples, e.g. rswag's `run_test!` internally defines examples. In these cases, no source file will be found and even if resolved to the GEM's function, it would make no sense as an execution point.


___

### **PR Type**
bug_fix


___

### **Description**
- Added a safeguard in `register_example_file_dependency` to handle cases where no source file is found.
- Prevented the registration of dependencies for examples created by certain GEM functions, such as `rswag`, which internally define examples without a source file.
- Improved robustness of the dependency registration process in the presence of GEM-specific behaviors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>runner.rb</strong><dd><code>Handle missing source files in example dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/rspec_tracer/runner.rb

<li>Added a check for <code>nil</code> source files in <br><code>register_example_file_dependency</code>.<br> <li> Prevented registration of dependencies when source file is missing.<br> <li> Commented on the behavior of certain GEM functions like <code>rswag</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/avmnu-sng/rspec-tracer/pull/72/files#diff-cbe0a6a7d2069c4a39819828d2aad908e787656dc6fb69ec2ddb844407050cef">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information