### PR TITLE
Set package ecosystem to 'bundler' in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "bundler" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Configure Dependabot to monitor Ruby dependencies via bundler

- Set package ecosystem from empty string to bundler


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dependabot.yml"] -- "update package-ecosystem" --> B["bundler ecosystem enabled"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Set bundler as package ecosystem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Changed <code>package-ecosystem</code> field from empty string to <code>"bundler"</code><br> <li> Enables Dependabot to automatically check for Ruby gem updates<br> <li> Maintains existing weekly schedule and root directory configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/avmnu-sng/rspec-tracer/pull/74/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

