### PR TITLE
chore(dependabot): ignore dev-dep upgrades that break Ruby 3.1 floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,18 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    # The `required_ruby_version` floor is `>= 3.1.0` (see rspec-tracer.gemspec).
+    # The upgrades below would break that by transitively requiring Ruby
+    # >= 3.2 or >= 3.3 via bundler or the `parallel` gem. Dependabot reports
+    # these as hard failures every week otherwise. Revisit when we raise
+    # the Ruby floor (likely in 2.0).
+    ignore:
+      - dependency-name: "parallel"
+        versions: [">= 2.0"]
+      - dependency-name: "aruba"
+        versions: [">= 2.3"]
+      - dependency-name: "cucumber"
+        versions: [">= 10.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

- The bundler ecosystem job has been failing weekly because Dependabot tries to upgrade `parallel` / `aruba` / `cucumber` to versions whose dependency chain requires Ruby ≥ 3.2 or ≥ 3.3.
- Our `required_ruby_version` is `>= 3.1.0`, so those upgrades would break the Ruby 3.1 cell in CI — Dependabot correctly refuses, but reports as a hard failure.
- Adding explicit `ignore:` entries so the UI stays focused on actionable upgrades (rubocop, simplecov, etc.).

## Test plan

- [x] YAML syntax valid (`ruby -ryaml -e 'YAML.load_file(".github/dependabot.yml")'`)
- [ ] CI green on this PR
- [ ] Next weekly Dependabot run (automatic): bundler ecosystem passes instead of failing on these three

🤖 Generated with [Claude Code](https://claude.com/claude-code)