### PR TITLE
feat(tracker): declared globs + whole-suite invalidators + new-file detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,7 +186,7 @@ tasks:
       - ITERATIONS=10000 bundle exec ruby spec/fuzz/cache_loader_fuzz.rb
 
   test:mutation:smoke:
-    desc: Mutation smoke — TimeFormatter.format_time + Tracker::Input must each hit >= 90% (< 2 min budget)
+    desc: Mutation smoke — TimeFormatter.format_time + Tracker::Input + Tracker::DeclaredGlobs + Tracker::WholeSuiteInvalidators must each hit >= 90% (< 2 min budget)
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -229,6 +229,12 @@ tasks:
         run_mutant_subject "Tracker::Input" \
           "rspec_tracer/tracker/input" \
           "RSpecTracer::Tracker::Input*" || fail=1
+        run_mutant_subject "Tracker::DeclaredGlobs" \
+          "rspec_tracer/tracker/declared_globs" \
+          "RSpecTracer::Tracker::DeclaredGlobs*" || fail=1
+        run_mutant_subject "Tracker::WholeSuiteInvalidators" \
+          "rspec_tracer/tracker/whole_suite_invalidators" \
+          "RSpecTracer::Tracker::WholeSuiteInvalidators*" || fail=1
         exit "$fail"
 
   test:mutation:full:

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -224,6 +224,47 @@ module RSpecTracer
       @coverage_track_files if defined?(@coverage_track_files)
     end
 
+    # M3.3 declared-globs DSL. Accumulates every call into a single
+    # array that DeclaredGlobs / NewFileDetector consume at boot.
+    # Coexists with legacy `coverage_track_files` (single-arg setter,
+    # overwrite-on-call) without changing that surface - see
+    # `#declared_globs` for the consolidated view.
+    def track_files(*globs)
+      if defined?(@declared_globs_frozen) && @declared_globs_frozen
+        raise InvalidUsageError,
+              'track_files cannot be called after the tracker has started'
+      end
+
+      @track_files_globs ||= []
+      @track_files_globs.concat(globs.flatten.compact.map(&:to_s))
+      @track_files_globs
+    end
+
+    # Consolidated read-only view over `track_files` + legacy
+    # `coverage_track_files`. Order: user-declared first (preserves
+    # DSL call order), legacy value last. De-duplicated; frozen so
+    # downstream consumers treat it as immutable.
+    def declared_globs
+      all = []
+      all.concat(@track_files_globs) if defined?(@track_files_globs) && @track_files_globs
+      all << @coverage_track_files if defined?(@coverage_track_files) && @coverage_track_files
+      all.uniq.freeze
+    end
+
+    # Rails preset hook. M3.3 ships it as a no-op so users can write
+    # `track_rails_defaults` in .rspec-tracer today without a
+    # NoMethodError; M4.1 fills in the Rails-specific glob set.
+    def track_rails_defaults
+      nil
+    end
+
+    # One-way latch. Tracker.setup (M3.6) flips it so a stray
+    # `track_files` later in the boot sequence raises instead of
+    # silently accumulating into state that has already been read.
+    def freeze_declared_globs!
+      @declared_globs_frozen = true
+    end
+
     def add_filter(filter = nil, &)
       filters << parse_filter(filter, &)
     end

--- a/lib/rspec_tracer/tracker/declared_globs.rb
+++ b/lib/rspec_tracer/tracker/declared_globs.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'set'
+
+require_relative 'input'
+
+module RSpecTracer
+  module Tracker
+    # Observer #3 in the 2.0 tracker pipeline (CoverageAdapter = #1,
+    # IOHooks = #2). Walks user-declared glob patterns at boot, digests
+    # each matching file, and emits :declared Inputs. Declared globs
+    # cover inputs that cannot be auto-observed - files no app code
+    # reads (Gemfile.lock, .rspec-tracer), or files that might not be
+    # rendered during a given run (a newly-added template).
+    #
+    # Exposes #covers? so IOHooks can skip paths the declared-globs
+    # walk already observed. ARCHITECTURE rule (Input taxonomy): "if
+    # the user declares a glob that covers the same files we auto-
+    # intercept, the declared glob takes precedence."
+    #
+    # Graceful degradation (CLAUDE.md): an unreadable declared file is
+    # skipped silently - the tracer never propagates failure into the
+    # user's test suite. Identity-based Set dedup collapses overlap
+    # when two globs match the same file.
+    class DeclaredGlobs
+      # FNM_PATHNAME keeps `*` from eating `/` so globs walk directory
+      # boundaries predictably. FNM_EXTGLOB enables `{a,b}` alternation
+      # so `coverage_track_files '{app,lib}/**/*.rb'` (a real pattern
+      # in the sample projects) matches the same files `Dir.glob` would.
+      FNMATCH_FLAGS = File::FNM_PATHNAME | File::FNM_EXTGLOB
+
+      attr_reader :root, :globs
+
+      def initialize(root:, globs: [])
+        @root = File.expand_path(root)
+        @root_prefix = "#{@root}/"
+        @globs = Array(globs).flatten.compact.map(&:to_s).uniq.freeze
+      end
+
+      # Memoized across calls - the architecture constraint is "glob
+      # walk at boot is a single pass; result cached for the life of
+      # the tracker instance."
+      def walk
+        @walk ||= compute_walk
+      end
+
+      # O(N_globs) per call; N is typically 1-10. Absolute paths only -
+      # the callers (IOHooks precedence, NewFileDetector diff) always
+      # hold absolute paths. Paths outside root never match.
+      def covers?(path)
+        return false if @globs.empty?
+        return false unless path.start_with?(@root_prefix)
+
+        rel = path[@root_prefix.length..]
+        @globs.any? { |glob| File.fnmatch?(glob, rel, FNMATCH_FLAGS) }
+      end
+
+      # Per-example attribution. Declared inputs attach to every example
+      # in the suite - the per-example DSL arrives in M5.2. Each example
+      # gets its own Set copy so downstream mutation of one example's
+      # input set does not leak into siblings.
+      def attribute_to(example_ids)
+        inputs = walk
+        example_ids.to_h { |id| [id, Set.new(inputs)] }
+      end
+
+      private
+
+      def compute_walk
+        @globs.each_with_object(Set.new) do |glob, acc|
+          Dir.glob(glob, base: @root).each do |rel|
+            abs = File.expand_path(rel, @root)
+            next unless abs.start_with?(@root_prefix) && File.file?(abs)
+
+            digest = file_digest(abs)
+            next if digest.nil?
+
+            acc << Input.for_file(path: abs, kind: :declared, digest: digest, root: @root)
+          end
+        end
+      end
+
+      def file_digest(path)
+        Digest::SHA256.file(path).hexdigest
+      rescue SystemCallError
+        nil
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/tracker/new_file_detector.rb
+++ b/lib/rspec_tracer/tracker/new_file_detector.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'set'
+
+require_relative 'declared_globs'
+
+module RSpecTracer
+  module Tracker
+    # Observer #5 (composition of DeclaredGlobs + cache diff). Fixes
+    # KNOWN_ISSUES Section B5: 1.x's fetch_changed_files loop only
+    # iterated the previous run's cache, so newly-added source files
+    # were never discovered and never triggered re-runs.
+    #
+    # The fix: at boot, walk the union of user-declared globs and a
+    # pure-Ruby default set (lib/**/*.rb). Every match on disk that is
+    # not in the loaded cache's known_paths emits an Input, which the
+    # filter engine (M3.5) treats as "added" and re-runs any example
+    # whose dependency graph could plausibly include it.
+    #
+    # Kind is :declared for every emission. The pure-Ruby default is
+    # logically a pre-declared glob on the user's behalf - the
+    # attribution semantics are identical to an explicit
+    # `track_files 'lib/**/*.rb'`.
+    #
+    # Rails preset (app/**/*.rb) arrives in M4.1 through
+    # Configuration#track_rails_defaults; the default list here stays
+    # framework-agnostic.
+    class NewFileDetector
+      DEFAULT_GLOBS = %w[lib/**/*.rb].freeze
+
+      attr_reader :root
+
+      def initialize(root:, declared_globs: [], default_globs: DEFAULT_GLOBS)
+        @root = File.expand_path(root)
+        merged = Array(declared_globs).flatten.compact.map(&:to_s) +
+          Array(default_globs).flatten.compact.map(&:to_s)
+        @walker = DeclaredGlobs.new(root: @root, globs: merged.uniq)
+      end
+
+      # Set<Input> for every on-disk match not present in the supplied
+      # known_paths Set. Called once per suite boot; the walker's
+      # underlying digest work is memoized on the DeclaredGlobs
+      # instance so repeated calls within a single suite don't re-hash.
+      def new_files(known_paths:)
+        known = known_paths.to_set
+        @walker.walk.reject { |input| known.include?(input.path) }.to_set
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/tracker/whole_suite_invalidators.rb
+++ b/lib/rspec_tracer/tracker/whole_suite_invalidators.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'digest'
+
+require_relative '../version'
+
+module RSpecTracer
+  module Tracker
+    # Observer #4 in the 2.0 tracker pipeline. Emits the binary
+    # "blow it all up" signal that runs before any per-example
+    # filtering - when any watched file changes, the filter engine
+    # (M3.5) treats every example as affected.
+    #
+    # Watch list is deliberately hard-coded (not config-overridable):
+    # these are the files whose semantics are universal across any
+    # rspec-tracer user.
+    #
+    #   - Gemfile.lock   : dependency changes ripple through every spec
+    #   - .ruby-version  : Ruby version changes can shift any behavior
+    #   - .rspec-tracer  : tracer config changes (filters, declared
+    #                      globs) affect what the cache considers fresh
+    #
+    # Plus a synthetic entry for the rspec-tracer gem identity itself -
+    # a gem upgrade that changes invalidation semantics has to
+    # invalidate the cache, which lockfile tracking alone doesn't catch
+    # (the gem path is version-stamped but Gemfile.lock only sees the
+    # constraint, not the resolved install).
+    #
+    # Graceful degradation (CLAUDE.md): absent watch files are skipped
+    # silently. Key-presence asymmetry is the invalidation signal
+    # (snapshot A has key, snapshot B does not => invalidated).
+    class WholeSuiteInvalidators
+      WATCH_FILES = %w[Gemfile.lock .ruby-version .rspec-tracer].freeze
+      GEM_IDENTITY_KEY = 'rspec-tracer-gem'
+
+      attr_reader :root, :gem_version
+
+      def initialize(root:, gem_version: RSpecTracer::VERSION)
+        @root = File.expand_path(root)
+        @gem_version = gem_version
+      end
+
+      # Fresh snapshot on every call - callers typically take one at
+      # boot (stored as the "current" snapshot) and compare against a
+      # previously-loaded snapshot (returned by storage in M3.4).
+      # Unlike DeclaredGlobs.walk, this is not memoized: the caller
+      # chooses when to sample.
+      def digest_snapshot
+        snapshot = {}
+        WATCH_FILES.each do |rel|
+          digest = file_digest(File.join(@root, rel))
+          snapshot[rel] = digest unless digest.nil?
+        end
+        snapshot[GEM_IDENTITY_KEY] = gem_identity_digest
+        snapshot
+      end
+
+      # nil previous_snapshot = first-run case (no cache); treat as
+      # invalidated so the filter engine runs every example. Any
+      # subsequent run with a stored snapshot compares value-equality
+      # across the whole Hash, which captures added/removed/changed
+      # watch files in one check.
+      def invalidated?(previous_snapshot)
+        return true if previous_snapshot.nil?
+
+        digest_snapshot != previous_snapshot
+      end
+
+      private
+
+      # Digest::SHA256.file raises SystemCallError for missing / non-file
+      # paths; the rescue normalizes the outcome so the existence check
+      # is implicit. Mirrors CoverageAdapter#file_digest's rescue-only
+      # shape.
+      def file_digest(path)
+        Digest::SHA256.file(path).hexdigest
+      rescue SystemCallError
+        nil
+      end
+
+      def gem_identity_digest
+        Digest::SHA256.hexdigest("rspec-tracer-#{@gem_version}")
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -99,6 +99,105 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
+  describe '#track_files' do
+    it 'returns an empty list when never configured' do
+      expect(config.declared_globs).to eq([])
+    end
+
+    it 'accumulates across multiple calls' do
+      config.track_files('db/schema.rb')
+      config.track_files('config/**/*.yml')
+
+      expect(config.declared_globs).to eq(%w[db/schema.rb config/**/*.yml])
+    end
+
+    it 'accepts multiple globs per call' do
+      config.track_files('a.rb', 'b.rb')
+
+      expect(config.declared_globs).to eq(%w[a.rb b.rb])
+    end
+
+    it 'flattens nested arrays' do
+      config.track_files(%w[a.rb b.rb])
+
+      expect(config.declared_globs).to eq(%w[a.rb b.rb])
+    end
+
+    it 'de-duplicates repeated globs' do
+      config.track_files('a.rb')
+      config.track_files('a.rb')
+
+      expect(config.declared_globs).to eq(['a.rb'])
+    end
+
+    it 'coerces non-string globs to strings' do
+      config.track_files(Pathname.new('a.rb'))
+
+      expect(config.declared_globs).to eq(['a.rb'])
+    end
+
+    it 'drops nil entries' do
+      config.track_files(nil, 'a.rb', nil)
+
+      expect(config.declared_globs).to eq(['a.rb'])
+    end
+  end
+
+  describe '#declared_globs consolidation' do
+    it 'returns a frozen array' do
+      expect(config.declared_globs).to be_frozen
+    end
+
+    it 'includes the legacy coverage_track_files value' do
+      config.coverage_track_files('app/**/*.rb')
+
+      expect(config.declared_globs).to eq(['app/**/*.rb'])
+    end
+
+    it 'merges track_files and coverage_track_files (track_files first)' do
+      config.track_files('db/schema.rb')
+      config.coverage_track_files('app/**/*.rb')
+
+      expect(config.declared_globs).to eq(%w[db/schema.rb app/**/*.rb])
+    end
+
+    it 'de-duplicates a glob declared via both surfaces' do
+      config.track_files('app/**/*.rb')
+      config.coverage_track_files('app/**/*.rb')
+
+      expect(config.declared_globs).to eq(['app/**/*.rb'])
+    end
+  end
+
+  describe '#freeze_declared_globs!' do
+    it 'prevents subsequent track_files calls' do
+      config.track_files('a.rb')
+      config.freeze_declared_globs!
+
+      expect { config.track_files('b.rb') }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /cannot be called/)
+    end
+
+    it 'keeps previously-declared globs readable after freezing' do
+      config.track_files('a.rb')
+      config.freeze_declared_globs!
+
+      expect(config.declared_globs).to eq(['a.rb'])
+    end
+  end
+
+  describe '#track_rails_defaults' do
+    it 'is a no-op stub until M4.1 (returns nil)' do
+      expect(config.track_rails_defaults).to be_nil
+    end
+
+    it 'does not accumulate any declared globs' do
+      config.track_rails_defaults
+
+      expect(config.declared_globs).to eq([])
+    end
+  end
+
   describe '#add_filter' do
     # Uses the isolated `config` instance (Class.new { include Configuration })
     # rather than the global RSpecTracer constant so a registered filter

--- a/spec/properties/invalidation_monotonic_spec.rb
+++ b/spec/properties/invalidation_monotonic_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+# Property-test bodies legitimately need setup before the expectation;
+# RSpec/ExampleLength is tuned for unit tests with a single-line body.
+# rubocop:disable RSpec/ExampleLength, RSpec/DescribeClass
+require 'fileutils'
+require 'set'
+require 'tmpdir'
+require 'rantly/rspec_extensions'
+require 'rspec_tracer/tracker/declared_globs'
+require 'rspec_tracer/tracker/new_file_detector'
+
+# Fixed alphabet of files on disk - Rantly can only produce collisions
+# against a small population, and collisions are the whole point of
+# monotonicity testing (adding a glob that covers already-covered
+# files must not shrink the Input set).
+MONOTONIC_FILES = %w[
+  lib/a.rb lib/nested/b.rb lib/util/c.rb
+  app/x.rb app/models/y.rb
+  db/schema.rb
+  config/a.yml config/b.yml
+].freeze
+
+MONOTONIC_GLOBS = %w[
+  lib/**/*.rb
+  lib/*.rb
+  app/**/*.rb
+  db/schema.rb
+  config/*.yml
+  does/not/exist/*.rb
+].freeze
+
+module InvalidationMonotonicGen
+  module_function
+
+  def subset_of(list)
+    # choose(*list) with a random count; `sample` keeps the selection
+    # simple without pulling in extra Rantly combinators.
+    n = Rantly { range(0, list.size) }
+    list.sample(n)
+  end
+
+  def extra_glob(exclude:)
+    candidates = MONOTONIC_GLOBS - exclude
+    return nil if candidates.empty?
+
+    Rantly { choose(*candidates) }
+  end
+
+  def build_walker(root, globs)
+    RSpecTracer::Tracker::DeclaredGlobs.new(root: root, globs: globs)
+  end
+end
+
+RSpec.describe 'invalidation monotonicity' do
+  let(:tmp_base) { Dir.mktmpdir }
+  let(:root) { File.join(tmp_base, 'project').tap { |p| FileUtils.mkdir_p(p) } }
+
+  before do
+    MONOTONIC_FILES.each do |rel|
+      abs = File.join(root, rel)
+      FileUtils.mkdir_p(File.dirname(abs))
+      File.write(abs, "content:#{rel}\n")
+    end
+  end
+
+  after { FileUtils.rm_rf(tmp_base) if tmp_base }
+
+  describe 'DeclaredGlobs#walk' do
+    it 'is monotonic in the globs list (adding a glob never shrinks the Input set)' do
+      property_of { InvalidationMonotonicGen.subset_of(MONOTONIC_GLOBS) }.check(100) do |globs|
+        extra = InvalidationMonotonicGen.extra_glob(exclude: globs)
+        next if extra.nil?
+
+        before_inputs = InvalidationMonotonicGen.build_walker(root, globs).walk
+        after_inputs = InvalidationMonotonicGen.build_walker(root, globs + [extra]).walk
+
+        expect(after_inputs).to be >= before_inputs
+      end
+    end
+  end
+
+  describe 'DeclaredGlobs#covers?' do
+    it 'is monotonic: a path covered by G is still covered by G + {g}' do
+      property_of { InvalidationMonotonicGen.subset_of(MONOTONIC_GLOBS) }.check(100) do |globs|
+        extra = InvalidationMonotonicGen.extra_glob(exclude: globs)
+        next if extra.nil?
+
+        before_walker = InvalidationMonotonicGen.build_walker(root, globs)
+        after_walker = InvalidationMonotonicGen.build_walker(root, globs + [extra])
+
+        covered_before = MONOTONIC_FILES
+          .map { |rel| File.join(root, rel) }
+          .select { |p| before_walker.covers?(p) }
+
+        expect(covered_before).to all(satisfy { |p| after_walker.covers?(p) })
+      end
+    end
+  end
+
+  describe 'NewFileDetector#new_files' do
+    it 'is monotonic in declared_globs (adding a glob never shrinks the new-files set)' do
+      property_of { InvalidationMonotonicGen.subset_of(MONOTONIC_GLOBS) }.check(100) do |globs|
+        extra = InvalidationMonotonicGen.extra_glob(exclude: globs)
+        next if extra.nil?
+
+        before_set = RSpecTracer::Tracker::NewFileDetector
+          .new(root: root, declared_globs: globs, default_globs: [])
+          .new_files(known_paths: Set.new)
+        after_set = RSpecTracer::Tracker::NewFileDetector
+          .new(root: root, declared_globs: globs + [extra], default_globs: [])
+          .new_files(known_paths: Set.new)
+
+        expect(after_set).to be >= before_set
+      end
+    end
+  end
+
+  describe 'NewFileDetector#new_files is anti-monotonic in known_paths' do
+    it 'adding a path to known_paths never grows the new-files set' do
+      property_of { InvalidationMonotonicGen.subset_of(MONOTONIC_FILES) }.check(100) do |known_rels|
+        known_abs = known_rels.map { |rel| File.join(root, rel) }
+        extra = (MONOTONIC_FILES - known_rels).sample
+        next if extra.nil?
+
+        detector = RSpecTracer::Tracker::NewFileDetector.new(
+          root: root, declared_globs: MONOTONIC_GLOBS, default_globs: []
+        )
+        before_set = detector.new_files(known_paths: Set.new(known_abs))
+        after_set = detector.new_files(known_paths: Set.new(known_abs + [File.join(root, extra)]))
+
+        expect(before_set).to be >= after_set
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength, RSpec/DescribeClass

--- a/spec/tracker/declared_globs_spec.rb
+++ b/spec/tracker/declared_globs_spec.rb
@@ -1,0 +1,272 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'set'
+require 'tmpdir'
+require 'rspec_tracer/tracker/declared_globs'
+
+RSpec.describe RSpecTracer::Tracker::DeclaredGlobs do
+  let(:tmp_base) { Dir.mktmpdir }
+  let(:root) { File.join(tmp_base, 'project').tap { |p| FileUtils.mkdir_p(p) } }
+
+  after { FileUtils.rm_rf(tmp_base) if tmp_base }
+
+  def write_file(rel, contents = "x\n")
+    path = File.join(root, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    path
+  end
+
+  describe '#initialize' do
+    it 'expands the root to an absolute path' do
+      walker = described_class.new(root: Pathname.new(root).relative_path_from(Pathname.new(Dir.pwd)).to_s)
+
+      expect(walker.root).to eq(File.expand_path(root))
+    end
+
+    it 'freezes the supplied globs list' do
+      walker = described_class.new(root: root, globs: ['lib/**/*.rb'])
+
+      expect(walker.globs).to be_frozen
+    end
+
+    it 'defaults globs to an empty frozen list' do
+      walker = described_class.new(root: root)
+
+      expect(walker.globs).to eq([]).and be_frozen
+    end
+
+    it 'coerces non-string globs to strings' do
+      walker = described_class.new(root: root, globs: [Pathname.new('lib/foo.rb')])
+
+      expect(walker.globs).to eq(['lib/foo.rb'])
+    end
+
+    it 'flattens nested arrays of globs' do
+      walker = described_class.new(root: root, globs: [['a.rb'], ['b.rb']])
+
+      expect(walker.globs).to eq(%w[a.rb b.rb])
+    end
+
+    it 'de-duplicates identical globs' do
+      walker = described_class.new(root: root, globs: %w[lib/**/*.rb lib/**/*.rb])
+
+      expect(walker.globs).to eq(['lib/**/*.rb'])
+    end
+
+    it 'drops nil globs' do
+      walker = described_class.new(root: root, globs: [nil, 'lib/foo.rb', nil])
+
+      expect(walker.globs).to eq(['lib/foo.rb'])
+    end
+  end
+
+  describe '#walk' do
+    it 'returns an empty set when no globs are declared' do
+      walker = described_class.new(root: root)
+
+      expect(walker.walk).to eq(Set.new)
+    end
+
+    it 'emits :declared Inputs for every matching file' do
+      write_file('db/schema.rb', "schema\n")
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      expect(walker.walk.map(&:kind)).to eq([:declared])
+    end
+
+    it 'digests each match with SHA256 hex' do
+      write_file('db/schema.rb', "schema\n")
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      expect(walker.walk.first.digest).to eq(Digest::SHA256.hexdigest("schema\n"))
+    end
+
+    it 'expands paths to absolute form' do
+      path = write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      expect(walker.walk.first.path).to eq(File.expand_path(path))
+    end
+
+    it 'tags the Input identity with the :declared kind' do
+      write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      expect(walker.walk.first.identity).to eq('declared:db/schema.rb')
+    end
+
+    it 'walks recursive `**` globs' do
+      write_file('lib/a.rb')
+      write_file('lib/nested/b.rb')
+      walker = described_class.new(root: root, globs: ['lib/**/*.rb'])
+
+      expect(walker.walk.map(&:identity)).to contain_exactly('declared:lib/a.rb', 'declared:lib/nested/b.rb')
+    end
+
+    it 'supports extglob alternation like {a,b}/**/*.rb' do
+      %w[app/x.rb lib/y.rb other/z.rb].each { |rel| write_file(rel) }
+      walker = described_class.new(root: root, globs: ['{app,lib}/**/*.rb'])
+
+      expect(walker.walk.map(&:identity))
+        .to contain_exactly('declared:app/x.rb', 'declared:lib/y.rb')
+    end
+
+    it 'skips directories that happen to match the glob' do
+      FileUtils.mkdir_p(File.join(root, 'lib/matched_dir'))
+      walker = described_class.new(root: root, globs: ['lib/*'])
+
+      expect(walker.walk).to eq(Set.new)
+    end
+
+    it 'de-duplicates files matched by multiple globs' do
+      write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/*.rb', 'db/schema.rb'])
+
+      expect(walker.walk.size).to eq(1)
+    end
+
+    it 'returns an empty set when globs match nothing' do
+      walker = described_class.new(root: root, globs: ['never/matches/*.rb'])
+
+      expect(walker.walk).to eq(Set.new)
+    end
+
+    it 'memoizes the result across calls' do
+      write_file('a.rb')
+      walker = described_class.new(root: root, globs: ['a.rb'])
+
+      expect(walker.walk).to equal(walker.walk)
+    end
+
+    it 'does not re-digest on a second call (proves memoization)' do
+      write_file('a.rb', "v1\n")
+      walker = described_class.new(root: root, globs: ['a.rb'])
+      first = walker.walk.first.digest
+      File.write(File.join(root, 'a.rb'), "v2\n")
+
+      expect(walker.walk.first.digest).to eq(first)
+    end
+
+    it 'skips a path when digesting raises (graceful degradation)' do
+      write_file('boom.rb')
+      walker = described_class.new(root: root, globs: ['boom.rb'])
+      allow(Digest::SHA256).to receive(:file).and_raise(Errno::EACCES)
+
+      expect(walker.walk).to eq(Set.new)
+    end
+
+    it 'drops paths a glob resolved outside root (e.g. absolute glob escape)' do
+      outside = File.join(tmp_base, 'outside.rb')
+      File.write(outside, "x\n")
+      walker = described_class.new(root: root, globs: [outside])
+
+      expect(walker.walk).to eq(Set.new)
+    end
+  end
+
+  describe '#covers?' do
+    it 'returns false when no globs are declared' do
+      walker = described_class.new(root: root)
+
+      expect(walker.covers?(File.join(root, 'anything.rb'))).to be(false)
+    end
+
+    it 'returns false for paths outside root' do
+      walker = described_class.new(root: root, globs: ['**/*.rb'])
+
+      expect(walker.covers?('/elsewhere/a.rb')).to be(false)
+    end
+
+    it 'matches a literal filename' do
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      expect(walker.covers?(File.join(root, 'db/schema.rb'))).to be(true)
+    end
+
+    it 'matches a recursive `**` glob' do
+      walker = described_class.new(root: root, globs: ['lib/**/*.rb'])
+
+      expect(walker.covers?(File.join(root, 'lib/nested/foo.rb'))).to be(true)
+    end
+
+    it 'does not match paths the glob excludes' do
+      walker = described_class.new(root: root, globs: ['lib/**/*.rb'])
+
+      expect(walker.covers?(File.join(root, 'app/foo.rb'))).to be(false)
+    end
+
+    it 'does not match paths equal to root (no trailing separator)' do
+      walker = described_class.new(root: root, globs: ['**/*'])
+
+      expect(walker.covers?(root)).to be(false)
+    end
+
+    it 'supports extglob alternation' do
+      walker = described_class.new(root: root, globs: ['{app,lib}/**/*.rb'])
+
+      expect(walker.covers?(File.join(root, 'app/foo.rb'))).to be(true)
+    end
+  end
+
+  describe '#attribute_to' do
+    it 'returns an empty hash for no example ids' do
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      expect(walker.attribute_to([])).to eq({})
+    end
+
+    it 'attaches the declared inputs to every supplied example id' do
+      write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      attribution = walker.attribute_to(%w[ex1 ex2])
+
+      expect(attribution.keys).to contain_exactly('ex1', 'ex2')
+    end
+
+    it 'returns identity-equal Input sets per example' do
+      write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      attribution = walker.attribute_to(%w[ex1 ex2])
+
+      expect(attribution['ex1']).to eq(attribution['ex2'])
+    end
+
+    it 'returns distinct Set instances so per-example mutation stays local' do
+      write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      attribution = walker.attribute_to(%w[ex1 ex2])
+      attribution['ex1'].clear
+
+      expect(attribution['ex2']).not_to be_empty
+    end
+
+    it 'contains Inputs with the :declared kind' do
+      write_file('db/schema.rb')
+      walker = described_class.new(root: root, globs: ['db/schema.rb'])
+
+      attribution = walker.attribute_to(%w[ex1])
+
+      expect(attribution['ex1'].map(&:kind)).to eq([:declared])
+    end
+  end
+
+  describe 'end-to-end change detection' do
+    # Proves AC: a declared file's digest changes when its contents
+    # change - the signal that drives "re-run everything depending on
+    # this input" in M3.5/M3.6.
+    it 'returns a new digest when the declared file is modified between runs' do
+      path = write_file('db/schema.rb', "v1\n")
+      v1_digest = described_class.new(root: root, globs: ['db/schema.rb']).walk.first.digest
+      File.write(path, "v2\n")
+      v2_digest = described_class.new(root: root, globs: ['db/schema.rb']).walk.first.digest
+
+      expect(v1_digest).not_to eq(v2_digest)
+    end
+  end
+end

--- a/spec/tracker/new_file_detector_spec.rb
+++ b/spec/tracker/new_file_detector_spec.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'set'
+require 'tmpdir'
+require 'rspec_tracer/tracker/new_file_detector'
+
+RSpec.describe RSpecTracer::Tracker::NewFileDetector do
+  let(:tmp_base) { Dir.mktmpdir }
+  let(:root) { File.join(tmp_base, 'project').tap { |p| FileUtils.mkdir_p(p) } }
+
+  after { FileUtils.rm_rf(tmp_base) if tmp_base }
+
+  def write_file(rel, contents = "x\n")
+    path = File.join(root, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    path
+  end
+
+  describe '#initialize' do
+    it 'expands root to an absolute path' do
+      detector = described_class.new(root: root)
+
+      expect(detector.root).to eq(File.expand_path(root))
+    end
+  end
+
+  describe '#new_files with empty cache' do
+    it 'returns every file matching the default lib/**/*.rb glob' do
+      write_file('lib/a.rb')
+      write_file('lib/nested/b.rb')
+      detector = described_class.new(root: root)
+
+      expect(detector.new_files(known_paths: Set.new).map(&:identity))
+        .to contain_exactly('declared:lib/a.rb', 'declared:lib/nested/b.rb')
+    end
+
+    it 'adds user-declared globs on top of the default set' do
+      write_file('lib/a.rb')
+      write_file('db/schema.rb')
+      detector = described_class.new(root: root, declared_globs: ['db/schema.rb'])
+
+      expect(detector.new_files(known_paths: Set.new).map(&:identity))
+        .to contain_exactly('declared:lib/a.rb', 'declared:db/schema.rb')
+    end
+
+    it 'emits :declared kind for every new file' do
+      write_file('lib/a.rb')
+      detector = described_class.new(root: root)
+
+      expect(detector.new_files(known_paths: Set.new).map(&:kind)).to eq([:declared])
+    end
+  end
+
+  describe '#new_files filters out known paths' do
+    it 'drops files whose absolute path is in known_paths' do
+      path_a = write_file('lib/a.rb')
+      write_file('lib/b.rb')
+      detector = described_class.new(root: root)
+
+      expect(detector.new_files(known_paths: Set[path_a]).map(&:identity))
+        .to eq(['declared:lib/b.rb'])
+    end
+
+    it 'returns an empty set when every match is known' do
+      a = write_file('lib/a.rb')
+      b = write_file('lib/b.rb')
+      detector = described_class.new(root: root)
+
+      expect(detector.new_files(known_paths: Set[a, b])).to eq(Set.new)
+    end
+
+    it 'accepts an Array of known paths (to_set coerces)' do
+      a = write_file('lib/a.rb')
+      write_file('lib/b.rb')
+      detector = described_class.new(root: root)
+
+      expect(detector.new_files(known_paths: [a]).map(&:identity))
+        .to eq(['declared:lib/b.rb'])
+    end
+  end
+
+  describe '#new_files regression for KNOWN_ISSUES §B5' do
+    # The bug: 1.x only diffs files already in cache.all_files, so a
+    # newly-added source file is invisible to the invalidation path.
+    # The fix: walk declared + default globs and emit Inputs for any
+    # on-disk match not in the cache.
+    it 'emits an Input for a file added between runs' do
+      write_file('lib/existing.rb')
+      run1_paths = described_class.new(root: root).new_files(known_paths: Set.new).map(&:path)
+      write_file('lib/added.rb')
+
+      run2 = described_class.new(root: root).new_files(known_paths: Set.new(run1_paths)).map(&:identity)
+
+      expect(run2).to eq(['declared:lib/added.rb'])
+    end
+  end
+
+  describe 'custom default_globs override' do
+    it 'walks the supplied default set in place of lib/**/*.rb' do
+      write_file('lib/not_walked.rb')
+      write_file('custom/walked.rb')
+      detector = described_class.new(root: root, default_globs: ['custom/**/*.rb'])
+
+      expect(detector.new_files(known_paths: Set.new).map(&:identity))
+        .to eq(['declared:custom/walked.rb'])
+    end
+
+    it 'accepts an empty default_globs list (user-declared only)' do
+      %w[lib/ignored.rb db/schema.rb].each { |rel| write_file(rel) }
+      detector = described_class.new(root: root, declared_globs: ['db/schema.rb'], default_globs: [])
+
+      expect(detector.new_files(known_paths: Set.new).map(&:identity)).to eq(['declared:db/schema.rb'])
+    end
+  end
+
+  describe 'glob de-duplication between declared and default sets' do
+    it 'emits each file exactly once when declared and default globs overlap' do
+      write_file('lib/overlap.rb')
+      detector = described_class.new(
+        root: root, declared_globs: ['lib/**/*.rb']
+      )
+
+      expect(detector.new_files(known_paths: Set.new).size).to eq(1)
+    end
+  end
+end

--- a/spec/tracker/whole_suite_invalidators_spec.rb
+++ b/spec/tracker/whole_suite_invalidators_spec.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+require 'digest'
+require 'fileutils'
+require 'tmpdir'
+require 'rspec_tracer/tracker/whole_suite_invalidators'
+
+RSpec.describe RSpecTracer::Tracker::WholeSuiteInvalidators do
+  let(:tmp_base) { Dir.mktmpdir }
+  let(:root) { File.join(tmp_base, 'project').tap { |p| FileUtils.mkdir_p(p) } }
+
+  after { FileUtils.rm_rf(tmp_base) if tmp_base }
+
+  def write_watch(rel, contents)
+    path = File.join(root, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    path
+  end
+
+  describe '#initialize' do
+    it 'expands root to an absolute path' do
+      invs = described_class.new(root: root)
+
+      expect(invs.root).to eq(File.expand_path(root))
+    end
+
+    it 'defaults gem_version to RSpecTracer::VERSION' do
+      invs = described_class.new(root: root)
+
+      expect(invs.gem_version).to eq(RSpecTracer::VERSION)
+    end
+
+    it 'accepts an explicit gem_version override' do
+      invs = described_class.new(root: root, gem_version: '9.9.9')
+
+      expect(invs.gem_version).to eq('9.9.9')
+    end
+  end
+
+  describe '#digest_snapshot' do
+    it 'always includes the gem identity key' do
+      invs = described_class.new(root: root)
+
+      expect(invs.digest_snapshot).to have_key(described_class::GEM_IDENTITY_KEY)
+    end
+
+    it 'hashes gem identity with SHA256 over "rspec-tracer-<version>"' do
+      invs = described_class.new(root: root, gem_version: '1.2.3')
+
+      expect(invs.digest_snapshot[described_class::GEM_IDENTITY_KEY])
+        .to eq(Digest::SHA256.hexdigest('rspec-tracer-1.2.3'))
+    end
+
+    it 'omits absent watch files rather than inserting a nil sentinel' do
+      invs = described_class.new(root: root)
+
+      expect(invs.digest_snapshot).not_to have_key('Gemfile.lock')
+    end
+
+    it 'digests Gemfile.lock with SHA256 hex when present' do
+      write_watch('Gemfile.lock', "GEM\n")
+      invs = described_class.new(root: root)
+
+      expect(invs.digest_snapshot['Gemfile.lock'])
+        .to eq(Digest::SHA256.hexdigest("GEM\n"))
+    end
+
+    it 'digests .ruby-version when present' do
+      write_watch('.ruby-version', "3.3.10\n")
+      invs = described_class.new(root: root)
+
+      expect(invs.digest_snapshot['.ruby-version'])
+        .to eq(Digest::SHA256.hexdigest("3.3.10\n"))
+    end
+
+    it 'digests .rspec-tracer when present' do
+      write_watch('.rspec-tracer', "RSpecTracer.configure {}\n")
+      invs = described_class.new(root: root)
+
+      expect(invs.digest_snapshot['.rspec-tracer'])
+        .to eq(Digest::SHA256.hexdigest("RSpecTracer.configure {}\n"))
+    end
+
+    it 'returns a distinct digest on file-content changes' do
+      write_watch('Gemfile.lock', "v1\n")
+      invs = described_class.new(root: root)
+      v1 = invs.digest_snapshot['Gemfile.lock']
+      write_watch('Gemfile.lock', "v2\n")
+
+      expect(invs.digest_snapshot['Gemfile.lock']).not_to eq(v1)
+    end
+
+    it 'skips a watch file when digesting raises (graceful degradation)' do
+      write_watch('Gemfile.lock', "GEM\n")
+      invs = described_class.new(root: root)
+      allow(Digest::SHA256).to receive(:file).and_raise(Errno::EACCES)
+
+      expect(invs.digest_snapshot).not_to have_key('Gemfile.lock')
+    end
+  end
+
+  describe '#invalidated?' do
+    let(:invs) { described_class.new(root: root) }
+
+    it 'returns true when there is no previous snapshot (first run)' do
+      expect(invs.invalidated?(nil)).to be(true)
+    end
+
+    it 'returns false when the current snapshot equals the previous' do
+      snapshot = invs.digest_snapshot
+
+      expect(invs.invalidated?(snapshot)).to be(false)
+    end
+
+    it 'returns true when a watch file appears' do
+      previous = invs.digest_snapshot
+      write_watch('Gemfile.lock', "GEM\n")
+
+      expect(invs.invalidated?(previous)).to be(true)
+    end
+
+    it 'returns true when a watch file disappears' do
+      write_watch('Gemfile.lock', "GEM\n")
+      previous = invs.digest_snapshot
+      File.delete(File.join(root, 'Gemfile.lock'))
+
+      expect(invs.invalidated?(previous)).to be(true)
+    end
+
+    it 'returns true when a watch file content changes' do
+      write_watch('Gemfile.lock', "v1\n")
+      previous = invs.digest_snapshot
+      write_watch('Gemfile.lock', "v2\n")
+
+      expect(invs.invalidated?(previous)).to be(true)
+    end
+
+    it 'returns true when the gem version changes' do
+      previous = described_class.new(root: root, gem_version: '1.0.0').digest_snapshot
+      current = described_class.new(root: root, gem_version: '2.0.0')
+
+      expect(current.invalidated?(previous)).to be(true)
+    end
+
+    it 'returns false for an unrelated file change under root' do
+      write_watch('Gemfile.lock', "GEM\n")
+      previous = invs.digest_snapshot
+      write_watch('some/other.rb', "x\n")
+
+      expect(invs.invalidated?(previous)).to be(false)
+    end
+  end
+
+  describe 'end-to-end Gemfile.lock invalidation' do
+    # Proves AC: modifying Gemfile.lock invalidates the snapshot,
+    # which is the signal M3.5/M3.6 will translate into "re-run
+    # every example, regardless of any other config."
+    it 'fires on Gemfile.lock modification between runs' do
+      write_watch('Gemfile.lock', "run1\n")
+      run1 = described_class.new(root: root).digest_snapshot
+      write_watch('Gemfile.lock', "run2\n")
+
+      expect(described_class.new(root: root).invalidated?(run1)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Third Phase-3 leaf module, introducing three new tracker observers alongside the configuration surface that binds them:

- **`Tracker::DeclaredGlobs`** — walks user-declared glob patterns at boot, digests each match with SHA256, emits `:declared` Inputs. Exposes `covers?(abs_path)` so `IOHooks` can skip paths the glob walk already observed (ARCHITECTURE rule: declared globs take precedence over auto-interception). `attribute_to(example_ids)` returns per-example Input sets (distinct instances so downstream mutation stays local).
- **`Tracker::WholeSuiteInvalidators`** — hard-coded watch list (`Gemfile.lock`, `.ruby-version`, `.rspec-tracer`) plus a synthetic rspec-tracer gem-identity entry. `digest_snapshot` / `invalidated?(previous)` give the filter engine the binary "blow it all up" signal that runs before any per-example filtering.
- **`Tracker::NewFileDetector`** — fixes [KNOWN_ISSUES §B5](../blob/main/lib/rspec_tracer/runner.rb): 1.x's `fetch_changed_files` loop only iterated files already in the cache, so newly-added source files were invisible and never triggered re-runs. The detector walks the union of declared globs + a pure-Ruby default (`lib/**/*.rb`) and emits Inputs for any on-disk match not in the supplied `known_paths`.

Configuration gains four additions:
- `track_files(*globs)` — plural, accumulating DSL; raises `InvalidUsageError` after `freeze_declared_globs!`.
- `declared_globs` — consolidated read-only view merging `track_files` with the legacy single-arg `coverage_track_files` setter (which stays untouched — no behavior change for 1.x users).
- `freeze_declared_globs!` — one-way latch for Tracker.setup (M3.6) to flip before reading.
- `track_rails_defaults` — no-op stub so `.rspec-tracer` files can call it today; M4.1 will fill in Rails-specific globs.

All three new modules report through the existing `TrackerCoverageGate` at 100% line + branch.

## Mechanical AC checks

- [x] Specs: 100% line + branch on `declared_globs.rb`, `whole_suite_invalidators.rb`, `new_file_detector.rb` (`TrackerCoverageGate` gate).
- [x] Declared-file digest change flow — `declared_globs_spec.rb` end-to-end test: schema.rb v1 → v2 produces distinct digests.
- [x] `Gemfile.lock` invalidation flow — `whole_suite_invalidators_spec.rb` end-to-end test: modified lockfile flips `invalidated?` to true.
- [x] New-file regression for KNOWN_ISSUES §B5 — `new_file_detector_spec.rb` scenario: file added between runs surfaces as a `:declared` Input on the second walk.
- [x] Property spec runs 100 iterations per property (`spec/properties/invalidation_monotonic_spec.rb`): walk/covers?/new_files monotonicity plus known_paths anti-monotonicity.
- [x] Mutation smoke: `Tracker::DeclaredGlobs` 91.63% · `Tracker::WholeSuiteInvalidators` 91.05% · above the 90% gate.

Note: "all examples re-run" under the `track_files 'db/schema.rb'` and `Gemfile.lock` ACs is a tracker-wide integration outcome that needs M3.5 (filter engine) + M3.6 (`Tracker.setup` orchestration) to observe end-to-end. M3.3 ships the mechanical signals that drive it (digest mismatches + `invalidated?` returning true); the full wiring lands in M3.6.

## Rules of engagement

- **One session = one PR** — three modules + DSL delta + specs. Splitting would cut across the Configuration DSL change, so bundling is the cleaner seam.
- **Graceful degradation** — every file-system read is guarded; an unreadable declared file is skipped, not propagated.
- **Legacy surface preserved** — `coverage_track_files` keeps its single-arg overwrite-on-call semantics; sample projects and README examples continue to work unchanged.
- **Immutable-after-start** — `freeze_declared_globs!` is a one-way latch; the guard raises a clear `InvalidUsageError` if a `.rspec-tracer` file calls `track_files` after the tracker has started.

## Test plan

- [x] `task test:unit` (253 examples, 0 failures)
- [x] `task test:property` (14 examples × 100 iterations, all 4 new properties succeed)
- [x] `task test:mutation:smoke` (4/4 subjects ≥90%)
- [x] `task test:dogfood` (tracer-on-tracer cold + warm run green)
- [x] `task lint:ruby` (clean)
- [x] `task lint:yaml --strict` (Taskfile edit yamllint-clean)
- [x] `task lint:actions` (local PATH quirk — shellcheck goenv shim; CI runners pin shellcheck directly)
- [x] `task check:bundle` (Gemfile.lock installable)
- [x] `task security:bundle-audit` (no advisories)
- [x] `task benchmark:smoke` (cold_ruby / warm_noop / cache_load all within ratchet)
- [ ] CI matrix: Ruby 3.1/3.2/3.3/3.4/4.0 + JRuby (verifies I/O hook interaction survives Ruby-version differences; nothing Ruby-version-sensitive in this PR but the matrix is the ground truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)