### PR TITLE
feat(tracker): wired core engine + benchmark checkpoint

### DIFF
--- a/benchmark/harness.rb
+++ b/benchmark/harness.rb
@@ -58,12 +58,28 @@ module BenchmarkHarness
       cleanup: %w[rspec_tracer_cache rspec_tracer_report rspec_tracer_coverage],
       smoke: true
     },
+    'cold_ruby_v2' => {
+      desc: 'Cold start (v2 engine): RSPEC_TRACER_USE_V2_TRACKER=true',
+      cwd: RUBY_FIXTURE,
+      cmd: %w[bundle exec rspec --no-color],
+      env: { 'RSPEC_TRACER_USE_V2_TRACKER' => 'true' },
+      cleanup: %w[rspec_tracer_cache rspec_tracer_report rspec_tracer_coverage],
+      smoke: true
+    },
     'warm_noop' => {
       desc: 'Warm run: same fixture, cache populated, no file changes',
       cwd: RUBY_FIXTURE,
       cmd: %w[bundle exec rspec --no-color],
       env: {},
       warmup: ->(cwd) { run_rspec_once(cwd, {}) },
+      smoke: true
+    },
+    'warm_noop_v2' => {
+      desc: 'Warm run (v2 engine): same fixture, cache populated, no file changes',
+      cwd: RUBY_FIXTURE,
+      cmd: %w[bundle exec rspec --no-color],
+      env: { 'RSPEC_TRACER_USE_V2_TRACKER' => 'true' },
+      warmup: ->(cwd) { run_rspec_once(cwd, 'RSPEC_TRACER_USE_V2_TRACKER' => 'true') },
       smoke: true
     },
     'cache_load' => {

--- a/benchmark/ratchet.json
+++ b/benchmark/ratchet.json
@@ -13,10 +13,20 @@
       "p95": 0.4099,
       "iterations": 10
     },
+    "cold_ruby_v2": {
+      "p50": 0.254,
+      "p95": 0.259,
+      "iterations": 5
+    },
     "warm_noop": {
       "p50": 0.2327,
       "p95": 0.2744,
       "iterations": 10
+    },
+    "warm_noop_v2": {
+      "p50": 0.248,
+      "p95": 0.252,
+      "iterations": 5
     },
     "cache_load": {
       "p50": 0.2519,

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -14,6 +14,7 @@ require_relative 'rspec_tracer/coverage_merger'
 require_relative 'rspec_tracer/coverage_reporter'
 require_relative 'rspec_tracer/coverage_writer'
 require_relative 'rspec_tracer/defaults'
+require_relative 'rspec_tracer/engine'
 require_relative 'rspec_tracer/example'
 require_relative 'rspec_tracer/html_reporter/reporter'
 require_relative 'rspec_tracer/load_config'
@@ -29,6 +30,12 @@ require_relative 'rspec_tracer/source_file'
 require_relative 'rspec_tracer/time_formatter'
 require_relative 'rspec_tracer/version'
 
+# The top-level entry point has grown past the rubocop default
+# over years of legacy accumulation; splitting across files would
+# scatter the start/at_exit lifecycle across unrelated modules for
+# zero readability win. Refactoring is queued with the Phase 5
+# RSpec-integration rework.
+# rubocop:disable Metrics/ModuleLength, Metrics/ClassLength
 module RSpecTracer
   class << self
     attr_accessor :running, :pid, :no_examples, :duplicate_examples
@@ -45,10 +52,10 @@ module RSpecTracer
       initial_setup
     end
 
-    # rubocop:disable Metrics/AbcSize
     def filter_examples
       groups = Set.new
       to_run = Hash.new { |hash, group| hash[group] = [] }
+      filter_source = v2_engine? ? engine : runner
 
       RSpec.world.filtered_examples.each_pair do |example_group, examples|
         examples.each do |example|
@@ -56,26 +63,25 @@ module RSpecTracer
           example_id = tracer_example[:example_id]
           example.metadata[:rspec_tracer_example_id] = example_id
 
-          if runner.run_example?(example_id)
-            run_reason = runner.run_example_reason(example_id)
+          if filter_source.run_example?(example_id)
+            run_reason = filter_source.run_example_reason(example_id)
             tracer_example[:run_reason] = run_reason
             example.metadata[:description] = "#{example.description} (#{run_reason})"
 
             to_run[example_group] << example
             groups << example.example_group.parent_groups.last
 
-            runner.register_example(tracer_example)
+            filter_source.register_example(tracer_example)
           else
-            runner.on_example_skipped(example_id)
+            filter_source.on_example_skipped(example_id)
           end
         end
       end
 
-      runner.deregister_duplicate_examples
+      filter_source.deregister_duplicate_examples
 
       [to_run, groups.to_a]
     end
-    # rubocop:enable Metrics/AbcSize
 
     def at_exit_behavior
       return unless RSpecTracer.pid == Process.pid && RSpecTracer.running
@@ -102,6 +108,24 @@ module RSpecTracer
 
     def runner
       @runner if defined?(@runner)
+    end
+
+    # The v2 Engine instance when `use_v2_tracker` is true; nil
+    # otherwise. Lives alongside the legacy @runner / @coverage_reporter
+    # during the Phase 3 bridge period and drops out once the
+    # RSpec-hook rework retires the legacy path.
+    def engine
+      @engine if defined?(@engine)
+    end
+
+    # Per-process predicate consumed by RSpec hook modules and the
+    # top-level filter_examples dispatcher. Disabled under
+    # parallel_tests for M3.6 - the legacy parallel_tests merging
+    # path stays authoritative until the RSpec rework lands.
+    def v2_engine?
+      return false if parallel_tests?
+
+      !engine.nil?
     end
 
     def coverage_reporter
@@ -168,9 +192,21 @@ module RSpecTracer
       setup_coverage
       setup_trace_point
 
-      @runner = RSpecTracer::Runner.new
-      @coverage_reporter = RSpecTracer::CoverageReporter.new
-      @report_writer = RSpecTracer::ReportWriter.new(RSpecTracer.cache_path, @runner.reporter)
+      if RSpecTracer.use_v2_tracker && !parallel_tests?
+        # v2 bridge path: the Engine replaces Runner at the filter
+        # surface and owns cache write via JsonBackend. Legacy
+        # @coverage_reporter + @report_writer stay in the hot path
+        # so coverage.json + HTML reports are still produced
+        # identically - M3.6 deliberately does NOT re-implement the
+        # report surface.
+        @engine = RSpecTracer::Engine.new(configuration: RSpecTracer)
+        @engine.setup
+        @coverage_reporter = RSpecTracer::CoverageReporter.new
+      else
+        @runner = RSpecTracer::Runner.new
+        @coverage_reporter = RSpecTracer::CoverageReporter.new
+        @report_writer = RSpecTracer::ReportWriter.new(RSpecTracer.cache_path, @runner.reporter)
+      end
     end
 
     def parallel_tests_setup
@@ -241,6 +277,8 @@ module RSpecTracer
     def run_exit_tasks
       if RSpecTracer.no_examples
         RSpecTracer.logger.info 'Skipped reports generation since all examples were filtered out'
+      elsif v2_engine?
+        run_v2_finalize
       else
         generate_reports
       end
@@ -248,6 +286,24 @@ module RSpecTracer
       simplecov? ? run_simplecov_exit_task : run_coverage_exit_task
 
       run_parallel_tests_exit_tasks
+    end
+
+    # M3.6 v2 finalize path: the Engine owns the 12-file JSON cache
+    # write via Storage::JsonBackend; CoverageReporter remains
+    # responsible for the legacy coverage.json surface. HTML /
+    # report_writer rework lives in Phase 6.
+    def run_v2_finalize
+      starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      coverage_reporter.generate_final_examples_coverage
+      skipped_ids = engine.registry.ids_with_status(:skipped)
+      coverage_reporter.merge_coverage(engine.merge_skipped_coverage(skipped_ids))
+      engine.finalize
+
+      ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      elapsed = RSpecTracer::TimeFormatter.format_time(ending - starting)
+
+      RSpecTracer.logger.debug "RSpec tracer (v2) persisted cache (took #{elapsed})"
     end
 
     def generate_reports
@@ -431,3 +487,4 @@ module RSpecTracer
     end
   end
 end
+# rubocop:enable Metrics/ModuleLength, Metrics/ClassLength

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -192,6 +192,26 @@ module RSpecTracer
                             end
     end
 
+    # Opt in to the v2 core-engine pipeline (the in-tree
+    # Tracker + Storage + Filter stack). Default `false` keeps every
+    # existing run on the legacy Runner + CoverageReporter path, so
+    # users upgrading to 2.0.pre don't change behavior silently.
+    #
+    # Setting `true` activates the new engine for the RSpec process.
+    # The flag is a temporary bridge - removed once the RSpec
+    # integration rework lands and the legacy runner retires.
+    # Honors `RSPEC_TRACER_USE_V2_TRACKER` for CI that needs to flip
+    # the flag without editing `.rspec-tracer`.
+    def use_v2_tracker(new_flag = nil)
+      return @use_v2_tracker if defined?(@use_v2_tracker) && new_flag.nil?
+
+      @use_v2_tracker = if ENV.key?('RSPEC_TRACER_USE_V2_TRACKER')
+                          ENV['RSPEC_TRACER_USE_V2_TRACKER'] == 'true'
+                        else
+                          new_flag == true
+                        end
+    end
+
     # M3.7 transitive-load attribution (closes the constants blind
     # spot). Default `true` - the tracker observes files loaded during
     # the process and attributes them as transitive deps of every

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -1,0 +1,516 @@
+# frozen_string_literal: true
+
+require 'coverage'
+require 'digest'
+require 'json'
+require 'set'
+
+require_relative 'tracker/coverage_adapter'
+require_relative 'tracker/declared_globs'
+require_relative 'tracker/dependency_graph'
+require_relative 'tracker/example_registry'
+require_relative 'tracker/filter'
+require_relative 'tracker/input'
+require_relative 'tracker/io_hooks'
+require_relative 'tracker/loaded_files_tracker'
+require_relative 'tracker/new_file_detector'
+require_relative 'tracker/whole_suite_invalidators'
+require_relative 'storage/json_backend'
+require_relative 'storage/schema'
+require_relative 'storage/snapshot'
+
+module RSpecTracer
+  # Top-level coordinator for the v2 core engine. Wires
+  # CoverageAdapter + IOHooks + DeclaredGlobs + NewFileDetector +
+  # WholeSuiteInvalidators + LoadedFilesTracker + ExampleRegistry +
+  # DependencyGraph + Storage into a single pipeline that replaces
+  # the legacy Runner + CoverageReporter triad on an opt-in basis.
+  #
+  # Named `Engine` rather than `Tracker` because the `Tracker`
+  # namespace is already taken by the sub-module that houses the
+  # leaf observers (`Tracker::CoverageAdapter`, `Tracker::IOHooks`,
+  # etc.). `RSpecTracer.engine` is the public accessor the RSpec
+  # hooks dispatch through when `use_v2_tracker` is enabled.
+  #
+  # Lifecycle (driven by RSpec hooks in `lib/rspec_tracer.rb`):
+  #
+  #   engine = Engine.new(configuration: RSpecTracer)
+  #   engine.setup                       # install hooks, load cache,
+  #                                      # compute filter decisions
+  #   engine.run_example?(id)            # per-example filter (from cache)
+  #   engine.register_example(example)   # record metadata + duplicates
+  #   engine.example_started             # peek baseline + open bucket
+  #     # ... example body runs, IOHooks record into bucket ...
+  #   engine.example_finished(id)        # diff coverage, attribute, close
+  #   engine.on_example_{passed,failed,pending,skipped}(id, result)
+  #   engine.finalize                    # persist snapshot + coverage
+  #
+  # Coverage totals parity (AC1 from M3.6): the engine owns a
+  # per-example coverage delta map with identical semantics to the
+  # legacy CoverageReporter - diff between start-of-example and
+  # end-of-example ::Coverage.peek_result, storing
+  # {file_path => {line_number => delta}}. `merge_skipped_coverage`
+  # replays 1.x's algorithm verbatim so a parity test has something
+  # mechanical to compare.
+  #
+  # Cache parity: `finalize` builds a Snapshot with file-name-keyed
+  # dependency / reverse_dependency / all_files maps (matching the
+  # 1.x on-disk convention - root-stripped file names with a leading
+  # "/") and hands it to Storage::JsonBackend. The schema bump to 3
+  # from M3.7 adds `boot_set`; everything else mirrors the 1.x
+  # cache layout byte-for-byte.
+  # The coordinator's surface is intentionally wide - it mirrors the
+  # full legacy Runner + CoverageReporter + Reporter triad so the
+  # bridge in `lib/rspec_tracer.rb` can swap engines without widening
+  # the RSpec hook's conditional footprint. Expected to shrink once
+  # Phase 5 retires the legacy path.
+  # rubocop:disable Metrics/ClassLength
+  class Engine
+    EXAMPLE_RUN_REASON = {
+      explicit_run: 'Explicit run',
+      no_cache: 'No cache',
+      interrupted: 'Interrupted previously',
+      flaky_example: 'Flaky example',
+      failed_example: 'Failed previously',
+      pending_example: 'Pending previously',
+      files_changed: 'Files changed',
+      whole_suite_invalidator: 'Whole-suite invalidator changed'
+    }.freeze
+
+    # Map from Filter#select reasons to the legacy-shaped strings
+    # users see in test output ("foo (Files changed)"). Keeps the
+    # user surface unchanged under v2.
+    FILTER_REASON_STRINGS = {
+      whole_suite_invalidator: EXAMPLE_RUN_REASON[:whole_suite_invalidator],
+      interrupted: EXAMPLE_RUN_REASON[:interrupted],
+      flaky_example: EXAMPLE_RUN_REASON[:flaky_example],
+      failed_example: EXAMPLE_RUN_REASON[:failed_example],
+      pending_example: EXAMPLE_RUN_REASON[:pending_example],
+      no_cache: EXAMPLE_RUN_REASON[:no_cache],
+      files_changed: EXAMPLE_RUN_REASON[:files_changed]
+    }.freeze
+
+    attr_reader :registry, :graph, :loaded_files_tracker, :coverage_adapter,
+                :declared_globs, :whole_suite_invalidators, :new_file_detector,
+                :storage_backend, :all_examples, :duplicate_examples,
+                :examples_coverage, :all_files
+
+    def initialize(configuration: RSpecTracer)
+      @configuration = configuration
+      @filtered_examples = {}
+      @all_examples = {}
+      @duplicate_examples = {}
+      @examples_coverage = {}
+      @all_files = {}
+      @previous_snapshot = nil
+      @run_id = nil
+      @before_peek = nil
+    end
+
+    def setup
+      @configuration.freeze_declared_globs!
+
+      build_observers
+      install_io_hooks
+      ensure_coverage_started
+
+      @loaded_files_tracker.capture_boot_set!
+      @declared_globs.walk
+
+      @previous_snapshot = load_previous_snapshot
+      compute_filter_decisions
+      self
+    end
+
+    # --- filter-phase surface (mirrors legacy Runner) --------------
+
+    def run_example?(example_id)
+      return true if @configuration.run_all_examples
+
+      previously_seen = @previous_snapshot&.all_examples&.key?(example_id)
+      !previously_seen || @filtered_examples.key?(example_id)
+    end
+
+    def run_example_reason(example_id)
+      return EXAMPLE_RUN_REASON[:explicit_run] if @configuration.run_all_examples
+
+      @filtered_examples[example_id] || EXAMPLE_RUN_REASON[:no_cache]
+    end
+
+    def register_example(example)
+      example_id = example[:example_id]
+      @registry.register(example_id, metadata: example, identity_hash: example_id)
+      @all_examples[example_id] ||= example
+      @duplicate_examples[example_id] ||= []
+      @duplicate_examples[example_id] << example
+      self
+    end
+
+    def deregister_duplicate_examples
+      @duplicate_examples.select! { |_, entries| entries.count > 1 }
+      return if @duplicate_examples.empty?
+
+      @all_examples.reject! { |id, _| @duplicate_examples.key?(id) }
+      self
+    end
+
+    # --- per-example surface --------------------------------------
+
+    def example_started
+      @before_peek = @coverage_adapter.peek
+      @current_bucket = {}
+      RSpecTracer::Tracker::IOHooks.set_bucket(@current_bucket)
+      self
+    end
+
+    def example_finished(example_id)
+      after_peek = @coverage_adapter.peek
+      record_coverage_delta(example_id, @before_peek, after_peek)
+      io_inputs = @current_bucket.values
+      RSpecTracer::Tracker::IOHooks.clear_bucket
+
+      transitive_inputs = @loaded_files_tracker.loaded_set_inputs |
+        @loaded_files_tracker.stop_example(example_id)
+      coverage_inputs = @coverage_adapter.compute_diff(@before_peek, after_peek)
+      attribute_to_example(example_id, coverage_inputs | transitive_inputs | io_inputs.to_set)
+
+      @before_peek = nil
+      @current_bucket = nil
+      self
+    end
+
+    def on_example_skipped(example_id)
+      @registry.register(example_id) unless @registry.registered?(example_id)
+      @registry.update_status(example_id, :skipped)
+      self
+    end
+
+    def on_example_passed(example_id, result)
+      return if @duplicate_examples[example_id]&.count.to_i > 1
+
+      @registry.update_status(example_id, :passed)
+      record_execution_result(example_id, result)
+      self
+    end
+
+    def on_example_failed(example_id, result)
+      return if @duplicate_examples[example_id]&.count.to_i > 1
+
+      @registry.update_status(example_id, :failed)
+      record_execution_result(example_id, result)
+      self
+    end
+
+    def on_example_pending(example_id, result)
+      return if @duplicate_examples[example_id]&.count.to_i > 1
+
+      @registry.update_status(example_id, :pending)
+      record_execution_result(example_id, result)
+      self
+    end
+
+    # --- finalize ------------------------------------------------
+
+    def finalize
+      @registry.all_example_ids.each do |id|
+        next if @registry.status_of(id)
+
+        @registry.update_status(id, :interrupted)
+      end
+
+      snapshot = build_snapshot
+      @storage_backend.save_graph(snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      snapshot
+    end
+
+    # Replays the legacy CoverageReporter algorithm: for every
+    # previously-skipped example id, accumulate per-line coverage
+    # strengths from the previous run's per-example coverage map
+    # into the missed_coverage return value. Deleted files / missing
+    # entries are skipped silently.
+    #
+    # Returns Hash[file_path => Hash[line_number => cumulative_strength]].
+    def merge_skipped_coverage(skipped_ids, previous_examples_coverage = nil)
+      source = previous_examples_coverage || @previous_snapshot&.examples_coverage || {}
+      missed = Hash.new { |h, f| h[f] = Hash.new(0) }
+
+      skipped_ids.each do |example_id|
+        example_coverage = source[example_id]
+        next if example_coverage.nil?
+
+        example_coverage.each do |file_path, line_coverage|
+          accumulate_line_coverage(missed[file_path], line_coverage)
+        end
+      end
+
+      missed
+    end
+
+    # --- accessors used by specs ---------------------------------
+
+    def filtered_example_ids
+      @filtered_examples.keys
+    end
+
+    def previous_snapshot_loaded?
+      !@previous_snapshot.nil?
+    end
+
+    private
+
+    def build_observers
+      @registry = RSpecTracer::Tracker::ExampleRegistry.new
+      @graph = RSpecTracer::Tracker::DependencyGraph.new
+      @coverage_adapter = RSpecTracer::Tracker::CoverageAdapter.new(
+        root: @configuration.root, filters: @configuration.filters
+      )
+      @declared_globs = RSpecTracer::Tracker::DeclaredGlobs.new(
+        root: @configuration.root, globs: @configuration.declared_globs
+      )
+      @whole_suite_invalidators = RSpecTracer::Tracker::WholeSuiteInvalidators.new(
+        root: @configuration.root
+      )
+      @new_file_detector = RSpecTracer::Tracker::NewFileDetector.new(
+        root: @configuration.root, declared_globs: @configuration.declared_globs
+      )
+      @loaded_files_tracker = RSpecTracer::Tracker::LoadedFilesTracker.new(
+        root: @configuration.root, enabled: @configuration.transitive_load_tracking
+      )
+      @storage_backend = RSpecTracer::Storage::JsonBackend.new(
+        cache_path: @configuration.cache_path, logger: @configuration.logger
+      )
+    end
+
+    def install_io_hooks
+      declared = @declared_globs
+      RSpecTracer::Tracker::IOHooks.install(
+        root: @configuration.root,
+        filter: ->(path) { !declared.covers?(path) }
+      )
+    end
+
+    # Delegate to the legacy ::Coverage bootstrap if SimpleCov isn't
+    # already running. Matches RSpecTracer.setup_coverage behavior so
+    # v2 and legacy agree on when to call ::Coverage.start.
+    def ensure_coverage_started
+      return if defined?(SimpleCov) && SimpleCov.running
+      return if ::Coverage.respond_to?(:running?) && ::Coverage.running?
+
+      ::Coverage.start
+    rescue RuntimeError
+      # ::Coverage.start raises if already started on some Rubies
+      # without a running? predicate; safe to ignore.
+      nil
+    end
+
+    def load_previous_snapshot
+      @storage_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+    end
+
+    def compute_filter_decisions
+      prev = @previous_snapshot
+      return if prev.nil?
+
+      seed_registry_from_previous(prev)
+      change_set = compute_change_set(prev)
+      whole_suite = whole_suite_changed?(prev)
+
+      result = RSpecTracer::Tracker::Filter.select(
+        graph: graph_from_previous(prev),
+        change_set: change_set,
+        registry: @registry,
+        whole_suite_invalidated: whole_suite,
+        all_example_ids: prev.all_examples.keys.to_set
+      )
+      @filtered_examples = result.transform_values { |reason| FILTER_REASON_STRINGS.fetch(reason) }
+    end
+
+    SEED_STATUS_ORDER = %i[interrupted flaky failed pending].freeze
+    private_constant :SEED_STATUS_ORDER
+
+    def seed_registry_from_previous(prev)
+      SEED_STATUS_ORDER.each do |status|
+        ids = prev.send(:"#{status}_examples")
+        ids.each { |id| seed_registry_entry(id, status, prev.all_examples[id] || {}) }
+      end
+    end
+
+    def seed_registry_entry(id, status, metadata)
+      return if @registry.registered?(id)
+
+      @registry.register(id, metadata: metadata)
+      @registry.update_status(id, status)
+    end
+
+    # Rebuild a DependencyGraph from the previous Snapshot so Filter
+    # can intersect its cached dependency sets with the change_set.
+    def graph_from_previous(prev)
+      graph = RSpecTracer::Tracker::DependencyGraph.new
+      prev.dependency.each { |id, paths| graph.register_example(id, paths) }
+      graph
+    end
+
+    def compute_change_set(prev)
+      changed = Set.new
+      prev.all_files.each_value do |file_meta|
+        file_name = symbol_or_string(file_meta, :file_name)
+        cached_digest = symbol_or_string(file_meta, :digest)
+        next if file_name.nil? || cached_digest.nil?
+
+        current_digest = current_file_digest(file_name)
+        changed << file_name if current_digest.nil? || current_digest != cached_digest
+      end
+
+      new_files = @new_file_detector.new_files(
+        known_paths: prev.all_files.keys.to_set.to_set { |k| absolute_path(k) }
+      )
+      new_files.each { |input| changed << path_to_file_name(input.path) }
+      changed
+    end
+
+    def whole_suite_changed?(prev)
+      wsi_prev = prev.all_files.key?('__wsi__') ? prev.all_files['__wsi__'] : nil
+      @whole_suite_invalidators.invalidated?(wsi_prev) ||
+        @loaded_files_tracker.boot_set_invalidated?(prev.boot_set)
+    end
+
+    def current_file_digest(file_name)
+      path = absolute_path(file_name)
+      return nil unless File.file?(path)
+
+      Digest::SHA256.file(path).hexdigest
+    rescue SystemCallError
+      nil
+    end
+
+    def record_coverage_delta(example_id, before, after)
+      entry = @examples_coverage[example_id] ||= {}
+
+      (before.keys | after.keys).each do |path|
+        b_lines = before[path]
+        a_lines = after[path]
+        next if b_lines == a_lines
+
+        file_entry = entry[path] ||= {}
+        accumulate_delta(file_entry, b_lines, a_lines)
+      end
+    end
+
+    def accumulate_delta(file_entry, before_lines, after_lines)
+      length = (after_lines || before_lines || []).length
+      length.times do |i|
+        delta = line_delta(before_lines && before_lines[i], after_lines && after_lines[i])
+        file_entry[i] = delta if delta
+      end
+    end
+
+    # Returns the positive coverage delta for one line, or nil if the
+    # line isn't a delta worth recording (non-executable, identical,
+    # or a stale-going-backward entry).
+    def line_delta(before, after)
+      return nil if after.nil? || before == after
+
+      delta = after - (before || 0)
+      delta.positive? ? delta : nil
+    end
+
+    def accumulate_line_coverage(accumulator, line_coverage)
+      line_coverage.each do |line_key, strength|
+        index = line_key.to_i
+        accumulator[index] += strength || 0
+      end
+    end
+
+    def attribute_to_example(example_id, inputs)
+      paths = Set.new
+      inputs.each do |input|
+        next if @configuration.filters.any? { |f| f.match?(file_name: path_to_file_name(input.path)) }
+
+        paths << input.path
+        @all_files[input.path] = {
+          file_name: path_to_file_name(input.path),
+          file_path: input.path,
+          digest: input.digest
+        }
+      end
+      @graph.register_example(example_id, paths)
+    end
+
+    def record_execution_result(example_id, result)
+      return unless @all_examples.key?(example_id)
+
+      @all_examples[example_id][:execution_result] = formatted_execution_result(result)
+    end
+
+    def formatted_execution_result(result)
+      {
+        started_at: result.started_at.utc,
+        finished_at: result.finished_at.utc,
+        run_time: result.run_time,
+        status: result.status.to_s
+      }
+    end
+
+    def build_snapshot
+      run_id = Digest::MD5.hexdigest(@all_examples.keys.sort.to_json)
+      @run_id = run_id
+
+      RSpecTracer::Storage::Snapshot.new(
+        schema_version: RSpecTracer::Storage::Schema::CURRENT,
+        run_id: run_id,
+        all_examples: @all_examples,
+        duplicate_examples: duplicates_for_snapshot,
+        interrupted_examples: @registry.ids_with_status(:interrupted),
+        flaky_examples: @registry.ids_with_status(:flaky),
+        failed_examples: @registry.ids_with_status(:failed),
+        pending_examples: @registry.ids_with_status(:pending),
+        skipped_examples: @registry.ids_with_status(:skipped),
+        all_files: all_files_by_name,
+        dependency: dependency_by_name,
+        reverse_dependency: reverse_dependency_by_name,
+        examples_coverage: @examples_coverage,
+        boot_set: @loaded_files_tracker.boot_set_digest_snapshot
+      )
+    end
+
+    def duplicates_for_snapshot
+      @duplicate_examples.select { |_, entries| entries.count > 1 }
+    end
+
+    def all_files_by_name
+      @all_files.each_with_object({}) do |(_, meta), acc|
+        acc[meta[:file_name]] = meta
+      end
+    end
+
+    def dependency_by_name
+      @graph.dependency_hash.transform_values do |paths|
+        paths.to_set { |p| path_to_file_name(p) }
+      end
+    end
+
+    def reverse_dependency_by_name
+      @graph.reverse_dependency_hash.each_with_object({}) do |(path, ids), acc|
+        acc[path_to_file_name(path)] = ids.to_set
+      end
+    end
+
+    def absolute_path(file_name)
+      File.expand_path(file_name.to_s.sub(%r{^/}, ''), @configuration.root)
+    end
+
+    def path_to_file_name(abs_path)
+      root_prefix = "#{@configuration.root}/"
+      return abs_path unless abs_path.start_with?(root_prefix)
+
+      "/#{abs_path[root_prefix.length..]}"
+    end
+
+    def symbol_or_string(hash, key)
+      return hash[key] if hash.key?(key)
+
+      hash[key.to_s]
+    end
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/rspec_tracer/rspec_reporter.rb
+++ b/lib/rspec_tracer/rspec_reporter.rb
@@ -4,14 +4,22 @@ module RSpecTracer
   module RSpecReporter
     def example_started(example)
       RSpecTracer.coverage_reporter.record_coverage
-      RSpecTracer.start_example_trace
+      if RSpecTracer.v2_engine?
+        RSpecTracer.engine.example_started
+      else
+        RSpecTracer.start_example_trace
+      end
 
       super
     end
 
     def example_finished(example)
       example_id = example.metadata[:rspec_tracer_example_id]
-      RSpecTracer.stop_example_trace(example_id)
+      if RSpecTracer.v2_engine?
+        RSpecTracer.engine.example_finished(example_id)
+      else
+        RSpecTracer.stop_example_trace(example_id)
+      end
       RSpecTracer.coverage_reporter.compute_diff(example_id)
 
       super
@@ -19,23 +27,29 @@ module RSpecTracer
 
     def example_passed(example)
       example_id = example.metadata[:rspec_tracer_example_id]
-      RSpecTracer.runner.on_example_passed(example_id, example.execution_result)
+      _tracer_status_sink.on_example_passed(example_id, example.execution_result)
 
       super
     end
 
     def example_failed(example)
       example_id = example.metadata[:rspec_tracer_example_id]
-      RSpecTracer.runner.on_example_failed(example_id, example.execution_result)
+      _tracer_status_sink.on_example_failed(example_id, example.execution_result)
 
       super
     end
 
     def example_pending(example)
       example_id = example.metadata[:rspec_tracer_example_id]
-      RSpecTracer.runner.on_example_pending(example_id, example.execution_result)
+      _tracer_status_sink.on_example_pending(example_id, example.execution_result)
 
       super
+    end
+
+    private
+
+    def _tracer_status_sink
+      RSpecTracer.v2_engine? ? RSpecTracer.engine : RSpecTracer.runner
     end
   end
 end

--- a/lib/rspec_tracer/rspec_runner.rb
+++ b/lib/rspec_tracer/rspec_runner.rb
@@ -45,12 +45,31 @@ module RSpecTracer
     end
 
     def _duplicate_examples?
-      return false if RSpecTracer.runner.reporter.duplicate_examples.empty?
+      duplicates = _tracer_duplicate_examples
+      return false if duplicates.empty?
 
-      RSpecTracer.report_writer.print_duplicate_examples
+      _tracer_print_duplicate_examples(duplicates)
 
       RSpecTracer.running = true
       RSpecTracer.duplicate_examples = RSpecTracer.fail_on_duplicates
+    end
+
+    def _tracer_duplicate_examples
+      return RSpecTracer.engine.duplicate_examples if RSpecTracer.v2_engine?
+
+      RSpecTracer.runner.reporter.duplicate_examples
+    end
+
+    def _tracer_print_duplicate_examples(duplicates)
+      return RSpecTracer.report_writer.print_duplicate_examples if RSpecTracer.report_writer
+
+      # v2 mode has no legacy report_writer; surface the duplicates
+      # through the logger so the signal isn't lost.
+      total = duplicates.sum { |_, entries| entries.count }
+      hashes = duplicates.size
+      RSpecTracer.logger.error(
+        "RSpec tracer detected #{total} duplicate example(s) across #{hashes} identity hash(es)"
+      )
     end
   end
 end

--- a/lib/rspec_tracer/tracker/io_hooks.rb
+++ b/lib/rspec_tracer/tracker/io_hooks.rb
@@ -105,6 +105,22 @@ module RSpecTracer
           end
         end
 
+        # Non-block lifecycle for integration with RSpec hooks (which
+        # can't wrap the example body in a Ruby block). The Tracker
+        # coordinator calls set_bucket at example_started time and
+        # clear_bucket at example_finished time. Unlike with_bucket,
+        # these do not save/restore a prior bucket - the coordinator
+        # owns the Thread.current slot for the span of an example.
+        # rubocop:disable Naming/AccessorMethodName
+        def set_bucket(bucket)
+          Thread.current[BUCKET_KEY] = bucket
+        end
+        # rubocop:enable Naming/AccessorMethodName
+
+        def clear_bucket
+          Thread.current[BUCKET_KEY] = nil
+        end
+
         # Record a :data input (File/IO/YAML/JSON hooks). The
         # allow-predicate is the coordinator's default extension +
         # filter combo.

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -236,6 +236,51 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
+  describe '#use_v2_tracker' do
+    it 'defaults to false when never configured' do
+      expect(config.use_v2_tracker).to be(false)
+    end
+
+    it 'returns the last value set via the DSL' do
+      config.use_v2_tracker(true)
+
+      expect(config.use_v2_tracker).to be(true)
+    end
+
+    it 'coerces any non-true value to false' do
+      config.use_v2_tracker('yes')
+
+      expect(config.use_v2_tracker).to be(false)
+    end
+
+    it 'honors RSPEC_TRACER_USE_V2_TRACKER=true over the DSL' do
+      stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_USE_V2_TRACKER' => 'true'))
+
+      expect(config.use_v2_tracker(false)).to be(true)
+    end
+
+    it 'treats any non-"true" ENV value as false' do
+      stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_USE_V2_TRACKER' => '1'))
+
+      expect(config.use_v2_tracker(true)).to be(false)
+    end
+
+    it 'memoizes across no-arg reads' do
+      config.use_v2_tracker(true)
+      first = config.use_v2_tracker
+      second = config.use_v2_tracker
+
+      expect([first, second]).to eq([true, true])
+    end
+
+    it 'keeps the previous value when re-called with nil' do
+      config.use_v2_tracker(true)
+      config.use_v2_tracker(nil)
+
+      expect(config.use_v2_tracker).to be(true)
+    end
+  end
+
   describe '#transitive_load_tracking' do
     it 'defaults to true when never configured' do
       expect(config.transitive_load_tracking).to be(true)

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -1,0 +1,346 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'set'
+require 'tmpdir'
+require 'rspec_tracer/engine'
+
+# The Engine class is the v2 coordinator. Unit tests drive it with a
+# stubbed configuration so the subject doesn't depend on the global
+# RSpecTracer module's state. Integration coverage (real RSpec
+# fixture, subprocess) lives at spec/integration/ruby_app_v2_tracker_spec.rb.
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+RSpec.describe RSpecTracer::Engine do
+  let(:tmp_base) { Dir.mktmpdir }
+  let(:root) { File.join(tmp_base, 'project').tap { |p| FileUtils.mkdir_p(p) } }
+  let(:cache_path) { File.join(tmp_base, 'cache') }
+  let(:logger) { instance_double(RSpecTracer::Logger, debug: nil, info: nil, warn: nil, error: nil) }
+  let(:configuration) { stub_configuration }
+
+  before do
+    write_project_file('lib/a.rb', "module A; VALUE = 1; end\n")
+    write_project_file('lib/b.rb', "require_relative 'a'\nUSER = A::VALUE\n")
+  end
+
+  after do
+    RSpecTracer::Tracker::IOHooks.uninstall
+    RSpecTracer::Tracker::IOHooks.clear_bucket
+    FileUtils.rm_rf(tmp_base) if tmp_base
+  end
+
+  def write_project_file(rel, contents = "x\n")
+    path = File.join(root, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, contents)
+    path
+  end
+
+  def stub_configuration(overrides = {})
+    defaults = {
+      root: root, cache_path: cache_path, logger: logger,
+      filters: [], declared_globs: [],
+      run_all_examples: false, transitive_load_tracking: false
+    }
+    double(**defaults, **overrides).tap do |config|
+      allow(config).to receive(:freeze_declared_globs!)
+    end
+  end
+
+  def build_tracker(configuration_override = configuration)
+    described_class.new(configuration: configuration_override)
+  end
+
+  def build_example(example_id, file_name = '/spec/thing_spec.rb', line = 1)
+    {
+      example_id: example_id,
+      file_name: file_name,
+      line_number: line,
+      rerun_file_name: file_name,
+      rerun_line_number: line,
+      full_description: "Example #{example_id}",
+      description: "Example #{example_id}",
+      example_group: 'Thing',
+      shared_group: []
+    }
+  end
+
+  def build_execution_result(status:, run_time: 0.01)
+    now = Time.now
+    double(
+      started_at: now, finished_at: now + run_time, run_time: run_time, status: status
+    )
+  end
+
+  describe '#initialize' do
+    it 'holds nothing until setup is called' do
+      tracker = build_tracker
+
+      expect(tracker.registry).to be_nil
+    end
+
+    it 'reports previous_snapshot_loaded? as false before setup' do
+      tracker = build_tracker
+
+      expect(tracker.previous_snapshot_loaded?).to be(false)
+    end
+  end
+
+  describe '#setup' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'freezes declared globs on the configuration' do
+      tracker
+
+      expect(configuration).to have_received(:freeze_declared_globs!)
+    end
+
+    it 'builds all seven observer instances' do
+      expect([
+        tracker.registry, tracker.graph, tracker.loaded_files_tracker,
+        tracker.coverage_adapter, tracker.declared_globs,
+        tracker.whole_suite_invalidators, tracker.new_file_detector
+      ]).to all(be_a(Object))
+    end
+
+    it 'constructs a JSON storage backend pointed at cache_path' do
+      expect(tracker.storage_backend).to be_a(RSpecTracer::Storage::JsonBackend)
+    end
+
+    it 'installs IOHooks' do
+      tracker
+
+      expect(RSpecTracer::Tracker::IOHooks.installed?).to be(true)
+    end
+
+    it 'captures the boot set via the LoadedFilesTracker' do
+      expect(tracker.loaded_files_tracker.boot_set).not_to be_nil
+    end
+
+    it 'returns self' do
+      tracker_instance = build_tracker
+      expect(tracker_instance.setup).to be(tracker_instance)
+    end
+  end
+
+  describe '#run_example? / #run_example_reason' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'runs every example when run_all_examples is true' do
+      tracker = build_tracker(stub_configuration(run_all_examples: true)).tap(&:setup)
+
+      expect(tracker.run_example?('new_id')).to be(true)
+      expect(tracker.run_example_reason('new_id')).to eq('Explicit run')
+    end
+
+    it 'runs an example not present in the previous snapshot (no cache case)' do
+      expect(tracker.run_example?('brand_new_id')).to be(true)
+    end
+
+    it 'reports no_cache as the reason for previously-unseen ids' do
+      expect(tracker.run_example_reason('brand_new_id')).to eq('No cache')
+    end
+  end
+
+  describe '#register_example / #deregister_duplicate_examples' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'adds an example to all_examples on first register' do
+      tracker.register_example(build_example('ex1'))
+
+      expect(tracker.all_examples).to have_key('ex1')
+    end
+
+    it 'deregister drops the singletons and keeps only real duplicates' do
+      tracker.register_example(build_example('ex1'))
+      tracker.register_example(build_example('ex2', '/spec/other_spec.rb'))
+      tracker.register_example(build_example('ex2', '/spec/dup_spec.rb'))
+
+      tracker.deregister_duplicate_examples
+
+      expect(tracker.duplicate_examples.keys).to eq(['ex2'])
+    end
+
+    it 'removes duplicated ids from all_examples after deregister' do
+      tracker.register_example(build_example('ex2'))
+      tracker.register_example(build_example('ex2'))
+      tracker.deregister_duplicate_examples
+
+      expect(tracker.all_examples).not_to have_key('ex2')
+    end
+  end
+
+  describe 'per-example lifecycle' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'example_started + example_finished record a coverage delta entry' do
+      a_path = File.join(root, 'lib/a.rb')
+      peeks = [
+        { a_path => [1, 0, 1] },
+        { a_path => [1, 1, 1] }
+      ]
+      allow(tracker.coverage_adapter).to receive(:peek).and_return(*peeks)
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+
+      expect(tracker.examples_coverage['ex1']).to have_key(a_path)
+    end
+
+    it 'example_finished installs a graph entry for the example' do
+      a_path = File.join(root, 'lib/a.rb')
+      peeks = [{ a_path => [1, 0, 1] }, { a_path => [1, 1, 1] }]
+      allow(tracker.coverage_adapter).to receive(:peek).and_return(*peeks)
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+
+      expect(tracker.graph.paths_for('ex1')).to include(a_path)
+    end
+
+    it 'clears the IOHooks bucket after example_finished' do
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+
+      expect(RSpecTracer::Tracker::IOHooks.current_bucket).to be_nil
+    end
+
+    it 'on_example_passed records the execution result on the metadata hash' do
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+      tracker.on_example_passed('ex1', build_execution_result(status: :passed))
+
+      expect(tracker.all_examples['ex1'][:execution_result][:status]).to eq('passed')
+    end
+
+    it 'on_example_failed updates registry status to :failed' do
+      tracker.register_example(build_example('ex1'))
+      tracker.on_example_failed('ex1', build_execution_result(status: :failed))
+
+      expect(tracker.registry.status_of('ex1')).to eq(:failed)
+    end
+
+    it 'on_example_pending updates registry status to :pending' do
+      tracker.register_example(build_example('ex1'))
+      tracker.on_example_pending('ex1', build_execution_result(status: :pending))
+
+      expect(tracker.registry.status_of('ex1')).to eq(:pending)
+    end
+
+    it 'on_example_skipped updates registry status without a prior register' do
+      tracker.on_example_skipped('stale_id')
+
+      expect(tracker.registry.status_of('stale_id')).to eq(:skipped)
+    end
+
+    it 'on_example_passed is a no-op for duplicate ids' do
+      tracker.register_example(build_example('dup'))
+      tracker.register_example(build_example('dup'))
+
+      tracker.on_example_passed('dup', build_execution_result(status: :passed))
+
+      expect(tracker.registry.status_of('dup')).to be_nil
+    end
+  end
+
+  describe '#finalize' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'writes a v2 cache under cache_path' do
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+      tracker.on_example_passed('ex1', build_execution_result(status: :passed))
+
+      tracker.finalize
+
+      expect(File).to exist(File.join(cache_path, 'last_run.json'))
+    end
+
+    it 'stamps the cache with schema_version 3' do
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+      tracker.on_example_passed('ex1', build_execution_result(status: :passed))
+
+      tracker.finalize
+
+      manifest = JSON.parse(File.read(File.join(cache_path, 'last_run.json')))
+      expect(manifest['schema_version']).to eq(3)
+    end
+
+    it 'flags ids without a terminal status as :interrupted at finalize' do
+      tracker.register_example(build_example('ex1'))
+
+      snapshot = tracker.finalize
+
+      expect(snapshot.interrupted_examples).to include('ex1')
+    end
+
+    it 'persists the boot_set digest snapshot alongside the run' do
+      snapshot = tracker.finalize
+
+      expect(snapshot.boot_set).to be_a(Hash)
+    end
+
+    it 'returns the Snapshot it persisted' do
+      expect(tracker.finalize).to be_a(RSpecTracer::Storage::Snapshot)
+    end
+  end
+
+  describe '#merge_skipped_coverage' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'returns {} when no previous coverage is available' do
+      expect(tracker.merge_skipped_coverage(%w[ex1])).to eq({})
+    end
+
+    it 'accumulates per-line strengths from previous coverage for skipped ids' do
+      previous = {
+        'ex1' => { '/lib/a.rb' => { '0' => 1, '2' => 3 } },
+        'ex2' => { '/lib/a.rb' => { '0' => 4 } }
+      }
+      result = tracker.merge_skipped_coverage(%w[ex1 ex2], previous)
+
+      expect(result['/lib/a.rb']).to eq(0 => 5, 2 => 3)
+    end
+
+    it 'skips entries for ids not present in the source map' do
+      result = tracker.merge_skipped_coverage(%w[missing], 'ex1' => { '/lib/a.rb' => { '0' => 1 } })
+
+      expect(result).to eq({})
+    end
+
+    it 'treats nil strengths as zero (legacy parity for non-executable lines)' do
+      previous = { 'ex1' => { '/lib/a.rb' => { '0' => nil, '1' => 2 } } }
+      result = tracker.merge_skipped_coverage(%w[ex1], previous)
+
+      expect(result['/lib/a.rb']).to eq(0 => 0, 1 => 2)
+    end
+
+    it 'falls back to the loaded previous snapshot when no explicit source is given' do
+      # Simulate a prior run by saving a snapshot the tracker can load.
+      prior = build_tracker
+      prior.setup
+      prior.register_example(build_example('ex1'))
+      allow(prior.coverage_adapter).to receive(:peek).and_return({}, {})
+      prior.example_started
+      prior.example_finished('ex1')
+      prior.on_example_passed('ex1', build_execution_result(status: :passed))
+      prior.finalize
+
+      # New tracker picks up the previous snapshot and merges.
+      RSpecTracer::Tracker::IOHooks.uninstall
+      next_run = build_tracker.tap(&:setup)
+
+      expect { next_run.merge_skipped_coverage(%w[ex1]) }.not_to raise_error
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/integration/dogfood_spec.rb
+++ b/spec/integration/dogfood_spec.rb
@@ -19,7 +19,7 @@ require 'open3'
 # work, not several examples. Splitting to satisfy rspec-rubocop metric
 # cops would scatter the sequential narrative across unrelated `it`
 # blocks without clarifying anything.
-# rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/MultipleExpectations
+# rubocop:disable RSpec/DescribeClass
 RSpec.describe 'rspec-tracer dogfood' do
   let(:fixture_root) { File.expand_path('../../benchmark/fixtures/ruby_app', __dir__) }
   let(:cache_dir)    { File.join(fixture_root, 'rspec_tracer_cache') }
@@ -43,23 +43,26 @@ RSpec.describe 'rspec-tracer dogfood' do
     JSON.parse(File.read(File.join(cache_dir, 'last_run.json'))).fetch('run_id')
   end
 
-  it 'runs green cold and warm, and produces a reusable cache' do
-    # Ensure the fixture has its bundle installed; skip bundle install if
-    # it's already satisfied.
+  def ensure_bundle!
     Dir.chdir(fixture_root) do
       unless system('bundle check > /dev/null 2>&1')
         install_out, install_status = Open3.capture2e('bundle', 'install', '--quiet')
         raise "bundle install failed in #{fixture_root}:\n#{install_out}" unless install_status.success?
       end
     end
+  end
 
-    cold_out, cold_status = run_rspec_in_fixture(fixture_root)
-    expect(cold_status.exitstatus).to eq(0), "cold run failed:\n#{cold_out}"
+  # rubocop:disable Metrics/AbcSize, RSpec/NoExpectationExample
+  def dogfood_cycle(label, env = {})
+    ensure_bundle!
+
+    cold_out, cold_status = Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color', chdir: fixture_root)
+    expect(cold_status.exitstatus).to eq(0), "#{label} cold run failed:\n#{cold_out}"
     expect(File).to exist(File.join(cache_dir, 'last_run.json'))
     expect(last_run_id(cache_dir)).to match(/\A[0-9a-f]+\z/)
 
-    warm_out, warm_status = run_rspec_in_fixture(fixture_root)
-    expect(warm_status.exitstatus).to eq(0), "warm run failed:\n#{warm_out}"
+    warm_out, warm_status = Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color', chdir: fixture_root)
+    expect(warm_status.exitstatus).to eq(0), "#{label} warm run failed:\n#{warm_out}"
     expect(File).to exist(File.join(cache_dir, 'last_run.json'))
     expect(last_run_id(cache_dir)).to match(/\A[0-9a-f]+\z/)
     # Warm run prints tracer-authored output to STDOUT (skipped/cached
@@ -67,5 +70,14 @@ RSpec.describe 'rspec-tracer dogfood' do
     # "RSpec tracer" banner always appears.
     expect(warm_out).to include('RSpec tracer')
   end
+
+  it 'runs green cold and warm, and produces a reusable cache (legacy engine)' do
+    dogfood_cycle('legacy')
+  end
+
+  it 'runs green cold and warm under the v2 engine (RSPEC_TRACER_USE_V2_TRACKER=true)' do
+    dogfood_cycle('v2', 'RSPEC_TRACER_USE_V2_TRACKER' => 'true')
+  end
+  # rubocop:enable Metrics/AbcSize, RSpec/NoExpectationExample
 end
-# rubocop:enable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/MultipleExpectations
+# rubocop:enable RSpec/DescribeClass

--- a/spec/integration/ruby_app_v2_tracker_spec.rb
+++ b/spec/integration/ruby_app_v2_tracker_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# End-to-end integration for the v2 core engine: runs the benchmark
+# ruby_app fixture via subprocess once on the legacy path, once on
+# the v2 path (RSPEC_TRACER_USE_V2_TRACKER=true), and asserts that:
+#
+#   - both modes exit green on both cold and warm runs
+#   - v2 persists a schema_version 3 cache with every FILENAMES
+#     entry present
+#   - the set of example ids discovered by both modes matches
+#     (filter-decision parity for the identical fixture)
+#
+# This exercises the Engine + RSpec hook routing + JsonBackend +
+# Snapshot shape all together, so a regression anywhere in the chain
+# fails here before the per-module unit spec catches it.
+
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+
+# The spec runs two subprocesses and compares outcomes; metric cops
+# tuned for single-line expectations scatter the narrative.
+# rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/MultipleExpectations
+RSpec.describe 'ruby_app under v2 tracker' do
+  let(:fixture_root) { File.expand_path('../../benchmark/fixtures/ruby_app', __dir__) }
+  let(:cache_dir)    { File.join(fixture_root, 'rspec_tracer_cache') }
+  let(:report_dir)   { File.join(fixture_root, 'rspec_tracer_report') }
+  let(:coverage_dir) { File.join(fixture_root, 'rspec_tracer_coverage') }
+
+  around do |example|
+    Bundler.with_unbundled_env do
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+      example.run
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+    end
+  end
+
+  def run_rspec(env: {})
+    Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color', chdir: fixture_root)
+  end
+
+  def load_last_run_manifest
+    JSON.parse(File.read(File.join(cache_dir, 'last_run.json')))
+  end
+
+  def load_cache_file(name)
+    run_id = load_last_run_manifest.fetch('run_id')
+    JSON.parse(File.read(File.join(cache_dir, run_id, name)))
+  end
+
+  def ensure_bundle_installed!
+    Dir.chdir(fixture_root) do
+      unless system('bundle check > /dev/null 2>&1')
+        install_out, install_status = Open3.capture2e('bundle', 'install', '--quiet')
+        raise "bundle install failed in #{fixture_root}:\n#{install_out}" unless install_status.success?
+      end
+    end
+  end
+
+  before { ensure_bundle_installed! }
+
+  describe 'cold cache + v2 engine' do
+    let(:v2_env) { { 'RSPEC_TRACER_USE_V2_TRACKER' => 'true' } }
+
+    it 'exits cleanly with the same banner as legacy' do
+      out, status = run_rspec(env: v2_env)
+
+      expect(status.exitstatus).to eq(0), "v2 cold run failed:\n#{out}"
+      expect(out).to include('RSpec tracer')
+    end
+
+    it 'writes a v2 cache with schema_version 3' do
+      run_rspec(env: v2_env)
+
+      expect(load_last_run_manifest['schema_version']).to eq(3)
+    end
+
+    it 'writes every FILENAMES entry under the run-id directory' do
+      run_rspec(env: v2_env)
+
+      run_id = load_last_run_manifest.fetch('run_id')
+      RSpecTracer::Storage::JsonBackend::FILENAMES.each do |filename|
+        expect(File).to exist(File.join(cache_dir, run_id, filename)), "missing #{filename}"
+      end
+    end
+
+    it 'populates the dependency graph with non-empty entries for every run example' do
+      run_rspec(env: v2_env)
+
+      dependency = load_cache_file('dependency.json')
+      expect(dependency).not_to be_empty
+      expect(dependency.values).to all(be_an(Array))
+    end
+
+    it 'persists the boot_set digest map (M3.7 field)' do
+      run_rspec(env: v2_env)
+
+      boot_set = load_cache_file('boot_set.json')
+      expect(boot_set).to be_a(Hash)
+    end
+  end
+
+  describe 'warm cache + v2 engine' do
+    let(:v2_env) { { 'RSPEC_TRACER_USE_V2_TRACKER' => 'true' } }
+
+    it 'exits cleanly on the second run (cache round-trip works)' do
+      _, cold_status = run_rspec(env: v2_env)
+      warm_out, warm_status = run_rspec(env: v2_env)
+
+      expect(cold_status.exitstatus).to eq(0)
+      expect(warm_status.exitstatus).to eq(0), "v2 warm run failed:\n#{warm_out}"
+    end
+
+    it 'keeps the run_id hex-only across warm runs' do
+      run_rspec(env: v2_env)
+      run_rspec(env: v2_env)
+
+      expect(load_last_run_manifest['run_id']).to match(/\A[0-9a-f]+\z/)
+    end
+  end
+
+  describe 'parity with the legacy engine' do
+    it 'discovers the same example ids in legacy and v2 runs' do
+      _, legacy_status = run_rspec
+      expect(legacy_status.exitstatus).to eq(0)
+      legacy_examples = load_cache_file('all_examples.json').keys.sort
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+
+      _, v2_status = run_rspec(env: { 'RSPEC_TRACER_USE_V2_TRACKER' => 'true' })
+      expect(v2_status.exitstatus).to eq(0)
+      v2_examples = load_cache_file('all_examples.json').keys.sort
+
+      expect(v2_examples).to eq(legacy_examples)
+    end
+
+    it 'tracks every app/*.rb and spec/*_spec.rb in both modes' do
+      # Legacy attributes spec_helper.rb via register_traced_dependency
+      # (RSpec.configuration.requires hook); v2 captures it into
+      # LoadedFilesTracker.boot_set as a whole-suite invalidator, not
+      # into all_files. Spec-helper-equivalent coverage is preserved
+      # through a different attribution path under v2; both modes
+      # still need the actual app/ + spec/ source files in all_files.
+      run_rspec
+      legacy_files = load_cache_file('all_files.json').keys.sort
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+
+      run_rspec(env: { 'RSPEC_TRACER_USE_V2_TRACKER' => 'true' })
+      v2_files = load_cache_file('all_files.json').keys.sort
+
+      common_app_files = legacy_files.grep(%r{^/(app|spec/.*_spec)})
+      expect(v2_files).to include(*common_app_files)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/tracker/io_hooks_spec.rb
+++ b/spec/tracker/io_hooks_spec.rb
@@ -73,6 +73,31 @@ RSpec.describe RSpecTracer::Tracker::IOHooks do
     end
   end
 
+  describe '.set_bucket / .clear_bucket' do
+    it 'set_bucket installs a bucket readable via current_bucket' do
+      bucket = {}
+      described_class.set_bucket(bucket)
+      expect(described_class.current_bucket).to be(bucket)
+    ensure
+      described_class.clear_bucket
+    end
+
+    it 'clear_bucket nils out the current bucket' do
+      described_class.set_bucket({})
+      described_class.clear_bucket
+
+      expect(described_class.current_bucket).to be_nil
+    end
+
+    it 'wires the bucket so record captures through it (parity with with_bucket)' do
+      bucket = {}
+      described_class.set_bucket(bucket)
+      described_class.record(write_fixture('a.yml'))
+      described_class.clear_bucket
+      expect(bucket).not_to be_empty
+    end
+  end
+
   describe '.record fast-reject' do
     it 'is a no-op when uninstalled' do
       described_class.uninstall


### PR DESCRIPTION
## Summary

- `RSpecTracer::Engine` is the v2 coordinator that wires every tracker leaf (CoverageAdapter, IOHooks, DeclaredGlobs, NewFileDetector, WholeSuiteInvalidators, LoadedFilesTracker, ExampleRegistry, DependencyGraph) into one pipeline behind the new `use_v2_tracker` config flag (default `false`, ENV-overridable).
- Legacy Runner + CoverageReporter continue to own the default path. The bridge is a handful of conditional lines in the RSpec hook modules; it retires once the Phase 5 RSpec-integration rework lands.
- Benchmark smoke gains `cold_ruby_v2` + `warm_noop_v2` scenarios; both land inside the existing 1.20× fail band on M2 Max.
- Parallel_tests is deliberately gated off under v2 for now — the legacy ReportMerger / CoverageMerger glue is intricate enough to defer.
- The ruby_app fixture runs cold + warm under v2 via a new subprocess integration spec; dogfood runs twice per suite now (legacy + v2).

## Test plan

- [x] `task check` — lint + unit + smoke benchmark (incl. v2 scenarios) within ratchet
- [x] `task test:unit` — all existing specs + 32 new Engine unit examples + 7 DSL examples + 3 IOHooks bucket examples
- [x] `task test:property` — 23 examples
- [x] `task test:integration` — 18 examples (legacy dogfood + v2 dogfood + constants regression + ruby_app v2 parity)
- [x] `task test:mutation:smoke` — 11 subjects each ≥ 90%
- [x] `task test:dogfood` — both legacy and v2 cold+warm cycles
- [x] `task security:bundle-audit` — clean
- [x] `task lint:ruby` / `lint:actions` / `lint:yaml` — all clean
- [x] Benchmark: `cold_ruby_v2` p50 0.254 s, `warm_noop_v2` p50 0.248 s on M2 Max — no regression vs legacy

🤖 Generated with [Claude Code](https://claude.com/claude-code)