### PR TITLE
feat(rails): preset + detection + Railtie

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -187,11 +187,11 @@ tasks:
 
   test:mutation:smoke:
     desc: >-
-      Mutation smoke — 11 subjects (TimeFormatter.format_time, Tracker::Input,
+      Mutation smoke — 12 subjects (TimeFormatter.format_time, Tracker::Input,
       Tracker::DeclaredGlobs, Tracker::WholeSuiteInvalidators, Storage::Schema,
       Storage::Snapshot, Storage::Backend, Tracker::DependencyGraph,
-      Tracker::ExampleRegistry, Tracker::Filter, Tracker::LoadedFilesTracker)
-      must each hit >= 90% (< 2 min budget)
+      Tracker::ExampleRegistry, Tracker::Filter, Tracker::LoadedFilesTracker,
+      Rails::Preset) must each hit >= 90% (< 2 min budget)
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -261,6 +261,9 @@ tasks:
         run_mutant_subject "Tracker::LoadedFilesTracker" \
           "rspec_tracer/tracker/loaded_files_tracker" \
           "RSpecTracer::Tracker::LoadedFilesTracker*" || fail=1
+        run_mutant_subject "Rails::Preset" \
+          "rspec_tracer/rails/preset" \
+          "RSpecTracer::Rails::Preset*" || fail=1
         exit "$fail"
 
   test:mutation:full:

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -164,6 +164,15 @@ module RSpecTracer
       defined?(@parallel_tests) && @parallel_tests == true
     end
 
+    # True iff Rails is loaded in this process. Computed once during
+    # `initial_setup` (via `setup_rails`) and memoized; subsequent Rails
+    # activations within the same run are not re-detected. Matches the
+    # `simplecov?` / `parallel_tests?` shape so callers can branch on
+    # framework presence uniformly.
+    def rails?
+      defined?(@rails) && @rails == true
+    end
+
     private
 
     def valid_jruby_opts?
@@ -190,6 +199,7 @@ module RSpecTracer
       end
 
       setup_coverage
+      setup_rails
       setup_trace_point
 
       if RSpecTracer.use_v2_tracker && !parallel_tests?
@@ -263,6 +273,15 @@ module RSpecTracer
       require 'coverage'
 
       ::Coverage.start
+    end
+
+    # Detects Rails by the presence of `::Rails::VERSION`. Users who
+    # require `rspec_tracer/rails` transitively load the Railtie (when
+    # Rails is also present); this method only sets the flag consumed
+    # by `RSpecTracer.rails?`. Safe when Rails is absent - the
+    # `defined?` guard returns nil, flag stays false.
+    def setup_rails
+      @rails = defined?(::Rails::VERSION) && !::Rails::VERSION.nil?
     end
 
     def setup_trace_point

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -304,11 +304,22 @@ module RSpecTracer
       all.uniq.freeze
     end
 
-    # Rails preset hook. M3.3 ships it as a no-op so users can write
-    # `track_rails_defaults` in .rspec-tracer today without a
-    # NoMethodError; M4.1 fills in the Rails-specific glob set.
-    def track_rails_defaults
-      nil
+    # Rails preset hook. Expands to the Rails glob set defined in
+    # RSpecTracer::Rails::Preset (views, helpers, locales, config,
+    # schema, factories, fixtures) and accumulates those globs into
+    # `@track_files_globs`. Per-category opt-out via the `except:`
+    # keyword argument (e.g. `track_rails_defaults except: [:views]`).
+    #
+    # Requires 'rspec_tracer/rails/preset' lazily so pure-Ruby suites
+    # that never call `track_rails_defaults` do not pay for the file
+    # load. Deduplication and whole-suite-invalidator reuse happen in
+    # `#declared_globs` / `Tracker::WholeSuiteInvalidators`; this method
+    # is intentionally idempotent on repeat calls.
+    def track_rails_defaults(except: [])
+      require_relative 'rails/preset'
+
+      globs = RSpecTracer::Rails::Preset.globs(except: except)
+      track_files(*globs)
     end
 
     # One-way latch. Tracker.setup (M3.6) flips it so a stray

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -43,8 +43,13 @@ module RSpecTracer
         RSpecTracer::Configuration.private_instance_methods(false).each do |method_name|
           alias_method :"_#{method_name}", method_name
 
-          define_method method_name do |*args, &block|
-            send(:"_#{method_name}", *args, &block)
+          # Forward `**kwargs` too so DSL methods can accept Ruby 3+
+          # keyword args (e.g. `track_rails_defaults except: [:views]`,
+          # M3.8's `storage_backend :json, serializer: :msgpack`).
+          # Before M4.1 this wrapper forwarded `*args, &block` only and
+          # silently stripped kwargs; see M3.4 handoff notes.
+          define_method method_name do |*args, **kwargs, &block|
+            send(:"_#{method_name}", *args, **kwargs, &block)
           end
         end
       end

--- a/lib/rspec_tracer/load_config.rb
+++ b/lib/rspec_tracer/load_config.rb
@@ -8,8 +8,8 @@ require_relative 'load_global_config'
 require_relative 'load_local_config'
 
 # NOTE: `Configuration#configure` installs the public DSL wrappers
-# (alias `_name` + redefine `name` to forward `|*args, &block|`) the
-# first time any configurer runs. `load_default_config` is
+# (alias `_name` + redefine `name` to forward `|*args, **kwargs, &block|`)
+# the first time any configurer runs. `load_default_config` is
 # unconditional, so the wrappers are guaranteed to exist before anyone
 # can call `RSpecTracer.add_filter` etc. No second install step is
 # needed here.

--- a/lib/rspec_tracer/rails.rb
+++ b/lib/rspec_tracer/rails.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Rails integration entry point. Loaded explicitly by users who put
+# `require 'rspec_tracer/rails'` in their spec_helper - the gem does not
+# auto-load this file, so pure-Ruby suites pay zero cost.
+#
+# Behavior:
+#   - Always loads RSpecTracer::Rails::Preset so Configuration#track_rails_defaults
+#     works whether or not Rails itself is booted in the current process.
+#   - Loads RSpecTracer::Rails::Railtie iff `::Rails::Railtie` is defined,
+#     so requiring this file when Rails is absent is a clean no-op
+#     (AC1: "Rails absent: requiring rspec_tracer/rails noops cleanly").
+
+require_relative 'rails/preset'
+require_relative 'rails/railtie' if defined?(Rails::Railtie)

--- a/lib/rspec_tracer/rails/README.md
+++ b/lib/rspec_tracer/rails/README.md
@@ -1,18 +1,37 @@
 # Rails integration
 
-Auto-loaded when Rails is present. Provides a sensible preset for Rails
-test suites and wires Rails-specific input observers.
+Loaded by `require 'rspec_tracer/rails'`. Exposes the Rails preset and
+wires a Railtie that integrates with the Rails lifecycle when Rails is
+present in the process.
 
-## Responsibilities
+## Surface
 
-- Detect Rails and opt in automatically (Railtie-based).
-- Subscribe to `ActiveSupport::Notifications` for template renders, I18n
-  lookups, factory/fixture loads.
-- Provide a preset covering the common Rails tracking surface
-  (`config/locales/**/*.yml`, `db/schema.rb`, views, fixtures, factories).
+- **`RSpecTracer::Rails::Preset`** - closed-enum glob set covering the
+  Coverage-invisible Rails surface (views, helpers, locales, config
+  YAML, schema, factories, fixtures). Opt in via `track_rails_defaults`
+  in `.rspec-tracer`; opt out per category via
+  `track_rails_defaults except: [:views, :locales]`.
+- **`RSpecTracer::Rails::Railtie`** - only loaded when
+  `defined?(::Rails::Railtie)`. Registers a single `rspec_tracer.setup`
+  initializer that logs a confirmation line when Rails boots.
 
-## Status
+## Detection
 
-Placeholder for 2.0. No Rails integration existed in 1.x; this layer is
-net-new and lands in Phase 4 (sessions M4.1–M4.3). The integration
-test runs against the reference Rails 7.1 app fixture from M2.3.
+`RSpecTracer.rails?` returns true when `::Rails::VERSION` is defined at
+the time `RSpecTracer.start` runs. The flag is computed once during
+`initial_setup`; subsequent Rails loads do not flip it.
+
+## Zero-cost when Rails is absent
+
+`require 'rspec_tracer/rails'` loads Preset unconditionally and skips
+the Railtie via `defined?(::Rails::Railtie)`. A pure-Ruby suite that
+accidentally requires the file never pays for Rails-specific code.
+
+## Phase 4 scope split
+
+- **M4.1** (this file, shipped): preset + detection + Railtie scaffold.
+- **M4.2**: ActionView / I18n / schema / factory / fixture notification
+  subscribers plug into the Railtie.
+- **M4.3**: integration test against the reference Rails app
+  (`spec/fixtures/rails_app/`) covering the full "change X -> Y re-runs"
+  behavior matrix.

--- a/lib/rspec_tracer/rails/preset.rb
+++ b/lib/rspec_tracer/rails/preset.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'set'
+
+require_relative '../configuration'
+
+module RSpecTracer
+  module Rails
+    # Default Rails glob preset - the Coverage-invisible surface that
+    # rspec-tracer cannot auto-observe via its standard Ruby-execution
+    # tracking. Enabled by `track_rails_defaults` in .rspec-tracer.
+    #
+    # Covered categories (each toggleable via the `except:` kwarg):
+    #
+    #   :views     - app/views/**/* (ERB / Slim / Haml / JBuilder)
+    #   :helpers   - app/helpers/**/*.rb (tracked as declared so helper
+    #                files re-invalidate even before Zeitwerk loads them)
+    #   :locales   - config/locales/**/*.yml (I18n data files)
+    #   :config    - config/*.yml + config/routes.rb (database.yml,
+    #                cable.yml, storage.yml, routes - the YAML + routes
+    #                dispatcher are all config surface)
+    #   :schema    - db/schema.rb + db/structure.sql
+    #   :factories - spec/factories/**/*.rb + test/factories/**/*.rb
+    #   :fixtures  - spec/fixtures/**/*.{yml,yaml,json} + same under test/
+    #
+    # Intentionally omitted:
+    #   - Gemfile.lock, .ruby-version, .rspec-tracer: already tracked as
+    #     whole-suite invalidators (Tracker::WholeSuiteInvalidators).
+    #     Listing them as :declared would cross input-kind categories.
+    #   - config/environments/*.rb, config/app_constants.rb: loaded as
+    #     Ruby at Rails boot, so LoadedFilesTracker.@boot_set captures
+    #     them already as transitive-load inputs.
+    #
+    # Unknown `except:` keys raise Configuration::InvalidUsageError, same
+    # pattern as `storage_backend(:bogus)`.
+    class Preset
+      DEFAULTS = {
+        views: %w[app/views/**/*].freeze,
+        helpers: %w[app/helpers/**/*.rb].freeze,
+        locales: %w[config/locales/**/*.yml].freeze,
+        config: %w[config/*.yml config/routes.rb].freeze,
+        schema: %w[db/schema.rb db/structure.sql].freeze,
+        factories: %w[spec/factories/**/*.rb test/factories/**/*.rb].freeze,
+        fixtures: %w[
+          spec/fixtures/**/*.{yml,yaml,json}
+          test/fixtures/**/*.{yml,yaml,json}
+        ].freeze
+      }.freeze
+
+      ALLOWED_KEYS = DEFAULTS.keys.to_set.freeze
+
+      def self.globs(except: [])
+        excluded = normalize_excluded(except)
+        validate_excluded!(excluded)
+
+        DEFAULTS
+          .except(*excluded)
+          .values
+          .flatten
+          .uniq
+          .freeze
+      end
+
+      def self.normalize_excluded(except)
+        Array(except).compact
+      end
+
+      def self.validate_excluded!(excluded)
+        unknown = excluded.reject { |key| ALLOWED_KEYS.include?(key) }
+        return if unknown.empty?
+
+        raise RSpecTracer::Configuration::InvalidUsageError,
+              "unknown track_rails_defaults keys: #{unknown.inspect}; " \
+              "allowed: #{ALLOWED_KEYS.to_a.inspect}"
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/rails/railtie.rb
+++ b/lib/rspec_tracer/rails/railtie.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RSpecTracer
+  module Rails
+    # Rails lifecycle adapter. Only required by `lib/rspec_tracer/rails.rb`
+    # when `defined?(::Rails::Railtie)` is true, so loading this file in
+    # a non-Rails process is not expected and will raise NameError.
+    #
+    # M4.1 scope: define the Railtie class + register one initializer
+    # that logs a single confirmation line. M4.2 fills in
+    # ActiveSupport::Notifications subscribers for ActionView template
+    # renders, I18n lookups, and schema/factory/fixture tracking.
+    class Railtie < ::Rails::Railtie
+      initializer 'rspec_tracer.setup' do
+        RSpecTracer.logger.info 'rspec-tracer Rails integration loaded'
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,6 +7,31 @@ RSpec.describe RSpecTracer::Configuration do
 
   let(:clazz) { Class.new { include RSpecTracer::Configuration } }
 
+  describe '#configure DSL wrapper' do
+    # The DSL wrapper aliases every private setter to `_name`, then
+    # redefines the public name as a thin forwarder. Before M4.1 the
+    # forwarder stripped keyword arguments silently; M4.1 threads
+    # `**kwargs` through so `track_rails_defaults except: [:views]`
+    # (and the deferred M3.4/M3.8 `storage_backend` opts) work.
+    it 'forwards keyword arguments through to the underlying setter' do
+      params = described_class
+        .instance_method(:track_rails_defaults)
+        .parameters
+        .map(&:first)
+
+      expect(params).to include(:keyrest)
+    end
+
+    it 'still forwards positional arguments and blocks' do
+      params = described_class
+        .instance_method(:track_rails_defaults)
+        .parameters
+        .map(&:first)
+
+      expect(params).to include(:rest, :block)
+    end
+  end
+
   describe '#root' do
     context 'when not configured' do
       it 'returns current working directory' do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -212,14 +212,47 @@ RSpec.describe RSpecTracer::Configuration do
   end
 
   describe '#track_rails_defaults' do
-    it 'is a no-op stub until M4.1 (returns nil)' do
-      expect(config.track_rails_defaults).to be_nil
-    end
+    before { require 'rspec_tracer/rails/preset' }
 
-    it 'does not accumulate any declared globs' do
+    it 'accumulates the full Rails preset glob set into declared_globs' do
       config.track_rails_defaults
 
-      expect(config.declared_globs).to eq([])
+      expect(config.declared_globs).to include(*RSpecTracer::Rails::Preset.globs)
+    end
+
+    it 'honors the except: kwarg to skip a category' do
+      config.track_rails_defaults(except: [:views])
+
+      RSpecTracer::Rails::Preset::DEFAULTS[:views].each do |view_glob|
+        expect(config.declared_globs).not_to include(view_glob)
+      end
+    end
+
+    it 'keeps non-excluded categories when except: is used' do
+      config.track_rails_defaults(except: [:views])
+
+      expect(config.declared_globs).to include(*RSpecTracer::Rails::Preset::DEFAULTS[:locales])
+    end
+
+    it 'raises for an unknown except: key' do
+      expect { config.track_rails_defaults(except: [:bogus]) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /unknown track_rails_defaults/)
+    end
+
+    it 'is idempotent across repeat calls (de-duplicated via declared_globs)' do
+      config.track_rails_defaults
+      first = config.declared_globs.dup
+
+      config.track_rails_defaults
+
+      expect(config.declared_globs).to eq(first)
+    end
+
+    it 'composes with explicit track_files calls' do
+      config.track_files('custom/**/*.rb')
+      config.track_rails_defaults
+
+      expect(config.declared_globs).to include('custom/**/*.rb', *RSpecTracer::Rails::Preset.globs)
     end
   end
 

--- a/spec/fixtures/rails_app/.rspec-tracer
+++ b/spec/fixtures/rails_app/.rspec-tracer
@@ -1,3 +1,11 @@
-# Minimal rspec-tracer configuration for the reference Rails fixture.
-# Per-example Rails-aware tracking (`track_rails_defaults`) lands in M4.1.
-# For now this just ensures the tracer loads cleanly against the fixture.
+# rspec-tracer configuration for the reference Rails 7.1+ fixture.
+# `track_rails_defaults` wires the preset defined in
+# RSpecTracer::Rails::Preset: views, helpers, locales, config YAML,
+# routes, db/schema.rb, factories, and YAML fixtures. Per-category
+# opt-out via `except: [:views, :locales, ...]`.
+#
+# M4.1 ships the preset + Railtie scaffolding. M4.3 runs this fixture
+# under rspec-tracer and asserts the full behavior matrix.
+RSpecTracer.configure do
+  track_rails_defaults
+end

--- a/spec/rails/detection_spec.rb
+++ b/spec/rails/detection_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+# Loading the preset defines `RSpecTracer::Rails`, which is the module
+# under test. The `rails.rb` entry-point require exercises the same load
+# path but via the `load` helper inside individual examples.
+require 'rspec_tracer/rails/preset'
+
+RSpec.describe RSpecTracer::Rails do
+  let(:entry_path) { File.expand_path('../../lib/rspec_tracer/rails.rb', __dir__) }
+
+  describe 'requiring rspec_tracer/rails' do
+    it 'loads without raising when Rails is absent' do
+      hide_const('Rails') if defined?(Rails)
+
+      expect { load entry_path }.not_to raise_error
+    end
+
+    it 'defines RSpecTracer::Rails::Preset regardless of Rails presence' do
+      load entry_path
+
+      expect(described_class.const_defined?(:Preset)).to be(true)
+    end
+
+    it 'skips loading the Railtie when Rails::Railtie is not defined' do
+      hide_const('Rails::Railtie') if defined?(Rails::Railtie)
+      # rubocop:disable RSpec/RemoveConst
+      described_class.send(:remove_const, :Railtie) if described_class.const_defined?(:Railtie, false)
+      # rubocop:enable RSpec/RemoveConst
+
+      load entry_path
+
+      expect(described_class.const_defined?(:Railtie, false)).to be(false)
+    end
+  end
+
+  describe 'RSpecTracer.rails?' do
+    around do |example|
+      had_var = RSpecTracer.instance_variable_defined?(:@rails)
+      original = RSpecTracer.instance_variable_get(:@rails) if had_var
+
+      example.run
+    ensure
+      if had_var
+        RSpecTracer.instance_variable_set(:@rails, original)
+      elsif RSpecTracer.instance_variable_defined?(:@rails)
+        RSpecTracer.remove_instance_variable(:@rails)
+      end
+    end
+
+    # Matches `simplecov?` / `parallel_tests?` semantics: the predicate
+    # short-circuits on `defined?(@rails)` and returns nil before the
+    # flag has been computed. Callers branch on truthiness.
+    it 'is falsy when @rails has never been set' do
+      RSpecTracer.remove_instance_variable(:@rails) if RSpecTracer.instance_variable_defined?(:@rails)
+
+      expect(RSpecTracer).not_to be_rails
+    end
+
+    it 'is false when Rails is not defined at detection time' do
+      hide_const('Rails') if defined?(Rails)
+
+      RSpecTracer.send(:setup_rails)
+
+      expect(RSpecTracer.rails?).to be(false)
+    end
+
+    it 'is true when Rails::VERSION is defined at detection time' do
+      stub_const('Rails', Module.new)
+      stub_const('Rails::VERSION', '7.1.0')
+
+      RSpecTracer.send(:setup_rails)
+
+      expect(RSpecTracer).to be_rails
+    end
+
+    it 'is false when Rails is present but Rails::VERSION is nil' do
+      stub_const('Rails', Module.new)
+      stub_const('Rails::VERSION', nil)
+
+      RSpecTracer.send(:setup_rails)
+
+      expect(RSpecTracer.rails?).to be(false)
+    end
+
+    it 'memoizes the flag across multiple reads (no re-detection)' do
+      stub_const('Rails', Module.new)
+      stub_const('Rails::VERSION', '7.1.0')
+      RSpecTracer.send(:setup_rails)
+      hide_const('Rails')
+      expect(RSpecTracer.rails?).to be(true)
+    end
+  end
+end

--- a/spec/rails/preset_spec.rb
+++ b/spec/rails/preset_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require 'rspec_tracer/rails/preset'
+
+RSpec.describe RSpecTracer::Rails::Preset do
+  describe '.globs' do
+    context 'with no exclusions' do
+      it 'returns every glob from every DEFAULTS category' do
+        globs = described_class.globs
+
+        described_class::DEFAULTS.each_value do |category_globs|
+          expect(globs).to include(*category_globs)
+        end
+      end
+
+      it 'returns a frozen array' do
+        expect(described_class.globs).to be_frozen
+      end
+
+      it 'contains no duplicate entries' do
+        globs = described_class.globs
+
+        expect(globs).to eq(globs.uniq)
+      end
+    end
+
+    context 'with exclusions' do
+      it 'omits every glob of the excluded category' do
+        globs = described_class.globs(except: [:views])
+
+        described_class::DEFAULTS[:views].each do |view_glob|
+          expect(globs).not_to include(view_glob)
+        end
+      end
+
+      it 'keeps globs from non-excluded categories' do
+        globs = described_class.globs(except: [:views])
+
+        expect(globs).to include(*described_class::DEFAULTS[:locales])
+      end
+
+      it 'accepts multiple excluded categories' do
+        excluded = %i[views locales]
+        globs = described_class.globs(except: excluded)
+
+        excluded_globs = excluded.flat_map { |key| described_class::DEFAULTS[key] }
+        expect(globs).not_to include(*excluded_globs)
+      end
+
+      it 'coerces a single symbol to a one-element exclusion list' do
+        globs = described_class.globs(except: :views)
+
+        described_class::DEFAULTS[:views].each do |view_glob|
+          expect(globs).not_to include(view_glob)
+        end
+      end
+
+      it 'treats nil as no exclusion' do
+        expect(described_class.globs(except: nil)).to eq(described_class.globs)
+      end
+
+      it 'drops nil entries inside the exclusion list' do
+        expect(described_class.globs(except: [nil, :views]))
+          .to eq(described_class.globs(except: [:views]))
+      end
+
+      it 'raises for an unknown category key' do
+        expect { described_class.globs(except: [:bogus]) }
+          .to raise_error(
+            RSpecTracer::Configuration::InvalidUsageError,
+            /unknown track_rails_defaults keys/
+          )
+      end
+
+      it 'lists every unknown key in the error message' do
+        expect { described_class.globs(except: %i[bogus mystery]) }
+          .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /:bogus.*:mystery|:mystery.*:bogus/)
+      end
+
+      it 'reports allowed keys in the error message' do
+        expect { described_class.globs(except: [:bogus]) }
+          .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /allowed:/)
+      end
+    end
+  end
+
+  describe 'DEFAULTS constant' do
+    it 'defines the seven preset categories' do
+      expect(described_class::DEFAULTS.keys)
+        .to match_array(%i[views helpers locales config schema factories fixtures])
+    end
+
+    it 'is frozen' do
+      expect(described_class::DEFAULTS).to be_frozen
+    end
+
+    it 'stores frozen glob arrays per category' do
+      described_class::DEFAULTS.each_value do |globs|
+        expect(globs).to be_frozen
+      end
+    end
+
+    it 'stores at least one glob in every category' do
+      described_class::DEFAULTS.each_value do |globs|
+        expect(globs).not_to be_empty
+      end
+    end
+  end
+
+  describe 'ALLOWED_KEYS constant' do
+    it 'is a Set instance' do
+      expect(described_class::ALLOWED_KEYS).to be_a(Set)
+    end
+
+    it 'mirrors DEFAULTS keys' do
+      expect(described_class::ALLOWED_KEYS.to_a).to match_array(described_class::DEFAULTS.keys)
+    end
+
+    it 'is frozen' do
+      expect(described_class::ALLOWED_KEYS).to be_frozen
+    end
+  end
+
+  describe '.normalize_excluded' do
+    it 'wraps a single symbol in an array' do
+      expect(described_class.normalize_excluded(:views)).to eq([:views])
+    end
+
+    it 'returns [] for nil' do
+      expect(described_class.normalize_excluded(nil)).to eq([])
+    end
+
+    it 'drops nil entries inside a list' do
+      expect(described_class.normalize_excluded([nil, :views, nil])).to eq([:views])
+    end
+
+    it 'returns [] for an empty array' do
+      expect(described_class.normalize_excluded([])).to eq([])
+    end
+  end
+
+  describe '.validate_excluded!' do
+    it 'returns silently for all-allowed keys' do
+      expect { described_class.validate_excluded!(%i[views locales]) }.not_to raise_error
+    end
+
+    it 'returns silently for an empty list' do
+      expect { described_class.validate_excluded!([]) }.not_to raise_error
+    end
+
+    it 'raises when any key is not in ALLOWED_KEYS' do
+      expect { described_class.validate_excluded!([:bogus]) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError)
+    end
+  end
+end

--- a/spec/rails/railtie_spec.rb
+++ b/spec/rails/railtie_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+# Loading the preset defines `RSpecTracer::Rails`, the module the
+# Railtie class lives inside. Railtie.rb itself expects
+# `::Rails::Railtie` to already be defined; the before-block below
+# stubs that base class so this spec can run without the real Rails
+# gem in the object graph.
+require 'rspec_tracer/rails/preset'
+
+RSpec.describe RSpecTracer::Rails do
+  describe 'RSpecTracer::Rails::Railtie' do
+    let(:railtie_path) do
+      File.expand_path('../../lib/rspec_tracer/rails/railtie.rb', __dir__)
+    end
+
+    # The dev Gemfile does not include Rails, so a real ::Rails::Railtie
+    # is not in the object graph. Provide a minimal stand-in that records
+    # every `initializer(name, &block)` call so the spec can inspect what
+    # the loaded railtie.rb registered. Full fixture-level boot happens
+    # in M4.3's integration matrix.
+    let(:railtie_base) do
+      Class.new do
+        class << self
+          def initializer(name, &block)
+            registered_initializers[name] = block
+          end
+
+          def registered_initializers
+            @registered_initializers ||= {}
+          end
+        end
+      end
+    end
+
+    before do
+      stub_const('Rails', Module.new) unless defined?(Rails)
+      stub_const('Rails::Railtie', railtie_base)
+
+      # rubocop:disable RSpec/RemoveConst
+      described_class.send(:remove_const, :Railtie) if described_class.const_defined?(:Railtie, false)
+      # rubocop:enable RSpec/RemoveConst
+
+      load railtie_path
+    end
+
+    it 'defines the class under RSpecTracer::Rails' do
+      expect(described_class.const_defined?(:Railtie, false)).to be(true)
+    end
+
+    it 'subclasses the provided Rails::Railtie base' do
+      expect(RSpecTracer::Rails::Railtie).to be < railtie_base
+    end
+
+    it 'registers exactly one initializer named rspec_tracer.setup' do
+      expect(RSpecTracer::Rails::Railtie.registered_initializers.keys)
+        .to contain_exactly('rspec_tracer.setup')
+    end
+
+    it 'logs a confirmation line when the initializer block runs' do
+      allow(RSpecTracer.logger).to receive(:info)
+
+      RSpecTracer::Rails::Railtie.registered_initializers['rspec_tracer.setup'].call
+
+      expect(RSpecTracer.logger).to have_received(:info)
+        .with(/rspec-tracer Rails integration loaded/)
+    end
+  end
+end

--- a/spec/support/tracker_coverage_gate.rb
+++ b/spec/support/tracker_coverage_gate.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-# 100%-line + 100%-branch coverage gate scoped to lib/rspec_tracer/tracker/.
-# Legacy files get no retroactive pressure; mutation is the stronger
-# signal for those (M8.3).
+# 100%-line + 100%-branch coverage gate scoped to the lib/rspec_tracer
+# subdirectories listed in GATED_SUBDIRS. Legacy files get no retroactive
+# pressure; mutation is the stronger signal for those (M8.3).
 #
 # Activation is per-file, keyed on the lib/spec pairing convention
-# (lib/rspec_tracer/tracker/X.rb ↔ spec/tracker/X_spec.rb). Running a
-# single spec file only gates the lib module it covers; unrelated runs
+# (lib/rspec_tracer/<subdir>/X.rb <-> spec/<subdir>/X_spec.rb). Running
+# a single spec file only gates the lib module it covers; unrelated runs
 # (e.g. spec/time_formatter_spec.rb) don't trigger at all.
 module TrackerCoverageGate
-  TRACKER_PREFIX = File.expand_path('../../lib/rspec_tracer/tracker/', __dir__)
+  LIB_ROOT = File.expand_path('../../lib/rspec_tracer', __dir__)
+  GATED_SUBDIRS = %w[tracker rails].freeze
+  GATED_PREFIXES = GATED_SUBDIRS.map { |subdir| "#{File.join(LIB_ROOT, subdir)}/" }.freeze
   EPSILON = 0.001 # guard float equality of "100.0%"
 
   def self.install!
@@ -46,20 +48,29 @@ module TrackerCoverageGate
     defined?(::Mutant) || ENV['RSPEC_TRACER_DISABLE'] == '1'
   end
 
-  # Only the tracker files whose paired spec file was actually in this
+  # Only the gated lib files whose paired spec file was actually in this
   # run's files_to_run list.
   def self.gated_files
     return [] unless defined?(RSpec) && RSpec.configuration
 
     SimpleCov.result.files.select do |f|
-      f.filename.start_with?(TRACKER_PREFIX) && spec_ran_for?(f.filename)
+      gated_subdir_for(f.filename) && spec_ran_for?(f.filename)
     end
   end
 
   def self.spec_ran_for?(lib_file)
+    subdir = gated_subdir_for(lib_file)
+    return false if subdir.nil?
+
     basename = File.basename(lib_file, '.rb')
-    suffix = "/spec/tracker/#{basename}_spec.rb"
+    suffix = "/spec/#{subdir}/#{basename}_spec.rb"
     RSpec.configuration.files_to_run.any? { |f| f.end_with?(suffix) }
+  end
+
+  def self.gated_subdir_for(lib_file)
+    GATED_SUBDIRS.find.with_index do |_, index|
+      lib_file.start_with?(GATED_PREFIXES[index])
+    end
   end
 
   def self.full_coverage?(file)


### PR DESCRIPTION
## Summary
- Ship the user-facing Rails entry point (`require 'rspec_tracer/rails'`), the Rails glob preset (`RSpecTracer::Rails::Preset`), the Railtie scaffold, and `RSpecTracer.rails?` detection. This is the first installment of the Rails layer; notification subscribers (ActionView, I18n) land in the next change.
- Fill in `Configuration#track_rails_defaults` — shipped as a no-op stub in [#90](https://github.com/avmnu-sng/rspec-tracer/pull/90) — to resolve into the preset's glob set and accumulate via `track_files`. Supports `track_rails_defaults except: [:views, ...]` for per-category opt-out; unknown keys raise `Configuration::InvalidUsageError`.
- Widen the `configure` DSL wrapper to forward `**kwargs` alongside `*args, &block`. The prior wrapper silently stripped kwargs, which blocked kwarg-shaped DSL methods (the `except:` above; the storage-backend opts deferred in [#91](https://github.com/avmnu-sng/rspec-tracer/pull/91)). Split as its own commit with a signature-level spec guard.

## Behavior

- **Rails absent.** Requiring `rspec_tracer/rails` is a clean no-op — `Preset` loads (pure Ruby), `Railtie` is skipped via `defined?(::Rails::Railtie)`, and no Rails symbols are referenced.
- **Rails present.** Requiring `rspec_tracer/rails` additionally loads the Railtie, which registers one `rspec_tracer.setup` initializer that logs a confirmation line. Notification subscribers are intentionally out of scope here.
- **Preset scope.** Covers the Coverage-invisible surface: `app/views/**/*`, `app/helpers/**/*.rb`, `config/locales/**/*.yml`, `config/*.yml`, `config/routes.rb`, `db/schema.rb`, `db/structure.sql`, `spec/factories/**/*.rb` (+ `test/factories/`), `spec/fixtures/**/*.{yml,yaml,json}` (+ `test/fixtures/`). `Gemfile.lock`, `.ruby-version`, `.rspec-tracer` stay out — `Tracker::WholeSuiteInvalidators` owns them. `config/environments/*.rb` and other Ruby config stay out — Rails loads them at boot so `LoadedFilesTracker.@boot_set` already captures them.
- **Detection.** `RSpecTracer.rails?` mirrors `simplecov?` / `parallel_tests?`. Computed once during `initial_setup` from `defined?(::Rails::VERSION)`; memoized for the life of the process.

## Test plan
- [x] `task lint:ruby` — clean (114 files, 0 offenses).
- [x] `task lint:actions` / `task lint:yaml` — clean.
- [x] `task check:bundle` — Gemfile.lock satisfied.
- [x] `task security:bundle-audit` — 0 vulnerabilities.
- [x] `task security:trivy` — only pre-existing activestorage CVEs in the Rails fixture bundle (flagged in prior handoff notes, separate followup).
- [x] `task test:unit` — 601 examples, 0 failures. TrackerCoverageGate silent (100% line + branch for every gated file, including the two new Rails modules).
- [x] `task test:unit` — run once after the DSL-wrapper commit alone (559 examples, 0 failures) and again with the Rails surface stacked (601 examples, 0 failures), to catch a parity-breaking mutation on the wrapper independent of the downstream surface.
- [x] `task test:property` — 23 examples, 0 failures.
- [x] `task test:mutation:smoke` — 12/12 subjects at or above the 90% gate, including the new `RSpecTracer::Rails::Preset` at 93.82%.
- [x] `task test:dogfood` — legacy + v2 engine both green on the ruby_app fixture.
- [x] `task test:integration` — 18 examples (dogfood, constants regression, v2 ruby_app parity), 0 failures.
- [x] `task benchmark:smoke` — all five scenarios within 1.0× of their ratchet thresholds (no regression from this change; preset is boot-time glob accumulation, paid once).

## Notes for reviewers
- The DSL-wrapper commit is isolated so a mutation on `|*args, **kwargs, &block|` is caught independently of the Rails surface. The wrapper alias loop re-runs on every `configure` call, so the new `track_rails_defaults(except: [])` signature gets wrapped correctly once Configuration's unconditional default-config pass runs at gem load time.
- The Railtie unit spec stubs a minimal `::Rails::Railtie` base because the dev Gemfile does not include Rails (keeps `task check` under 10 s). Exercising the Railtie against the real `spec/fixtures/rails_app/` is deferred to the integration session that runs the full behavior matrix.
- `spec/fixtures/rails_app/.rspec-tracer` now calls `track_rails_defaults`. The fixture's RSpec run isn't yet wired through rspec-tracer (that happens in the Rails integration session), so this change is documentation intent for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)