### PR TITLE
fix(cache): pin UTF-8 encoding across legacy JSON read/write paths

### DIFF
--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -392,7 +392,7 @@ module RSpecTracer
 
         next unless File.directory?(cache_dir)
 
-        run_id = JSON.parse(File.read(File.join(cache_dir, 'last_run.json')))['run_id']
+        run_id = JSON.parse(File.read(File.join(cache_dir, 'last_run.json'), encoding: 'UTF-8'))['run_id']
 
         reports_dir << File.join(cache_dir, run_id)
       end

--- a/lib/rspec_tracer/cache.rb
+++ b/lib/rspec_tracer/cache.rb
@@ -98,7 +98,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      JSON.parse(File.read(file_name))['run_id']
+      JSON.parse(File.read(file_name, encoding: 'UTF-8'))['run_id']
     end
 
     def load_all_examples_cache(cache_dir, discard_run_reason: true)
@@ -106,7 +106,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @all_examples = JSON.parse(File.read(file_name)).transform_values do |examples|
+      @all_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values do |examples|
         examples.transform_keys(&:to_sym)
       end
 
@@ -121,7 +121,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @duplicate_examples = JSON.parse(File.read(file_name)).transform_values do |examples|
+      @duplicate_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values do |examples|
         examples.map { |example| example.transform_keys(&:to_sym) }
       end
     end
@@ -131,7 +131,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @interrupted_examples = JSON.parse(File.read(file_name)).to_set
+      @interrupted_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).to_set
     end
 
     def load_flaky_examples_cache(cache_dir)
@@ -139,7 +139,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @flaky_examples = JSON.parse(File.read(file_name)).to_set
+      @flaky_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).to_set
     end
 
     def load_failed_examples_cache(cache_dir)
@@ -147,7 +147,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @failed_examples = JSON.parse(File.read(file_name)).to_set
+      @failed_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).to_set
     end
 
     def load_pending_examples_cache(cache_dir)
@@ -155,7 +155,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @pending_examples = JSON.parse(File.read(file_name)).to_set
+      @pending_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).to_set
     end
 
     def load_skipped_examples_cache(cache_dir)
@@ -163,7 +163,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @skipped_examples = JSON.parse(File.read(file_name)).to_set
+      @skipped_examples = JSON.parse(File.read(file_name, encoding: 'UTF-8')).to_set
     end
 
     def load_all_files_cache(cache_dir)
@@ -171,7 +171,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @all_files = JSON.parse(File.read(file_name)).transform_values do |files|
+      @all_files = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values do |files|
         files.transform_keys(&:to_sym)
       end
     end
@@ -181,7 +181,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @dependency = JSON.parse(File.read(file_name)).transform_values(&:to_set)
+      @dependency = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values(&:to_set)
     end
 
     def load_examples_coverage_cache(cache_dir)
@@ -189,7 +189,7 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @examples_coverage = JSON.parse(File.read(file_name))
+      @examples_coverage = JSON.parse(File.read(file_name, encoding: 'UTF-8'))
     end
   end
 end

--- a/lib/rspec_tracer/coverage_merger.rb
+++ b/lib/rspec_tracer/coverage_merger.rb
@@ -14,7 +14,8 @@ module RSpecTracer
       reports_dir.each do |report_dir|
         next unless File.directory?(report_dir)
 
-        cache_coverage = JSON.parse(File.read("#{report_dir}/coverage.json"))['RSpecTracer']['coverage']
+        raw = File.read("#{report_dir}/coverage.json", encoding: 'UTF-8')
+        cache_coverage = JSON.parse(raw)['RSpecTracer']['coverage']
 
         cache_coverage.each_pair do |file_name, line_coverage|
           unless @coverage.key?(file_name)

--- a/lib/rspec_tracer/coverage_reporter.rb
+++ b/lib/rspec_tracer/coverage_reporter.rb
@@ -165,7 +165,7 @@ module RSpecTracer
 
     def jruby_line_stub(file_path)
       lines = File.foreach(file_path).map { nil }
-      root_node = ::JRuby.parse(File.read(file_path))
+      root_node = ::JRuby.parse(File.read(file_path, encoding: 'UTF-8'))
 
       visitor = org.jruby.ast.visitor.NodeVisitor.impl do |_name, node|
         if node.newline?

--- a/lib/rspec_tracer/coverage_writer.rb
+++ b/lib/rspec_tracer/coverage_writer.rb
@@ -15,7 +15,7 @@ module RSpecTracer
         }
       }
 
-      File.write(@file_name, JSON.pretty_generate(report))
+      File.write(@file_name, JSON.pretty_generate(report), encoding: 'UTF-8')
     end
 
     def print_stats(elapsed_time)

--- a/lib/rspec_tracer/html_reporter/reporter.rb
+++ b/lib/rspec_tracer/html_reporter/reporter.rb
@@ -211,7 +211,7 @@ module RSpecTracer
       end
 
       def template(name)
-        ERB.new(File.read(File.join(File.dirname(__FILE__), 'views/', "#{name}.erb")))
+        ERB.new(File.read(File.join(File.dirname(__FILE__), 'views/', "#{name}.erb"), encoding: 'UTF-8'))
       end
 
       def example_status_css_class(example_status)

--- a/lib/rspec_tracer/remote_cache/cache.rb
+++ b/lib/rspec_tracer/remote_cache/cache.rb
@@ -60,7 +60,7 @@ module RSpecTracer
 
         ref_list = @repo.branch_refs.merge(@repo.branch_ref => branch_ref_time.to_i)
 
-        File.write(file_name, JSON.pretty_generate(ref_list))
+        File.write(file_name, JSON.pretty_generate(ref_list), encoding: 'UTF-8')
       end
 
       def last_run_id
@@ -68,7 +68,7 @@ module RSpecTracer
 
         raise CacheError, 'Could not find any local cache to upload' unless File.file?(file_name)
 
-        JSON.parse(File.read(file_name))['run_id']
+        JSON.parse(File.read(file_name, encoding: 'UTF-8'))['run_id']
       end
     end
   end

--- a/lib/rspec_tracer/remote_cache/repo.rb
+++ b/lib/rspec_tracer/remote_cache/repo.rb
@@ -169,7 +169,7 @@ module RSpecTracer
         file_name = File.join(RSpecTracer.cache_path, 'branch_refs.json')
 
         if @aws.download_branch_refs(branch_name, file_name)
-          @branch_refs = JSON.parse(File.read(file_name)).transform_values(&:to_i)
+          @branch_refs = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values(&:to_i)
 
           return if @branch_refs.empty?
 

--- a/lib/rspec_tracer/report_merger.rb
+++ b/lib/rspec_tracer/report_merger.rb
@@ -57,7 +57,7 @@ module RSpecTracer
 
     def merge_last_run_report(cache_dir)
       file_name = File.join(cache_dir, 'last_run.json')
-      cached_last_run = JSON.parse(File.read(file_name), symbolize_names: true)
+      cached_last_run = JSON.parse(File.read(file_name, encoding: 'UTF-8'), symbolize_names: true)
       cached_last_run[:pid] = [cached_last_run[:pid]]
 
       cached_last_run.delete_if { |key, _| %i[run_id timestamp].include?(key) }

--- a/lib/rspec_tracer/report_writer.rb
+++ b/lib/rspec_tracer/report_writer.rb
@@ -68,74 +68,74 @@ module RSpecTracer
     def write_all_examples_report
       file_name = File.join(@cache_dir, 'all_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.all_examples))
+      File.write(file_name, JSON.pretty_generate(@reporter.all_examples), encoding: 'UTF-8')
     end
 
     def write_duplicate_examples_report
       file_name = File.join(@cache_dir, 'duplicate_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.duplicate_examples))
+      File.write(file_name, JSON.pretty_generate(@reporter.duplicate_examples), encoding: 'UTF-8')
     end
 
     def write_interrupted_examples_report
       file_name = File.join(@cache_dir, 'interrupted_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.interrupted_examples.sort.to_a))
+      File.write(file_name, JSON.pretty_generate(@reporter.interrupted_examples.sort.to_a), encoding: 'UTF-8')
     end
 
     def write_flaky_examples_report
       file_name = File.join(@cache_dir, 'flaky_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.flaky_examples.sort.to_a))
+      File.write(file_name, JSON.pretty_generate(@reporter.flaky_examples.sort.to_a), encoding: 'UTF-8')
     end
 
     def write_failed_examples_report
       file_name = File.join(@cache_dir, 'failed_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.failed_examples.sort.to_a))
+      File.write(file_name, JSON.pretty_generate(@reporter.failed_examples.sort.to_a), encoding: 'UTF-8')
     end
 
     def write_pending_examples_report
       file_name = File.join(@cache_dir, 'pending_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.pending_examples.sort.to_a))
+      File.write(file_name, JSON.pretty_generate(@reporter.pending_examples.sort.to_a), encoding: 'UTF-8')
     end
 
     def write_skipped_examples_report
       file_name = File.join(@cache_dir, 'skipped_examples.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.skipped_examples.sort.to_a))
+      File.write(file_name, JSON.pretty_generate(@reporter.skipped_examples.sort.to_a), encoding: 'UTF-8')
     end
 
     def write_all_files_report
       file_name = File.join(@cache_dir, 'all_files.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.all_files))
+      File.write(file_name, JSON.pretty_generate(@reporter.all_files), encoding: 'UTF-8')
     end
 
     def write_dependency_report
       file_name = File.join(@cache_dir, 'dependency.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.dependency))
+      File.write(file_name, JSON.pretty_generate(@reporter.dependency), encoding: 'UTF-8')
     end
 
     def write_reverse_dependency_report
       file_name = File.join(@cache_dir, 'reverse_dependency.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.reverse_dependency))
+      File.write(file_name, JSON.pretty_generate(@reporter.reverse_dependency), encoding: 'UTF-8')
     end
 
     def write_examples_coverage_report
       file_name = File.join(@cache_dir, 'examples_coverage.json')
 
-      File.write(file_name, JSON.pretty_generate(@reporter.examples_coverage))
+      File.write(file_name, JSON.pretty_generate(@reporter.examples_coverage), encoding: 'UTF-8')
     end
 
     def write_last_run_report
       file_name = File.join(@report_dir, 'last_run.json')
       last_run_data = @reporter.last_run.merge(run_id: @run_id, timestamp: Time.now.utc)
 
-      File.write(file_name, JSON.pretty_generate(last_run_data))
+      File.write(file_name, JSON.pretty_generate(last_run_data), encoding: 'UTF-8')
     end
   end
 end

--- a/lib/rspec_tracer/source_file.rb
+++ b/lib/rspec_tracer/source_file.rb
@@ -12,7 +12,7 @@ module RSpecTracer
       {
         file_path: file_path,
         file_name: file_name(file_path),
-        digest: Digest::MD5.hexdigest(File.read(file_path))
+        digest: Digest::MD5.hexdigest(File.binread(file_path))
       }
     end
 

--- a/spec/lib/rspec_tracer/cache_spec.rb
+++ b/spec/lib/rspec_tracer/cache_spec.rb
@@ -45,5 +45,47 @@ RSpec.describe RSpecTracer::Cache do
         expect(cache.instance_variable_get(:@examples_coverage)).not_to be_nil
       end
     end
+
+    # Regression guard: cache JSON files contain UTF-8 bytes whenever a
+    # spec description uses a non-ASCII character (e.g. the KNOWN_ISSUES
+    # "§B5" reference). Without an explicit `encoding: 'UTF-8'` on the
+    # File.read, a shell with `LANG=` unset makes Ruby default to
+    # US-ASCII and the read raises Encoding::InvalidByteSequenceError on
+    # the first xC2 byte, taking spec_helper down before any example runs.
+    context 'when the cache JSON contains UTF-8 bytes under a US-ASCII default external' do
+      let(:run_id) { 'utf8abc' }
+      let(:utf8_key) { "example with \u00A7" }
+
+      around do |example|
+        original_external = Encoding.default_external
+        original_verbose = $VERBOSE
+        $VERBOSE = nil
+        Encoding.default_external = Encoding::US_ASCII
+        example.run
+      ensure
+        Encoding.default_external = original_external
+        $VERBOSE = original_verbose
+      end
+
+      before do
+        File.write(File.join(tmp, 'last_run.json'), JSON.dump('run_id' => run_id), encoding: 'UTF-8')
+        run_dir = File.join(tmp, run_id)
+        Dir.mkdir(run_dir)
+        File.write(
+          File.join(run_dir, 'examples_coverage.json'),
+          JSON.dump(utf8_key => { '/lib/foo.rb' => [1, 0, 1] }),
+          encoding: 'UTF-8'
+        )
+        allow(RSpecTracer).to receive_messages(cache_path: tmp, parallel_tests?: false)
+      end
+
+      it 'reads the cache without raising Encoding::InvalidByteSequenceError' do
+        expect { cache.cached_examples_coverage }.not_to raise_error
+      end
+
+      it 'preserves UTF-8 keys through the JSON round-trip' do
+        expect(cache.cached_examples_coverage).to have_key(utf8_key)
+      end
+    end
   end
 end

--- a/spec/lib/rspec_tracer/source_file_spec.rb
+++ b/spec/lib/rspec_tracer/source_file_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+
+RSpec.describe RSpecTracer::SourceFile do
+  describe '.from_path' do
+    let(:tmp) { Dir.mktmpdir }
+
+    after { FileUtils.remove_entry(tmp) if File.directory?(tmp) }
+
+    # File.binread bypasses external-encoding transcoding and returns
+    # raw bytes; Digest::MD5 hashes the byte content. Without binread,
+    # a source file containing UTF-8 (helpers with inline Unicode, spec
+    # files referencing "\u00A7") would crash on `LANG=`-unset shells
+    # where Encoding.default_external resolves to US-ASCII.
+    context 'when the source file contains UTF-8 bytes under US-ASCII default external' do
+      let(:path) { File.join(tmp, 'unicode.rb') }
+      let(:content) { "# KNOWN_ISSUES \u00A7B5\n" }
+
+      around do |example|
+        original_external = Encoding.default_external
+        original_verbose = $VERBOSE
+        $VERBOSE = nil
+        Encoding.default_external = Encoding::US_ASCII
+        example.run
+      ensure
+        Encoding.default_external = original_external
+        $VERBOSE = original_verbose
+      end
+
+      before { File.write(path, content, encoding: 'UTF-8') }
+
+      it 'digests the file without raising' do
+        expect { described_class.from_path(path) }.not_to raise_error
+      end
+
+      it 'returns a digest over the raw UTF-8 bytes' do
+        expected = Digest::MD5.hexdigest(content.b)
+
+        expect(described_class.from_path(path)[:digest]).to eq(expected)
+      end
+
+      it 'remains byte-identical to the digest under a UTF-8 default external' do
+        digest_us_ascii = described_class.from_path(path)[:digest]
+
+        Encoding.default_external = Encoding::UTF_8
+        digest_utf8 = described_class.from_path(path)[:digest]
+
+        expect(digest_us_ascii).to eq(digest_utf8)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Legacy cache/report/coverage paths call `File.read` and `File.write` without an explicit encoding. Ruby falls back to `Encoding.default_external`, which resolves to `US-ASCII` on macOS shells launched without `LANG` set (the GUI-terminal default).
- Any spec description containing a non-ASCII character — the existing suite has one at `spec/tracker/new_file_detector_spec.rb` (`KNOWN_ISSUES §B5`) — writes UTF-8 bytes into `all_examples.json`. The next warm run on the same machine crashes at `Cache#load_all_examples_cache:109` with `Encoding::InvalidByteSequenceError: \"\\xC2\" on US-ASCII`, taking the whole `spec_helper` down before any example runs.
- Every legacy `File.read` / `File.write` of JSON / ERB / Ruby source now pins `encoding: 'UTF-8'` (matching the `Storage::JsonBackend` convention). `SourceFile.from_path` switches to `File.binread` since its MD5 digest operates on raw bytes — transcoding buys nothing and crashes on non-ASCII under `LANG=`-empty shells.
- Regression tests in `spec/lib/rspec_tracer/cache_spec.rb` and the new `spec/lib/rspec_tracer/source_file_spec.rb` pin `Encoding.default_external = Encoding::US_ASCII` inside an `around` hook and assert the round-trips succeed.

## Files touched (13)

**Reads (JSON, ERB, Ruby source) — now `encoding: 'UTF-8'`:**
- `lib/rspec_tracer/cache.rb` (11 call sites)
- `lib/rspec_tracer.rb:395` (`last_run.json` during parallel_tests merge)
- `lib/rspec_tracer/report_merger.rb:60`
- `lib/rspec_tracer/remote_cache/cache.rb:71`
- `lib/rspec_tracer/remote_cache/repo.rb:172`
- `lib/rspec_tracer/coverage_merger.rb:17`
- `lib/rspec_tracer/coverage_reporter.rb:168` (JRuby source parse)
- `lib/rspec_tracer/html_reporter/reporter.rb:214` (ERB templates)

**Writes (JSON) — now `encoding: 'UTF-8'`:**
- `lib/rspec_tracer/report_writer.rb` (12 call sites)
- `lib/rspec_tracer/coverage_writer.rb:18`
- `lib/rspec_tracer/remote_cache/cache.rb:63`

**Digest (raw bytes):**
- `lib/rspec_tracer/source_file.rb:15` — `File.read` → `File.binread`.

## Test plan
- [x] Reproduced locally under `unset LANG LC_ALL LC_CTYPE` — cold + warm `task test:unit` both pass (previously warm crashed on the `\\xC2` byte).
- [x] `task lint:ruby` / `lint:actions` / `lint:yaml` — clean.
- [x] `task check:bundle` — satisfied.
- [x] `task security:bundle-audit` — 0 vulnerabilities. `task security:trivy` exits 0 (pre-existing activestorage CVEs in the Rails fixture bundle, flagged in prior handoffs).
- [x] `task test:unit` — 562 examples, 0 failures (5 new regression tests added).
- [x] `task test:property` — 23 examples.
- [x] `task test:mutation:smoke` — all 11 subjects at or above the 90% gate.
- [x] `task test:dogfood` — legacy + v2 both green.
- [x] `task test:integration` — 18 examples.
- [x] `task benchmark:smoke` — all 5 scenarios within ratchet (no regression; the encoding kwarg is a constant-time path).

## Why `File.binread` for the digest
`Digest::MD5.hexdigest` operates on bytes. Calling `File.read` under a US-ASCII external encoding attempts to transcode UTF-8 bytes into US-ASCII before handing the string to MD5 — which fails with `InvalidByteSequenceError`, never reaching the digest. `File.binread` returns raw bytes unmodified, producing a digest that is (a) identical to the prior UTF-8-env behavior for ASCII and valid-UTF-8 files, (b) stable regardless of the process locale, and (c) cannot crash on non-ASCII content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)