### PR TITLE
fix(parallel_tests): elect merge worker deterministically (v1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.1.1] - 2026-04-23
+
+### Fixed
+
+- **parallel_tests at-exit deadlock** — `parallel_tests_last_process?`
+  relied on a lock file written during `RSpecTracer.start` to identify
+  the last worker. If a fast worker reached `at_exit` before a slower
+  peer had loaded `spec_helper` and registered its `TEST_ENV_NUMBER`,
+  both workers could self-elect as the last process, both entered
+  `::ParallelTests.wait_for_other_processes_to_finish`, and deadlocked
+  on each other's pid. The elector now delegates to
+  `::ParallelTests.first_process?`, which reads immutable env vars set
+  by the parent at worker spawn. Exactly one worker is elected per run,
+  regardless of boot-time ordering or runner CPU count. No public-API
+  change — the `rspec_tracer.lock` file is still written and cleaned
+  up, just no longer consulted.
+
 ## [1.1.0] - 2026-04-20
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-tracer (1.1.0)
+    rspec-tracer (1.1.1)
       docile (~> 1.4)
       rspec-core (~> 3.12)
 

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -416,18 +416,47 @@ module RSpecTracer
       true
     end
 
+    # Elects the worker that performs the per-run merge. Delegates to
+    # `::ParallelTests.first_process?`, which returns true iff
+    # `TEST_ENV_NUMBER.to_i <= 1` — i.e. for exactly one worker
+    # (TEST_ENV_NUMBER == '' or '1'), regardless of how many workers
+    # were actually spawned vs. how many CPUs the runner reports.
+    #
+    # Two previously attempted approaches do NOT work here:
+    #
+    #   1. The lock-file scheme below (each worker writing its
+    #      TEST_ENV_NUMBER to `rspec_tracer.lock` via
+    #      `track_parallel_tests_test_env_number`; last_process picked
+    #      the max) deadlocked under slow CI: worker 1 could finish
+    #      its examples before worker 2 even loaded spec_helper,
+    #      observe itself as the max, and enter
+    #      `::ParallelTests.wait_for_other_processes_to_finish`
+    #      concurrently with worker 2's own self-election — both
+    #      workers then spun on each other's pid.
+    #
+    #   2. `::ParallelTests.last_process?` compares TEST_ENV_NUMBER
+    #      against PARALLEL_TEST_GROUPS, which parallel_rspec sets to
+    #      the CPU-based *intended* process count — NOT the actual
+    #      worker count. When spec files < CPU count (common), no
+    #      TEST_ENV_NUMBER ever matches PARALLEL_TEST_GROUPS and the
+    #      merge is silently skipped.
+    #
+    # `first_process?` avoids both: set by the parent at spawn,
+    # immutable thereafter, and identifies exactly one worker
+    # regardless of CPU count. The elected worker still calls
+    # `wait_for_other_processes_to_finish` before merging so peer
+    # caches are guaranteed on disk.
+    #
+    # `track_parallel_tests_test_env_number` and the lock-file
+    # cleanup in `at_exit_behavior` are retained for backward
+    # compatibility with users who observe `rspec_tracer.lock` /
+    # set `RSPEC_TRACER_LOCK_FILE`; the file is still written and
+    # removed but is no longer consulted.
     def parallel_tests_last_process?
       return false unless parallel_tests?
+      return false unless defined?(::ParallelTests)
 
-      max_test_num = 0
-
-      File.open(RSpecTracer.lock_file, 'r') do |f|
-        f.flock(File::LOCK_SH)
-
-        max_test_num = f.read.to_i
-      end
-
-      ENV['TEST_ENV_NUMBER'].to_i == max_test_num
+      ::ParallelTests.first_process?
     end
   end
 end

--- a/lib/rspec_tracer/version.rb
+++ b/lib/rspec_tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RSpecTracer
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
## Summary

Back-ports the parallel_tests at-exit deadlock fix to the 1.x line + bumps to v1.1.1.

Root cause: \`parallel_tests_last_process?\` relied on a lock file written during \`RSpecTracer.start\` to identify the last worker. Under slow CI (observed at ~70% rate on GitHub Actions ubuntu-latest ruby-parallel matrix during [PR #100](https://github.com/avmnu-sng/rspec-tracer/pull/100)'s investigation), a fast worker could finish all its examples and reach \`at_exit\` before a slower peer had loaded \`spec_helper\` and registered its \`TEST_ENV_NUMBER\` in the lock file. Both workers then self-elected as last process, both entered \`::ParallelTests.wait_for_other_processes_to_finish\`, and deadlocked on each other's pid.

The fix delegates election to \`::ParallelTests.first_process?\` — reads immutable \`TEST_ENV_NUMBER\` set by the parent at worker spawn, so election is race-free. Exactly one worker per run is elected regardless of boot-time ordering or CPU count. The elected worker still calls \`wait_for_other_processes_to_finish\` before merging, so peer caches are guaranteed on disk.

## What's in this PR

- \`lib/rspec_tracer.rb\` — \`parallel_tests_last_process?\` body swapped to \`::ParallelTests.first_process?\`. \`track_parallel_tests_test_env_number\` and \`rspec_tracer.lock\` cleanup retained intact (now vestigial — no public-API change).
- \`lib/rspec_tracer/version.rb\` — bump to \`1.1.1\`.
- \`CHANGELOG.md\` — new \`[1.1.1]\` entry.

## Why not \`::ParallelTests.last_process?\`

parallel_tests' own \`last_process?\` compares \`TEST_ENV_NUMBER\` to \`PARALLEL_TEST_GROUPS\`, which parallel_rspec sets to the CPU-based intended process count — not the actual worker count. When spec files < CPU count, no \`TEST_ENV_NUMBER\` matches and the merge is silently skipped. The \`first_process?\` API does not have this problem.

## Test plan

- [x] \`bundle exec rspec\` — 47/47 pass locally
- [x] \`bundle exec rubocop\` — clean
- [ ] CI matrix on this PR
- [ ] After merge: tag \`v1.1.1\` on the merge commit → release workflow publishes to rubygems

🤖 Generated with [Claude Code](https://claude.com/claude-code)