### PR TITLE
feat(dsl): per-example metadata DSL for declared tracking

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --require spec_helper
 --format documentation
---exclude-pattern "spec/fixtures/**/*_spec.rb,spec/integration/rails_app_spec.rb,spec/integration/parallel_tests_spec.rb"
+--exclude-pattern "spec/fixtures/**/*_spec.rb,spec/integration/rails_app_spec.rb,spec/integration/parallel_tests_spec.rb,spec/integration/per_example_dsl_spec.rb"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -208,11 +208,11 @@ tasks:
 
   test:mutation:smoke:
     desc: >-
-      Mutation smoke — 12 subjects (TimeFormatter.format_time, Tracker::Input,
+      Mutation smoke — 13 subjects (TimeFormatter.format_time, Tracker::Input,
       Tracker::DeclaredGlobs, Tracker::WholeSuiteInvalidators, Storage::Schema,
       Storage::Snapshot, Storage::Backend, Tracker::DependencyGraph,
       Tracker::ExampleRegistry, Tracker::Filter, Tracker::LoadedFilesTracker,
-      Rails::Preset) must each hit >= 90% (< 2 min budget)
+      Rails::Preset, Tracker::EnvSnapshot) must each hit >= 90% (< 2 min budget)
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -285,6 +285,9 @@ tasks:
         run_mutant_subject "Rails::Preset" \
           "rspec_tracer/rails/preset" \
           "RSpecTracer::Rails::Preset*" || fail=1
+        run_mutant_subject "Tracker::EnvSnapshot" \
+          "rspec_tracer/tracker/env_snapshot" \
+          "RSpecTracer::Tracker::EnvSnapshot*" || fail=1
         # Rails::Notifications deferred to M8.3 - the subscribe-side
         # surface (ActiveSupport::Notifications stubs + thread-local
         # bucket lifecycle) yields a large population of alive
@@ -356,6 +359,15 @@ tasks:
       The CI `rails` job invokes this per Rails matrix cell.
     cmds:
       - bundle exec rspec --no-color spec/integration/rails_app_spec.rb
+
+  test:integration:per-example-dsl:
+    desc: >-
+      M5.2 per-example tracks DSL integration test. Drives the Rails fixture
+      with a feature_flags_spec annotated with tracks: { env: ... }, cold/warm
+      with the tracked env flipped, asserts only the env-branch examples
+      re-run. Excluded from the default rspec sweep (subprocess, ~45s).
+    cmds:
+      - bundle exec rspec --no-color spec/integration/per_example_dsl_spec.rb
 
   test:features:jruby:
     desc: >-

--- a/benchmark/fixtures/ruby_app/spec/calculator_spec.rb
+++ b/benchmark/fixtures/ruby_app/spec/calculator_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-RSpec.describe Calculator do
+# M5.2 benchmark: annotate one describe block with `tracks: { env: ... }`
+# so the env-snapshot code path is exercised by every benchmark scenario
+# that runs this fixture. Holds the steady-state env-tracking overhead
+# on the benchmark ratchet so regressions show up during `task benchmark:*`.
+RSpec.describe Calculator, tracks: { env: 'RSPEC_TRACER_BENCH_ENV' } do
   subject(:calc) { described_class.new }
 
   it { expect(calc.add(2, 3)).to eq(5) }

--- a/benchmark/harness.rb
+++ b/benchmark/harness.rb
@@ -66,6 +66,22 @@ module BenchmarkHarness
       warmup: ->(cwd) { run_rspec_once(cwd, {}) },
       smoke: true
     },
+    'warm_env_mismatch' => {
+      # M5.2 env-snapshot mismatch: warmup primes the cache with the
+      # tracked env = 'baseline'; iterations run with the tracked env
+      # flipped to 'changed', which forces the env-annotated describe
+      # block (Calculator in calculator_spec.rb) through the env_changed
+      # filter path. First iteration hits the re-run path; subsequent
+      # iterations see env match the last cached value and fall back to
+      # warm_noop. Scenario pinned to smoke:false so `task check`
+      # stays under its fast-feedback budget.
+      desc: 'Warm run with env_snapshot mismatch on the first iteration (M5.2 overhead floor)',
+      cwd: RUBY_FIXTURE,
+      cmd: %w[bundle exec rspec --no-color],
+      env: { 'RSPEC_TRACER_BENCH_ENV' => 'changed' },
+      warmup: ->(cwd) { run_rspec_once(cwd, { 'RSPEC_TRACER_BENCH_ENV' => 'baseline' }) },
+      smoke: false
+    },
     'parallel_tests_2_workers' => {
       desc: 'parallel_tests with 2 workers, cold: worker split + merge at exit',
       cwd: RUBY_FIXTURE,

--- a/benchmark/ratchet.json
+++ b/benchmark/ratchet.json
@@ -5,42 +5,47 @@
     "os": "darwin24",
     "cpu": "Apple M2 Max",
     "cores": 12,
-    "recorded_at": "2026-04-22T00:00:00Z"
+    "recorded_at": "2026-04-22T21:13:41Z"
   },
   "scenarios": {
     "cold_ruby": {
-      "p50": 0.254,
-      "p95": 0.259,
-      "iterations": 5
+      "p50": 0.2455,
+      "p95": 0.2716,
+      "iterations": 10
     },
     "warm_noop": {
-      "p50": 0.248,
-      "p95": 0.252,
-      "iterations": 5
+      "p50": 0.2296,
+      "p95": 0.2446,
+      "iterations": 10
+    },
+    "warm_env_mismatch": {
+      "p50": 0.228,
+      "p95": 0.2296,
+      "iterations": 10
     },
     "parallel_tests_2_workers": {
-      "p50": 1.25,
-      "p95": 1.45,
-      "iterations": 5
+      "p50": 1.459,
+      "p95": 1.5059,
+      "iterations": 10
     },
     "cold_rails": {
-      "p50": 2.938,
-      "p95": 3.566,
-      "iterations": 5
+      "p50": 2.8459,
+      "p95": 3.4042,
+      "iterations": 10
     },
     "coverage_adapter": {
-      "p50": 2.5691,
-      "p95": 2.6305,
+      "p50": 2.4751,
+      "p95": 2.5077,
       "iterations": 10
     },
     "file_read_hook": {
-      "p50": 8.1492,
-      "p95": 8.3206,
+      "p50": 7.5968,
+      "p95": 7.9102,
       "iterations": 10
     },
     "loaded_files_tracker": {
-      "p50": 1.84,
-      "p95": 1.93,
+      "p50": 1.8274,
+      "p95": 1.852,
       "iterations": 10
     }
   }

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -8,6 +8,7 @@ require 'set'
 require_relative 'tracker/coverage_adapter'
 require_relative 'tracker/declared_globs'
 require_relative 'tracker/dependency_graph'
+require_relative 'tracker/env_snapshot'
 require_relative 'tracker/example_registry'
 require_relative 'tracker/filter'
 require_relative 'tracker/input'
@@ -74,7 +75,8 @@ module RSpecTracer
       failed_example: 'Failed previously',
       pending_example: 'Pending previously',
       files_changed: 'Files changed',
-      whole_suite_invalidator: 'Whole-suite invalidator changed'
+      whole_suite_invalidator: 'Whole-suite invalidator changed',
+      env_changed: 'Environment changed'
     }.freeze
 
     # Map from Filter#select reasons to the legacy-shaped strings
@@ -87,12 +89,13 @@ module RSpecTracer
       failed_example: EXAMPLE_RUN_REASON[:failed_example],
       pending_example: EXAMPLE_RUN_REASON[:pending_example],
       no_cache: EXAMPLE_RUN_REASON[:no_cache],
-      files_changed: EXAMPLE_RUN_REASON[:files_changed]
+      files_changed: EXAMPLE_RUN_REASON[:files_changed],
+      env_changed: EXAMPLE_RUN_REASON[:env_changed]
     }.freeze
 
     attr_reader :registry, :graph, :loaded_files_tracker, :coverage_adapter,
                 :declared_globs, :whole_suite_invalidators, :new_file_detector,
-                :storage_backend, :all_examples, :duplicate_examples,
+                :env_snapshot, :storage_backend, :all_examples, :duplicate_examples,
                 :examples_coverage, :all_files
 
     def initialize(configuration: RSpecTracer)
@@ -102,6 +105,9 @@ module RSpecTracer
       @duplicate_examples = {}
       @examples_coverage = {}
       @all_files = {}
+      @tracks_files = Hash.new { |h, id| h[id] = Set.new } # id => Set<abs_path>
+      @tracks_env = Hash.new { |h, id| h[id] = Set.new }   # id => Set<env_name>
+      @tracked_env_names = Set.new
       @previous_snapshot = nil
       @run_id = nil
       @before_peek = nil
@@ -148,6 +154,57 @@ module RSpecTracer
       self
     end
 
+    # M5.2 per-example tracking DSL hook. Called from RunnerHook with
+    # the normalized `{files: Set<String>, env: Set<String>}` that
+    # `RSpec::Metadata.tracks_for(example)` produced. Resolves the
+    # file globs against the project root once per distinct glob
+    # string (memoized) and unions the matching Inputs into this
+    # example's dependency set. Env names are accumulated into
+    # `@tracked_env_names` so the finalize snapshot covers every key
+    # the run cared about.
+    # rubocop:disable Metrics/PerceivedComplexity
+    def register_tracks(example_id, tracks)
+      files = tracks[:files] || tracks['files'] || Set.new
+      envs = tracks[:env] || tracks['env'] || Set.new
+
+      files.each { |glob| @tracks_files[example_id].merge(resolved_glob_inputs(glob)) } unless files.empty?
+      return self if envs.empty?
+
+      envs_strs = envs.map(&:to_s)
+      @tracks_env[example_id].merge(envs_strs)
+      @tracked_env_names.merge(envs_strs)
+      self
+    end
+    # rubocop:enable Metrics/PerceivedComplexity
+
+    # M5.2. Called from RunnerHook AFTER the filter-decision pre-walk
+    # has populated `@tracks_env` / `@tracked_env_names` for every
+    # example. Compares each declared env key against the previous
+    # snapshot's `env_snapshot` via Tracker::EnvSnapshot; marks any
+    # example whose tracked-env set intersects the invalidated set
+    # as re-runnable. Strictly additive vs other filter reasons -
+    # if the example was already in `@filtered_examples` for a
+    # stronger reason (files_changed / whole_suite_invalidator /
+    # failed_example / ...), env_changed does NOT overwrite.
+    def apply_env_filter_decisions
+      return self if @previous_snapshot.nil?
+      return self if @tracked_env_names.empty?
+
+      invalidated = @env_snapshot.invalidated_keys(
+        @previous_snapshot.env_snapshot, @tracked_env_names
+      )
+      return self if invalidated.empty?
+
+      reason = FILTER_REASON_STRINGS.fetch(:env_changed)
+      @tracks_env.each do |example_id, envs|
+        next unless envs.intersect?(invalidated)
+        next if @filtered_examples.key?(example_id)
+
+        @filtered_examples[example_id] = reason
+      end
+      self
+    end
+
     def deregister_duplicate_examples
       @duplicate_examples.select! { |_, entries| entries.count > 1 }
       return if @duplicate_examples.empty?
@@ -179,9 +236,11 @@ module RSpecTracer
         @loaded_files_tracker.stop_example(example_id)
       coverage_inputs = @coverage_adapter.compute_diff(@before_peek, after_peek)
       declared_inputs = @declared_globs.walk
+      tracks_inputs = per_example_tracks_inputs(example_id)
       attribute_to_example(
         example_id,
-        coverage_inputs | transitive_inputs | io_inputs.to_set | rails_inputs.to_set | declared_inputs
+        coverage_inputs | transitive_inputs | io_inputs.to_set |
+          rails_inputs.to_set | declared_inputs | tracks_inputs
       )
 
       @before_peek = nil
@@ -282,6 +341,7 @@ module RSpecTracer
       @whole_suite_invalidators = RSpecTracer::Tracker::WholeSuiteInvalidators.new(
         root: @configuration.root
       )
+      @env_snapshot = RSpecTracer::Tracker::EnvSnapshot.new
       @new_file_detector = RSpecTracer::Tracker::NewFileDetector.new(
         root: @configuration.root, declared_globs: @configuration.declared_globs
       )
@@ -632,8 +692,63 @@ module RSpecTracer
         reverse_dependency: reverse_dependency_by_name,
         examples_coverage: @examples_coverage,
         boot_set: @loaded_files_tracker.boot_set_digest_snapshot,
-        wsi_snapshot: @whole_suite_invalidators.digest_snapshot
+        wsi_snapshot: @whole_suite_invalidators.digest_snapshot,
+        env_snapshot: env_snapshot_for_persistence
       )
+    end
+
+    # Snapshot only the env keys THIS run tracked - persisting keys
+    # that stopped being tracked (user removed `tracks: env: ...`
+    # between runs) would pin stale digests in the cache. Missing
+    # keys on the next load just trigger a one-time re-run for any
+    # example that reintroduces them, which is the correct behavior.
+    def env_snapshot_for_persistence
+      return {} if @env_snapshot.nil? || @tracked_env_names.empty?
+
+      @env_snapshot.digest_snapshot(@tracked_env_names)
+    end
+
+    # Resolve one glob against the project root into a Set of
+    # `:declared`-kind Inputs. Walks via Dir.glob
+    # (FNM_PATHNAME+FNM_EXTGLOB like DeclaredGlobs so user muscle
+    # memory works identically) and digests each hit with SHA256.
+    # Unreadable files are skipped silently - graceful degradation.
+    # Memoized per distinct glob string so N examples declaring the
+    # same glob pay the filesystem walk cost exactly once.
+    def resolved_glob_inputs(glob)
+      @resolved_glob_cache ||= {}
+      @resolved_glob_cache[glob] ||= walk_one_glob(glob)
+    end
+
+    def walk_one_glob(glob)
+      inputs = Set.new
+      root = @configuration.root
+      Dir.glob(glob, File::FNM_PATHNAME | File::FNM_EXTGLOB, base: root).each do |rel|
+        abs = File.expand_path(rel, root)
+        next unless abs.start_with?("#{root}/") && File.file?(abs)
+
+        digest = tracks_file_digest(abs)
+        next if digest.nil?
+
+        inputs << RSpecTracer::Tracker::Input.for_file(
+          path: abs, kind: :declared, digest: digest, root: root
+        )
+      end
+      inputs
+    end
+
+    def tracks_file_digest(path)
+      Digest::SHA256.file(path).hexdigest
+    rescue SystemCallError
+      nil
+    end
+
+    # Materialize the per-example tracks-file Input set. Returns an
+    # empty Set when the example has no `tracks: files:` metadata,
+    # keeping the downstream union cheap for the 99% case.
+    def per_example_tracks_inputs(example_id)
+      set = @tracks_files[example_id]
+      set.nil? || set.empty? ? Set.new : set.dup
     end
 
     def duplicates_for_snapshot

--- a/lib/rspec_tracer/rspec/README.md
+++ b/lib/rspec_tracer/rspec/README.md
@@ -6,9 +6,10 @@ responsibility.
 | File | Role |
 |------|------|
 | [`installation.rb`](installation.rb) | Prepends `RunnerHook` + `ReporterHook` onto `RSpec::Core::Runner` / `RSpec::Core::Reporter`. Idempotent. Called once from `RSpecTracer.start`. |
-| [`runner_hook.rb`](runner_hook.rb) | Overrides `run_specs`. Partitions `RSpec.world.filtered_examples` into tracked + ignored, asks `Engine#run_example?` for filter decisions, mutates `RSpec.world` to the filtered set, logs the `RSpec tracer is running N examples` banner. |
+| [`runner_hook.rb`](runner_hook.rb) | Overrides `run_specs`. Two-pass filter walk: Pass 1 reads `tracks:` metadata + registers per-example glob/env declarations on the engine; Pass 2 asks `Engine#run_example?` for filter decisions. Mutates `RSpec.world` to the filtered set, logs the `RSpec tracer is running N examples` banner. |
 | [`reporter_hook.rb`](reporter_hook.rb) | Overrides `example_started`, `example_finished`, `example_passed`, `example_failed`, `example_pending`. Forwards into `Engine` + `CoverageReporter` so dependency attribution + coverage.json emission stay synchronized. |
 | [`parallel_tests.rb`](parallel_tests.rb) | `TEST_ENV_NUMBER` + `PARALLEL_TEST_GROUPS` detection, `rspec_tracer.lock` lifecycle, narrator selection for log silencing, last-process merge via `Storage::JsonBackend#merge_from_peers`. |
+| [`metadata.rb`](metadata.rb) | Per-example `tracks:` DSL walker. Reads `tracks: { files: ..., env: ... }` off an example plus every ancestor group, unions the entries (RSpec's default metadata cascade would clobber on shared keys), and returns the merged `{ files:, env: }` for RunnerHook to register with the engine. |
 
 ## Load-order contract
 
@@ -45,6 +46,28 @@ from now on".
 
 ## Per-example metadata DSL (M5.2)
 
-`metadata.rb` is not yet present. It lands with M5.2 to parse
-`tracks: { files: '...', env: 'API_KEY' }` metadata and route it into
-`Tracker::DeclaredGlobs` per-example attribution.
+Annotate a describe / context / example with `tracks: { files: ..., env: ... }`
+to declare additional dependencies that Coverage + IO observation cannot see:
+
+```ruby
+describe 'AdminController',
+         tracks: { files: 'app/policies/**/*.rb', env: 'ROLE_CONFIG' } do
+  it 'gates on the feature flag' do
+    expect(enabled?).to be(true)
+  end
+end
+```
+
+Both keys accept a String glob / env name OR an Array of them. Nested groups
+contribute additively — a child group declaring `tracks: { env: 'X' }` does
+NOT clobber an ancestor's `tracks: { files: 'Y' }`; both contribute to the
+example's dependency set.
+
+Internally: `Metadata.tracks_for(example)` walks `example.example_group
+.parent_groups` plus the example itself and returns the union. `RunnerHook`
+hands that to `Engine#register_tracks`, which resolves file globs to
+`:declared`-kind Inputs and accumulates the env names for the finalize-time
+`env_snapshot.json` write. Warm runs compare the previous run's env_snapshot
+to the current ENV via `Tracker::EnvSnapshot#invalidated_keys` and mark any
+example whose tracked env key drifted as re-runnable
+(`EXAMPLE_RUN_REASON[:env_changed] => "Environment changed"`).

--- a/lib/rspec_tracer/rspec/metadata.rb
+++ b/lib/rspec_tracer/rspec/metadata.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'set'
+
+module RSpecTracer
+  module RSpec
+    # M5.2 per-example tracking DSL. Reads the `tracks:` metadata key
+    # off an example and its ancestor example groups and emits a
+    # normalized union of declared file globs + env-var names.
+    #
+    # DSL shape (user-facing):
+    #
+    #   RSpec.describe 'AdminController',
+    #                  tracks: { files: 'app/policies/**/*.rb', env: 'ROLE_CONFIG' } do
+    #     ...
+    #   end
+    #
+    # Values for `:files` and `:env` accept either a single String or
+    # an Array of Strings. Nested groups each contribute their own
+    # tracks hash; the union (not the replace) is what the example
+    # inherits. RSpec's built-in metadata cascade uses Hash#merge
+    # which would clobber a parent `tracks:` with a child `tracks:`
+    # on a shared key - almost never the user's intent. `tracks_for`
+    # bypasses the auto-cascade and walks ancestors explicitly.
+    #
+    # Returns `{ files: Set<String>, env: Set<String> }`. Empty sets
+    # when nothing is declared - callers can short-circuit on
+    # `result[:files].empty? && result[:env].empty?` to skip the
+    # attribution/env-snapshot plumbing.
+    #
+    # Pure-function (module-level, no state). Safe to call from the
+    # RunnerHook filter loop without synchronization.
+    module Metadata
+      TRACKS_KEY = :tracks
+      FILES_KEY = :files
+      ENV_KEY = :env
+
+      # Keep methods module-level via `def self.x` (not module_function)
+      # so mutant can observe them - module_function attaches the
+      # methods to an anonymous singleton that Method#source_location
+      # can't trace (memory: feedback_mutation_friendly_modules).
+      def self.tracks_for(example)
+        files = Set.new
+        envs = Set.new
+
+        collect(example.example_group.parent_groups, files, envs)
+        merge_hash(example.metadata[TRACKS_KEY], files, envs)
+
+        { FILES_KEY => files, ENV_KEY => envs }
+      end
+
+      # parent_groups returns outer-first. Walk from outer to inner so
+      # the set-union is order-agnostic anyway; the order is
+      # documented for future readers who need it deterministic.
+      def self.collect(parent_groups, files, envs)
+        parent_groups.reverse_each do |group|
+          merge_hash(group.metadata[TRACKS_KEY], files, envs)
+        end
+      end
+
+      # A `tracks:` value of nil, non-Hash, or an empty Hash contributes
+      # nothing. Non-Hash values are silently ignored - tolerating
+      # user typos over raising is consistent with the rest of the
+      # DSL surface (add_filter, coverage_track_files).
+      def self.merge_hash(tracks, files, envs)
+        return unless tracks.is_a?(Hash)
+
+        normalize(tracks[FILES_KEY]).each { |v| files << v }
+        normalize(tracks[ENV_KEY]).each { |v| envs << v }
+      end
+
+      # String -> [String]; Array -> itself; anything else -> []. nil,
+      # empty-string, and blank values are filtered so
+      # `tracks: { files: '', env: nil }` doesn't inject empty entries
+      # into the attribution set.
+      def self.normalize(value)
+        case value
+        when String
+          value.empty? ? [] : [value]
+        when Array
+          value.map(&:to_s).reject(&:empty?)
+        else
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/rspec/runner_hook.rb
+++ b/lib/rspec_tracer/rspec/runner_hook.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'metadata'
+
 module RSpecTracer
   module RSpec
     # Prepended onto `RSpec::Core::Runner` by
@@ -72,24 +74,35 @@ module RSpecTracer
         RSpecTracer.no_examples = true
       end
 
-      # Walk RSpec.world.filtered_examples once. For each example, either:
-      #   - ignored (matches Configuration#ignore_spec_files): pass straight
-      #     through; RSpec runs it, engine never sees it, so no identity
-      #     hash is computed, no duplicate detection, no filter decision
-      #     contributes to its state.
-      #   - tracked: build a tracer-example, tag metadata with the id, and
-      #     ask the engine whether to run. Skip-decisions go to
-      #     Engine#on_example_skipped so the skipped_examples snapshot
-      #     entry persists across warm runs (M4.3 fix #2).
+      # Two-pass filter-decision walk over RSpec.world.filtered_examples.
       #
-      # The loop body is cohesive - splitting it for ABC/MethodLength
-      # would scatter the one-pass filter decision across unrelated
-      # private helpers.
+      # Pass 1 pre-walks every tracked example to compute its identity
+      # hash (Example.from) and register the `tracks:` metadata via
+      # `Engine#register_tracks`. This must complete for every
+      # example before ANY `run_example?` call because the env-
+      # invalidation pass (`Engine#apply_env_filter_decisions`) needs
+      # the full set of tracked env names to classify which examples
+      # re-run. Caching the tracer-example per example.object_id
+      # avoids a second MD5 in Pass 2.
+      #
+      # Between passes, `apply_env_filter_decisions` unions the
+      # env-changed decisions into @filtered_examples so Pass 2's
+      # `run_example?` sees them alongside the file-change decisions
+      # computed at Engine.setup time.
+      #
+      # Pass 2 makes the actual run/skip decisions and tags metadata.
+      # Ignored spec files (Configuration#ignore_spec_files) are
+      # handled in Pass 2 and skip both passes' engine surface -
+      # RSpec still runs them, the tracer never sees them.
       # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       def _rspec_tracer_build_filter_decision
         to_run = Hash.new { |hash, group| hash[group] = [] }
         groups = Set.new
         engine = RSpecTracer.engine
+        tracer_cache = {}.compare_by_identity
+
+        _rspec_tracer_collect_tracks(engine, tracer_cache)
+        engine.apply_env_filter_decisions
 
         ::RSpec.world.filtered_examples.each_pair do |example_group, examples|
           examples.each do |example|
@@ -99,9 +112,8 @@ module RSpecTracer
               next
             end
 
-            tracer_example = RSpecTracer::Example.from(example)
+            tracer_example = tracer_cache.fetch(example)
             example_id = tracer_example[:example_id]
-            example.metadata[:rspec_tracer_example_id] = example_id
 
             if engine.run_example?(example_id)
               run_reason = engine.run_example_reason(example_id)
@@ -123,6 +135,24 @@ module RSpecTracer
         [to_run, groups.to_a]
       end
       # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      def _rspec_tracer_collect_tracks(engine, tracer_cache)
+        ::RSpec.world.filtered_examples.each_pair do |_example_group, examples|
+          examples.each do |example|
+            next if RSpecTracer.ignore_spec_file?(example.metadata[:file_path])
+
+            tracer_example = RSpecTracer::Example.from(example)
+            example_id = tracer_example[:example_id]
+            example.metadata[:rspec_tracer_example_id] = example_id
+            tracer_cache[example] = tracer_example
+
+            tracks = RSpecTracer::RSpec::Metadata.tracks_for(example)
+            next if tracks[:files].empty? && tracks[:env].empty?
+
+            engine.register_tracks(example_id, tracks)
+          end
+        end
+      end
 
       def _rspec_tracer_duplicates_detected?
         duplicates = RSpecTracer.engine.duplicate_examples

--- a/lib/rspec_tracer/storage/json_backend.rb
+++ b/lib/rspec_tracer/storage/json_backend.rb
@@ -53,6 +53,10 @@ module RSpecTracer
       # nil previous and treated every run as a cold first run.
       # Missing file deserializes to `{}` so pre-M4.3 caches still
       # load - the fallback path fires one full re-run (safe).
+      # env_snapshot.json (M5.2) persists the `Tracker::EnvSnapshot`
+      # digest map for env-var values the per-example `tracks:
+      # { env: ... }` DSL declares. Same missing-coerces-to-`{}`
+      # fallback as wsi_snapshot - no schema bump.
       FILENAMES = %w[
         all_examples.json
         duplicate_examples.json
@@ -67,6 +71,7 @@ module RSpecTracer
         examples_coverage.json
         boot_set.json
         wsi_snapshot.json
+        env_snapshot.json
       ].freeze
 
       LAST_RUN_FILENAME = 'last_run.json'
@@ -81,14 +86,17 @@ module RSpecTracer
       ID_SET_FIELDS = %w[
         interrupted_examples flaky_examples failed_examples pending_examples skipped_examples
       ].freeze
-      HASH_FIELDS = %w[all_examples duplicate_examples all_files examples_coverage boot_set wsi_snapshot].freeze
+      HASH_FIELDS = %w[
+        all_examples duplicate_examples all_files examples_coverage
+        boot_set wsi_snapshot env_snapshot
+      ].freeze
       DEPENDENCY_FIELDS = %w[dependency reverse_dependency].freeze
       SYMBOLIZED_FIELDS = %w[all_examples all_files].freeze
       # Fields that round-trip as a plain Hash on both sides - no
       # key/value transformation. examples_coverage (1.x) preserved
-      # string keys; boot_set (M3.7) + wsi_snapshot (M4.3) are simple
-      # name/path => digest maps.
-      PLAIN_HASH_FIELDS = %w[examples_coverage boot_set wsi_snapshot].freeze
+      # string keys; boot_set (M3.7), wsi_snapshot (M4.3), and
+      # env_snapshot (M5.2) are simple name/path => digest maps.
+      PLAIN_HASH_FIELDS = %w[examples_coverage boot_set wsi_snapshot env_snapshot].freeze
 
       attr_reader :cache_path
 
@@ -220,7 +228,8 @@ module RSpecTracer
             reverse_dependency: state[:reverse_dependency],
             examples_coverage: state[:examples_coverage],
             boot_set: state[:boot_set],
-            wsi_snapshot: state[:wsi_snapshot]
+            wsi_snapshot: state[:wsi_snapshot],
+            env_snapshot: state[:env_snapshot]
           )
         end
 
@@ -237,7 +246,8 @@ module RSpecTracer
             dependency: Hash.new { |h, k| h[k] = Set.new },
             examples_coverage: {},
             boot_set: {},
-            wsi_snapshot: {}
+            wsi_snapshot: {},
+            env_snapshot: {}
           }
         end
 
@@ -264,6 +274,7 @@ module RSpecTracer
           merge_examples_coverage!(state[:examples_coverage], snapshot.examples_coverage || {})
           state[:boot_set].merge!(snapshot.boot_set || {})
           state[:wsi_snapshot].merge!(snapshot.wsi_snapshot || {})
+          state[:env_snapshot].merge!(snapshot.env_snapshot || {})
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 

--- a/lib/rspec_tracer/storage/snapshot.rb
+++ b/lib/rspec_tracer/storage/snapshot.rb
@@ -41,6 +41,14 @@ module RSpecTracer
     # saved before M4.3 continue to load (missing wsi.json coerces to
     # `{}`, which compares unequal and triggers one cold re-run - safe
     # fallback, same cost as any other cache miss).
+    #
+    # M5.2 adds `env_snapshot` - Hash[env_name => md5_hex] produced by
+    # `Tracker::EnvSnapshot#digest_snapshot`. Covers env-var values
+    # declared via the per-example `tracks: { env: ... }` DSL.
+    # Without it, a warm run can't tell whether an env-gated example
+    # needs to re-run when the env changes. Same optional-in-JSON
+    # treatment as wsi_snapshot: missing file coerces to `{}`, no
+    # schema_version bump, one cold re-run on upgrade.
     Snapshot = Struct.new(
       :schema_version,
       :run_id,
@@ -57,6 +65,7 @@ module RSpecTracer
       :examples_coverage,
       :boot_set,
       :wsi_snapshot,
+      :env_snapshot,
       keyword_init: true
     )
 
@@ -81,7 +90,8 @@ module RSpecTracer
           reverse_dependency: {},
           examples_coverage: {},
           boot_set: {},
-          wsi_snapshot: {}
+          wsi_snapshot: {},
+          env_snapshot: {}
         )
       end
     end

--- a/lib/rspec_tracer/tracker/env_snapshot.rb
+++ b/lib/rspec_tracer/tracker/env_snapshot.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'digest/md5'
+require 'set'
+
+module RSpecTracer
+  module Tracker
+    # Observer #5 in the 2.0 tracker pipeline (WholeSuiteInvalidators
+    # is #4). Owns the per-run snapshot of environment-variable
+    # values that M5.2's `tracks: { env: ... }` metadata declares.
+    #
+    # Watch list is caller-provided - unlike WholeSuiteInvalidators,
+    # which hard-codes Gemfile.lock / .ruby-version / .rspec-tracer,
+    # env names come from user metadata and are only known once
+    # RSpec has discovered every example. The engine unions every
+    # example's declared env names and hands the set to
+    # `digest_snapshot` at finalize time.
+    #
+    # Digest algorithm: `Digest::MD5.hexdigest(ENV[name].to_s)`.
+    # Missing env var digests the same as empty string - absent is a
+    # valid state. ENV is process-stable within a single run (we
+    # never mutate it mid-run), so one snapshot per run is enough.
+    #
+    # Graceful degradation: the observer never raises on malformed
+    # input. Non-String env names are coerced via #to_s; nil / empty
+    # names are skipped silently.
+    class EnvSnapshot
+      # ENV source is injectable for testability - specs can pass a
+      # Hash double without poking the real process env.
+      def initialize(env: ::ENV)
+        @env = env
+      end
+
+      # Snapshot the current ENV values for `names`. Returns
+      # `Hash[name => md5_hex]`. Idempotent; callers may invoke it
+      # repeatedly without side effects.
+      def digest_snapshot(names)
+        snapshot = {}
+        names.each do |raw|
+          key = raw.to_s
+          next if key.empty?
+
+          snapshot[key] = Digest::MD5.hexdigest(@env[key].to_s)
+        end
+        snapshot
+      end
+
+      # Return the set of env names whose digest differs between
+      # `previous_snapshot` and the current ENV. Keys in either
+      # snapshot participate:
+      #
+      #   - present in both, digests differ  => invalidated
+      #   - present in previous, absent now  => invalidated
+      #   - absent previously, present now   => invalidated
+      #
+      # `previous_snapshot` may be nil (first run, no cache); in that
+      # case every currently-tracked key is considered invalidated so
+      # the examples declaring them get a mandatory cold re-run on
+      # first sighting. `names` scopes the check: only keys in
+      # `names` are considered, which means one example adding a new
+      # `tracks: env: ...` doesn't cascade-invalidate examples that
+      # declared different env keys previously.
+      def invalidated_keys(previous_snapshot, names)
+        previous = previous_snapshot || {}
+        current = digest_snapshot(names)
+        invalidated = Set.new
+
+        current.each do |key, digest|
+          invalidated << key if digest != previous[key]
+        end
+        invalidated
+      end
+    end
+  end
+end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -96,11 +96,12 @@ RSpec.describe RSpecTracer::Engine do
       expect(configuration).to have_received(:freeze_declared_globs!)
     end
 
-    it 'builds all seven observer instances' do
+    it 'builds all eight observer instances' do
       expect([
         tracker.registry, tracker.graph, tracker.loaded_files_tracker,
         tracker.coverage_adapter, tracker.declared_globs,
-        tracker.whole_suite_invalidators, tracker.new_file_detector
+        tracker.whole_suite_invalidators, tracker.new_file_detector,
+        tracker.env_snapshot
       ]).to all(be_a(Object))
     end
 
@@ -292,6 +293,150 @@ RSpec.describe RSpecTracer::Engine do
 
     it 'returns the Snapshot it persisted' do
       expect(tracker.finalize).to be_a(RSpecTracer::Storage::Snapshot)
+    end
+
+    it 'persists env_snapshot for every tracked env key' do
+      stub_const('ENV', 'API_KEY' => 'secret')
+      tracker.register_tracks('ex1', files: Set.new, env: Set.new(['API_KEY']))
+
+      snapshot = tracker.finalize
+
+      expect(snapshot.env_snapshot).to have_key('API_KEY')
+    end
+
+    it 'leaves env_snapshot empty when no tracks were registered' do
+      snapshot = tracker.finalize
+
+      expect(snapshot.env_snapshot).to eq({})
+    end
+  end
+
+  describe '#register_tracks (M5.2 DSL hook)' do
+    subject(:tracker) { build_tracker.tap(&:setup) }
+
+    it 'adds declared-kind inputs for each tracked glob to the example dep set' do
+      write_project_file('config/settings.yml', "feature: enabled\n")
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+
+      tracker.register_tracks('ex1', files: Set.new(['config/*.yml']), env: Set.new)
+      tracker.register_example(build_example('ex1'))
+      tracker.example_started
+      tracker.example_finished('ex1')
+
+      settings_name = '/config/settings.yml'
+      expect(tracker.all_files).to have_key(File.join(root, 'config/settings.yml'))
+      expect(tracker.graph.dependency_hash['ex1']).to include(File.join(root, 'config/settings.yml'))
+      expect(settings_name).to be_a(String) # sentinel - file_name shape tested in finalize specs
+    end
+
+    it 'accumulates env names across examples into @tracked_env_names' do
+      tracker.register_tracks('ex1', files: Set.new, env: Set.new(['A']))
+      tracker.register_tracks('ex2', files: Set.new, env: Set.new(['B']))
+
+      snapshot = tracker.finalize
+
+      expect(snapshot.env_snapshot.keys).to contain_exactly('A', 'B')
+    end
+
+    it 'is a no-op when both files and env are empty' do
+      expect { tracker.register_tracks('ex1', files: Set.new, env: Set.new) }.not_to raise_error
+    end
+
+    it 'memoizes glob resolution so the filesystem is walked once per distinct glob' do
+      write_project_file('config/a.yml', 'a')
+      write_project_file('config/b.yml', 'b')
+      allow(Dir).to receive(:glob).and_call_original
+
+      tracker.register_tracks('ex1', files: Set.new(['config/*.yml']), env: Set.new)
+      tracker.register_tracks('ex2', files: Set.new(['config/*.yml']), env: Set.new)
+
+      expect(Dir).to have_received(:glob).with('config/*.yml', anything, base: root).once
+    end
+  end
+
+  describe '#apply_env_filter_decisions (M5.2)' do
+    let(:prev_cache_path) { File.join(tmp_base, 'cache') }
+    # Pre-seed wsi_snapshot with a digest matching the current project's
+    # WholeSuiteInvalidators output so the engine's whole_suite_changed?
+    # returns false. Without this, every previous example gets marked as
+    # whole_suite_invalidated and env_changed is suppressed by the
+    # "stronger prior filter reason" guard.
+    let(:current_wsi) do
+      RSpecTracer::Tracker::WholeSuiteInvalidators.new(root: root).digest_snapshot
+    end
+    let(:previous_snapshot) do
+      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |s|
+        s.all_examples = { 'ex1' => build_example('ex1'), 'ex2' => build_example('ex2') }
+        # Non-empty dependency keeps Filter from marking every prev example
+        # as :no_cache (Filter maps missing-from-graph to no_cache which
+        # the engine promotes to @filtered_examples, masking env_changed).
+        s.dependency = { 'ex1' => Set.new(['/lib/a.rb']), 'ex2' => Set.new(['/lib/b.rb']) }
+        s.all_files = {
+          '/lib/a.rb' => { file_name: '/lib/a.rb', file_path: File.join(root, 'lib/a.rb'),
+                           digest: Digest::SHA256.file(File.join(root, 'lib/a.rb')).hexdigest },
+          '/lib/b.rb' => { file_name: '/lib/b.rb', file_path: File.join(root, 'lib/b.rb'),
+                           digest: Digest::SHA256.file(File.join(root, 'lib/b.rb')).hexdigest }
+        }
+        s.env_snapshot = {
+          'API_KEY' => Digest::MD5.hexdigest('old'),
+          'OTHER' => Digest::MD5.hexdigest('') # matches current ENV['OTHER'] (absent -> '')
+        }
+        s.wsi_snapshot = current_wsi
+      end
+    end
+
+    def prime_previous_cache
+      FileUtils.mkdir_p(prev_cache_path)
+      backend = RSpecTracer::Storage::JsonBackend.new(cache_path: prev_cache_path, logger: logger)
+      backend.save_graph(previous_snapshot, schema_version: 3)
+    end
+
+    it 'adds env_changed decisions for examples whose tracked env key changed' do
+      stub_const('ENV', 'API_KEY' => 'new')
+      prime_previous_cache
+      tracker = build_tracker.tap(&:setup)
+      tracker.register_tracks('ex1', files: Set.new, env: Set.new(['API_KEY']))
+
+      tracker.apply_env_filter_decisions
+
+      expect(tracker.run_example?('ex1')).to be(true)
+      expect(tracker.run_example_reason('ex1')).to eq('Environment changed')
+    end
+
+    it 'leaves examples not declaring the changed key alone' do
+      stub_const('ENV', 'API_KEY' => 'new')
+      prime_previous_cache
+      tracker = build_tracker.tap(&:setup)
+      tracker.register_tracks('ex2', files: Set.new, env: Set.new(['OTHER']))
+
+      tracker.apply_env_filter_decisions
+
+      expect(tracker.run_example?('ex2')).to be(false)
+    end
+
+    it 'is a no-op when no previous snapshot exists (cold first run)' do
+      tracker = build_tracker.tap(&:setup)
+      tracker.register_tracks('ex1', files: Set.new, env: Set.new(['API_KEY']))
+
+      expect { tracker.apply_env_filter_decisions }.not_to raise_error
+    end
+
+    it 'does not overwrite a stronger prior filter reason' do
+      stub_const('ENV', 'API_KEY' => 'new')
+      prime_previous_cache
+      tracker = build_tracker.tap(&:setup)
+      tracker.instance_variable_get(:@filtered_examples)['ex1'] = 'Failed previously'
+      tracker.register_tracks('ex1', files: Set.new, env: Set.new(['API_KEY']))
+
+      tracker.apply_env_filter_decisions
+
+      expect(tracker.run_example_reason('ex1')).to eq('Failed previously')
+    end
+
+    it 'returns self even on early-out paths' do
+      tracker = build_tracker.tap(&:setup)
+
+      expect(tracker.apply_env_filter_decisions).to be(tracker)
     end
   end
 

--- a/spec/fixtures/rails_app/spec/services/feature_flags_spec.rb
+++ b/spec/fixtures/rails_app/spec/services/feature_flags_spec.rb
@@ -69,7 +69,12 @@ RSpec.describe FeatureFlags do
     end
   end
 
-  describe '.require_review? (ENV-branch blind-spot exercise)' do
+  # M5.2 per-example DSL: this describe's examples depend on the
+  # `RAILS_APP_FORCE_REVIEW` env var (via FeatureFlags#require_review?)
+  # — invisible to Coverage / IO observation because the env read
+  # happens inside pure Ruby. Declaring `tracks: { env: ... }` teaches
+  # rspec-tracer to re-run these examples when the env changes.
+  describe '.require_review? (ENV-branch blind-spot exercise)', tracks: { env: 'RAILS_APP_FORCE_REVIEW' } do
     around do |example|
       before = ENV['RAILS_APP_FORCE_REVIEW']
       example.run

--- a/spec/integration/per_example_dsl_spec.rb
+++ b/spec/integration/per_example_dsl_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# M5.2 end-to-end integration for the per-example `tracks:` DSL.
+# Drives the reference Rails fixture at `spec/fixtures/rails_app/`
+# via subprocess RSpec. The fixture's feature_flags_spec declares
+# `tracks: { env: 'RAILS_APP_FORCE_REVIEW' }` on the
+# `.require_review?` describe block (an ENV-branch blind spot that
+# Coverage / IO observation cannot see).
+#
+# Assertion philosophy matches M4.3's behavior-matrix pattern:
+# assert on the set of examples that re-ran on warm (all_examples
+# minus skipped_examples), not just exit status. An env mutation
+# between cold and warm must re-run exactly the three
+# ENV-branch examples and skip every other example.
+
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'set'
+
+module PerExampleDslSpecHelpers
+  FIXTURE_ROOT = File.expand_path('../fixtures/rails_app', __dir__)
+  CACHE_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_cache')
+  COVERAGE_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_coverage')
+  REPORT_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_report')
+  LOCAL_COVERAGE = File.join(FIXTURE_ROOT, 'coverage')
+  TRACER_ENV = { 'RSPEC_TRACER' => '1' }.freeze
+  SCRUB_DIRS = [CACHE_DIR, COVERAGE_DIR, REPORT_DIR, LOCAL_COVERAGE].freeze
+
+  module_function
+
+  def run_rspec_in_fixture(env = {})
+    Bundler.with_unbundled_env do
+      Open3.capture2e(TRACER_ENV.merge(env), 'bundle', 'exec', 'rspec', '--no-color',
+                      chdir: FIXTURE_ROOT)
+    end
+  end
+
+  def ensure_bundle_and_db
+    Bundler.with_unbundled_env do
+      Dir.chdir(FIXTURE_ROOT) do
+        gemfile_env = { 'BUNDLE_GEMFILE' => File.join(FIXTURE_ROOT, 'Gemfile') }
+        unless system(gemfile_env, 'bundle', 'check', out: File::NULL, err: File::NULL)
+          system(gemfile_env, 'bundle', 'install', '--quiet') || raise('bundle install failed')
+        end
+        system('bundle', 'exec', 'rails', 'db:test:prepare',
+               out: File::NULL, err: File::NULL) || raise('db:test:prepare failed')
+      end
+    end
+  end
+
+  def clear_tracer_state
+    FileUtils.rm_rf(SCRUB_DIRS)
+  end
+
+  def load_cache_file(name)
+    manifest = JSON.parse(File.read(File.join(CACHE_DIR, 'last_run.json')))
+    JSON.parse(File.read(File.join(CACHE_DIR, manifest.fetch('run_id'), name)))
+  end
+
+  # Ids of examples that actually re-ran on warm = all_examples - skipped_examples.
+  # The v2 seed_state_from_previous path carries prior skipped ids into
+  # all_examples, so this diff is the exact re-run set.
+  def re_run_example_ids_after_warm
+    all_examples = load_cache_file('all_examples.json')
+    skipped = load_cache_file('skipped_examples.json')
+    (all_examples.keys - skipped.to_a).to_set
+  end
+
+  # The feature_flags env-branch describe has three examples
+  # (unset / '1' / '0' branches of RAILS_APP_FORCE_REVIEW).
+  def env_branch_example_descriptions
+    [
+      'reflects the features.json default when ENV is unset',
+      'is true when RAILS_APP_FORCE_REVIEW=1',
+      'is false for any other ENV value'
+    ]
+  end
+
+  # Filter the all_examples map down to the env-branch describe's
+  # examples by full_description prefix match.
+  def env_branch_ids(all_examples)
+    all_examples.select do |_, meta|
+      full = meta['full_description'] || meta[:full_description]
+      env_branch_example_descriptions.any? { |d| full.to_s.include?(d) }
+    end.keys.to_set
+  end
+end
+
+# rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/BeforeAfterAll, RSpec/InstanceVariable
+RSpec.describe 'M5.2 per-example tracks DSL integration' do
+  include PerExampleDslSpecHelpers
+
+  before(:all) do
+    PerExampleDslSpecHelpers.ensure_bundle_and_db
+    PerExampleDslSpecHelpers.clear_tracer_state
+
+    # Cold run with RAILS_APP_FORCE_REVIEW unset. Registers every
+    # example in the cache, including the env-branch describe's
+    # three examples (which declare tracks: { env: '...' }).
+    @cold_out, @cold_status = PerExampleDslSpecHelpers.run_rspec_in_fixture
+    raise "cold run failed:\n#{@cold_out}" unless @cold_status.success?
+
+    @cold_all_examples = PerExampleDslSpecHelpers.load_cache_file('all_examples.json')
+    @cold_env_snapshot = PerExampleDslSpecHelpers.load_cache_file('env_snapshot.json')
+    @expected_env_branch_ids = PerExampleDslSpecHelpers.env_branch_ids(@cold_all_examples)
+
+    # Warm run with RAILS_APP_FORCE_REVIEW flipped. Only the three
+    # env-branch examples should re-run; everything else is skipped.
+    @warm_out, @warm_status = PerExampleDslSpecHelpers.run_rspec_in_fixture(
+      'RAILS_APP_FORCE_REVIEW' => '1'
+    )
+    raise "warm run failed:\n#{@warm_out}" unless @warm_status.success?
+
+    @re_run_ids = PerExampleDslSpecHelpers.re_run_example_ids_after_warm
+    @warm_env_snapshot = PerExampleDslSpecHelpers.load_cache_file('env_snapshot.json')
+  end
+
+  after(:all) { PerExampleDslSpecHelpers.clear_tracer_state }
+
+  describe 'cold run persists env_snapshot for the declared key' do
+    it 'records RAILS_APP_FORCE_REVIEW in env_snapshot.json' do
+      expect(@cold_env_snapshot).to have_key('RAILS_APP_FORCE_REVIEW')
+    end
+
+    it 'does not record env keys no example tracked' do
+      expect(@cold_env_snapshot.keys).to eq(['RAILS_APP_FORCE_REVIEW'])
+    end
+  end
+
+  describe 'warm run with the tracked env flipped' do
+    it 'captured the cold-run baseline (sanity)' do
+      expect(@expected_env_branch_ids.size).to eq(3),
+                                               "expected 3 env-branch examples, got #{@expected_env_branch_ids.size}"
+    end
+
+    it 're-runs exactly the env-branch examples, skipping everything else' do
+      unexpected_reruns = @re_run_ids - @expected_env_branch_ids
+      missed_reruns = @expected_env_branch_ids - @re_run_ids
+
+      expect(unexpected_reruns).to be_empty,
+                                   "unexpectedly re-ran non-env-branch examples: #{unexpected_reruns.to_a}"
+      expect(missed_reruns).to be_empty,
+                               "missed env-branch example re-runs: #{missed_reruns.to_a}"
+    end
+
+    it 'updates env_snapshot to the new digest' do
+      expect(@warm_env_snapshot['RAILS_APP_FORCE_REVIEW']).not_to eq(@cold_env_snapshot['RAILS_APP_FORCE_REVIEW'])
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/BeforeAfterAll, RSpec/InstanceVariable

--- a/spec/integration/per_example_dsl_spec.rb
+++ b/spec/integration/per_example_dsl_spec.rb
@@ -44,6 +44,7 @@ module PerExampleDslSpecHelpers
         unless system(gemfile_env, 'bundle', 'check', out: File::NULL, err: File::NULL)
           system(gemfile_env, 'bundle', 'install', '--quiet') || raise('bundle install failed')
         end
+
         system('bundle', 'exec', 'rails', 'db:test:prepare',
                out: File::NULL, err: File::NULL) || raise('db:test:prepare failed')
       end
@@ -88,7 +89,7 @@ module PerExampleDslSpecHelpers
   end
 end
 
-# rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/BeforeAfterAll, RSpec/InstanceVariable
+# rubocop:disable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable
 RSpec.describe 'M5.2 per-example tracks DSL integration' do
   include PerExampleDslSpecHelpers
 
@@ -138,11 +139,9 @@ RSpec.describe 'M5.2 per-example tracks DSL integration' do
     it 're-runs exactly the env-branch examples, skipping everything else' do
       unexpected_reruns = @re_run_ids - @expected_env_branch_ids
       missed_reruns = @expected_env_branch_ids - @re_run_ids
+      diff_msg = "unexpected reruns: #{unexpected_reruns.to_a} / missed: #{missed_reruns.to_a}"
 
-      expect(unexpected_reruns).to be_empty,
-                                   "unexpectedly re-ran non-env-branch examples: #{unexpected_reruns.to_a}"
-      expect(missed_reruns).to be_empty,
-                               "missed env-branch example re-runs: #{missed_reruns.to_a}"
+      expect([unexpected_reruns, missed_reruns]).to eq([Set.new, Set.new]), diff_msg
     end
 
     it 'updates env_snapshot to the new digest' do
@@ -150,4 +149,4 @@ RSpec.describe 'M5.2 per-example tracks DSL integration' do
     end
   end
 end
-# rubocop:enable RSpec/DescribeClass, RSpec/ExampleLength, RSpec/BeforeAfterAll, RSpec/InstanceVariable
+# rubocop:enable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable

--- a/spec/properties/metadata_inheritance_spec.rb
+++ b/spec/properties/metadata_inheritance_spec.rb
@@ -11,7 +11,7 @@
 # file-globs and env-names. Assertion checks that the walker output
 # equals the exact set-union across the walked path.
 #
-# rubocop:disable RSpec/ExampleLength, RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:disable RSpec/DescribeClass
 require 'set'
 require 'rantly/rspec_extensions'
 require 'rspec_tracer/rspec/metadata'
@@ -34,7 +34,7 @@ module MetadataCascadeGen
     hash = {}
     hash[:files] = pick_value(rantly, PROPERTY_FILES_POOL)
     hash[:env] = pick_value(rantly, PROPERTY_ENVS_POOL)
-    hash.reject { |_, v| v.nil? }
+    hash.compact
   end
 
   def pick_value(rantly, pool)
@@ -130,4 +130,4 @@ RSpec.describe 'RSpecTracer::RSpec::Metadata cascade invariants' do
     end
   end
 end
-# rubocop:enable RSpec/ExampleLength, RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:enable RSpec/DescribeClass

--- a/spec/properties/metadata_inheritance_spec.rb
+++ b/spec/properties/metadata_inheritance_spec.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+# Property: Metadata.tracks_for unions each ancestor group's
+# `tracks:` hash with the leaf example's own, for both :files and
+# :env. No key is ever lost; no group's contribution is clobbered
+# by a descendant (unlike RSpec's default metadata cascade which
+# replaces on conflict).
+#
+# Generators run 200 iterations over randomly-built N-deep group
+# trees, each ancestor optionally carrying a random mix of
+# file-globs and env-names. Assertion checks that the walker output
+# equals the exact set-union across the walked path.
+#
+# rubocop:disable RSpec/ExampleLength, RSpec/DescribeClass, RSpec/MultipleExpectations
+require 'set'
+require 'rantly/rspec_extensions'
+require 'rspec_tracer/rspec/metadata'
+
+PROPERTY_FILES_POOL = %w[
+  app/**/*.rb config/**/*.yml lib/tasks/*.rake db/schema.rb
+  app/policies/**/*.rb app/helpers/*.rb
+].freeze
+PROPERTY_ENVS_POOL = %w[API_KEY ROLE_CONFIG FEATURE_FLAG RAILS_ENV DATABASE_URL].freeze
+
+module MetadataCascadeGen
+  module_function
+
+  # Produce a random `tracks:` hash OR nil. `:files` and `:env` are
+  # each independently absent / singular / array - mirrors the real
+  # user surface shape.
+  def random_tracks(rantly)
+    return nil if rantly.boolean
+
+    hash = {}
+    hash[:files] = pick_value(rantly, PROPERTY_FILES_POOL)
+    hash[:env] = pick_value(rantly, PROPERTY_ENVS_POOL)
+    hash.reject { |_, v| v.nil? }
+  end
+
+  def pick_value(rantly, pool)
+    roll = rantly.range(0, 3)
+    case roll
+    when 0 then nil
+    when 1 then pool.sample
+    else
+      count = rantly.range(1, 3)
+      pool.sample(count)
+    end
+  end
+
+  # Build an N-depth example with an ancestor chain; each group
+  # carries its own random `tracks:` metadata.
+  def build_example(rantly)
+    depth = rantly.range(1, 4)
+    ancestors = Array.new(depth) { build_group(rantly) }
+    example_tracks = random_tracks(rantly)
+
+    MetadataCascadeFakes::FakeExample.new(
+      MetadataCascadeFakes::FakeGroup.new(ancestors, example_tracks)
+    )
+  end
+
+  def build_group(rantly)
+    MetadataCascadeFakes::FakeGroup.new([], random_tracks(rantly))
+  end
+end
+
+# Minimal doubles for the walker - `example.example_group.parent_groups`
+# and `group.metadata[:tracks]` are the only surfaces used.
+module MetadataCascadeFakes
+  FakeGroup = Struct.new(:parent_groups, :tracks_value) do
+    def metadata
+      { tracks: tracks_value }
+    end
+  end
+
+  FakeExample = Struct.new(:example_group) do
+    def metadata
+      { tracks: example_group.tracks_value }
+    end
+  end
+end
+
+RSpec.describe 'RSpecTracer::RSpec::Metadata cascade invariants' do
+  # Expected union computed independently - same normalization as
+  # the walker uses (String => [String], Array => flattened strings,
+  # empty/nil filtered).
+  def normalize_expected(value)
+    case value
+    when String then value.empty? ? [] : [value]
+    when Array then value.map(&:to_s).reject(&:empty?)
+    else []
+    end
+  end
+
+  def expected_union(example)
+    files = Set.new
+    envs = Set.new
+    ancestors = example.example_group.parent_groups
+    ancestors.each do |group|
+      tracks = group.metadata[:tracks]
+      next unless tracks.is_a?(Hash)
+
+      normalize_expected(tracks[:files]).each { |v| files << v }
+      normalize_expected(tracks[:env]).each { |v| envs << v }
+    end
+    leaf = example.metadata[:tracks]
+    if leaf.is_a?(Hash)
+      normalize_expected(leaf[:files]).each { |v| files << v }
+      normalize_expected(leaf[:env]).each { |v| envs << v }
+    end
+    { files: files, env: envs }
+  end
+
+  it 'unions :files across every ancestor plus the leaf' do
+    property_of { MetadataCascadeGen.build_example(self) }.check(200) do |example|
+      expected = expected_union(example)
+      actual = RSpecTracer::RSpec::Metadata.tracks_for(example)
+
+      expect(actual[:files]).to eq(expected[:files])
+    end
+  end
+
+  it 'unions :env across every ancestor plus the leaf' do
+    property_of { MetadataCascadeGen.build_example(self) }.check(200) do |example|
+      expected = expected_union(example)
+      actual = RSpecTracer::RSpec::Metadata.tracks_for(example)
+
+      expect(actual[:env]).to eq(expected[:env])
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength, RSpec/DescribeClass, RSpec/MultipleExpectations

--- a/spec/rspec/metadata_spec.rb
+++ b/spec/rspec/metadata_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'rspec_tracer/rspec/metadata'
+
+# rubocop:disable RSpec/MultipleExpectations, RSpec/VerifiedDoubles, RSpec/ExampleLength
+RSpec.describe RSpecTracer::RSpec::Metadata do
+  # Build minimal test doubles for the RSpec metadata walk. Real
+  # RSpec::Core::ExampleGroup instances require a configuration +
+  # subclass dance that is overkill for unit coverage of the walker.
+  # The walker only reads `example.example_group.parent_groups` and
+  # `group.metadata[:tracks]` - both trivially fakeable.
+  let(:grandparent) { fake_group(tracks: nil) }
+  let(:parent) { fake_group(tracks: nil) }
+  let(:child) { fake_group(tracks: nil) }
+
+  def fake_group(tracks:)
+    double('ExampleGroup', metadata: { tracks: tracks })
+  end
+
+  def fake_example(tracks:, parent_groups:)
+    group_double = double('ExampleGroup', parent_groups: parent_groups)
+    double('Example', example_group: group_double, metadata: { tracks: tracks })
+  end
+
+  describe '.tracks_for' do
+    it 'returns empty sets when no tracks metadata anywhere' do
+      example = fake_example(tracks: nil, parent_groups: [parent, grandparent])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new)
+      expect(result[:env]).to eq(Set.new)
+    end
+
+    it 'reads a single-string :files value' do
+      example = fake_example(
+        tracks: { files: 'app/policies/**/*.rb' },
+        parent_groups: [parent]
+      )
+      allow(parent).to receive(:metadata).and_return({})
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new(['app/policies/**/*.rb']))
+    end
+
+    it 'reads an array :files value' do
+      example = fake_example(
+        tracks: { files: %w[a/*.rb b/*.rb] },
+        parent_groups: []
+      )
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new(%w[a/*.rb b/*.rb]))
+    end
+
+    it 'reads a single-string :env value' do
+      example = fake_example(tracks: { env: 'API_KEY' }, parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:env]).to eq(Set.new(['API_KEY']))
+    end
+
+    it 'reads an array :env value' do
+      example = fake_example(tracks: { env: %w[API_KEY ROLE_CONFIG] }, parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:env]).to eq(Set.new(%w[API_KEY ROLE_CONFIG]))
+    end
+
+    it 'unions (not replaces) file globs across parent-group hierarchy' do
+      allow(grandparent).to receive(:metadata).and_return(tracks: { files: 'gp/**/*' })
+      allow(parent).to receive(:metadata).and_return(tracks: { files: 'p/**/*' })
+      example = fake_example(
+        tracks: { files: 'e/**/*' },
+        parent_groups: [parent, grandparent]
+      )
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new(%w[gp/**/* p/**/* e/**/*]))
+    end
+
+    it 'unions env names across parent-group hierarchy' do
+      allow(grandparent).to receive(:metadata).and_return(tracks: { env: 'ONE' })
+      allow(parent).to receive(:metadata).and_return(tracks: { env: %w[TWO THREE] })
+      example = fake_example(
+        tracks: { env: 'FOUR' },
+        parent_groups: [parent, grandparent]
+      )
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:env]).to eq(Set.new(%w[ONE TWO THREE FOUR]))
+    end
+
+    it 'unions both files and env from a mixed hierarchy' do
+      allow(parent).to receive(:metadata).and_return(tracks: { files: 'p/*.rb' })
+      example = fake_example(
+        tracks: { env: 'API_KEY' },
+        parent_groups: [parent]
+      )
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new(['p/*.rb']))
+      expect(result[:env]).to eq(Set.new(['API_KEY']))
+    end
+
+    it 'ignores a non-Hash :tracks value' do
+      example = fake_example(tracks: 'not a hash', parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new)
+      expect(result[:env]).to eq(Set.new)
+    end
+
+    it 'ignores a non-Hash :tracks on an ancestor group' do
+      allow(parent).to receive(:metadata).and_return(tracks: 42)
+      example = fake_example(tracks: { files: 'a/*' }, parent_groups: [parent])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new(['a/*']))
+    end
+
+    it 'filters out empty-string entries from an array value' do
+      example = fake_example(tracks: { files: ['a/*.rb', ''] }, parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new(['a/*.rb']))
+    end
+
+    it 'treats an empty-string single value as no-op' do
+      example = fake_example(tracks: { files: '' }, parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new)
+    end
+
+    it 'coerces non-String array entries via to_s' do
+      example = fake_example(tracks: { env: [:API_KEY] }, parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:env]).to eq(Set.new(['API_KEY']))
+    end
+
+    it 'ignores Integer or other non-Array non-String values' do
+      example = fake_example(tracks: { files: 42, env: nil }, parent_groups: [])
+
+      result = described_class.tracks_for(example)
+
+      expect(result[:files]).to eq(Set.new)
+      expect(result[:env]).to eq(Set.new)
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleExpectations, RSpec/VerifiedDoubles, RSpec/ExampleLength

--- a/spec/rspec/runner_hook_spec.rb
+++ b/spec/rspec/runner_hook_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
   let(:example_group) { double('ExampleGroup') }
   let(:example_metadata) { { file_path: 'spec/foo_spec.rb' } }
   let(:example) do
-    double('Example', metadata: example_metadata, description: 'does things',
+    double('Example', object_id: 1001, metadata: example_metadata, description: 'does things',
                       example_group: double('EG', parent_groups: [example_group]))
   end
   let(:tracer_example) { { example_id: 'ex1' } }
@@ -48,9 +48,12 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
     allow(RSpecTracer).to receive_messages(engine: engine, logger: logger, fail_on_duplicates: false,
                                            ignore_spec_file?: false)
     allow(RSpecTracer::Example).to receive(:from).and_return(tracer_example)
+    allow(RSpecTracer::RSpec::Metadata).to receive(:tracks_for).and_return(files: Set.new, env: Set.new)
     allow(engine).to receive_messages(run_example?: true, run_example_reason: 'No cache',
                                       duplicate_examples: {})
     allow(engine).to receive(:register_example)
+    allow(engine).to receive(:register_tracks)
+    allow(engine).to receive(:apply_env_filter_decisions)
     allow(engine).to receive(:on_example_skipped)
     allow(engine).to receive(:deregister_duplicate_examples)
   end
@@ -134,6 +137,52 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
 
         expect(engine).to have_received(:on_example_skipped).with('ex1')
         expect(engine).not_to have_received(:register_example)
+      end
+    end
+
+    context 'when per-example tracks metadata is present (M5.2)' do
+      before do
+        allow(world).to receive(:example_count).and_return(1, 1)
+        allow(world).to receive(:filtered_examples).and_return(example_group => [example])
+        allow(world).to receive(:instance_variable_set)
+      end
+
+      it 'registers non-empty tracks metadata on the engine (Pass 1)' do
+        allow(RSpecTracer::RSpec::Metadata).to receive(:tracks_for).with(example).and_return(
+          files: Set.new(['config/*.yml']), env: Set.new(['API_KEY'])
+        )
+
+        runner.run_specs([])
+
+        expect(engine).to have_received(:register_tracks)
+          .with('ex1', hash_including(files: Set.new(['config/*.yml']), env: Set.new(['API_KEY'])))
+      end
+
+      it 'skips register_tracks when both tracks sets are empty' do
+        runner.run_specs([])
+
+        expect(engine).not_to have_received(:register_tracks)
+      end
+
+      it 'invokes apply_env_filter_decisions between the two passes' do
+        runner.run_specs([])
+
+        expect(engine).to have_received(:apply_env_filter_decisions)
+      end
+
+      it 'does not read tracks for ignored spec files' do
+        allow(RSpecTracer).to receive(:ignore_spec_file?).with('spec/foo_spec.rb').and_return(true)
+
+        runner.run_specs([])
+
+        expect(RSpecTracer::RSpec::Metadata).not_to have_received(:tracks_for)
+        expect(engine).not_to have_received(:register_tracks)
+      end
+
+      it 'computes Example.from only once per example (Pass 1 caches into Pass 2)' do
+        runner.run_specs([])
+
+        expect(RSpecTracer::Example).to have_received(:from).once
       end
     end
 

--- a/spec/storage/json_backend_spec.rb
+++ b/spec/storage/json_backend_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       reverse_dependency: { '/a.rb' => Set.new(['ex1']) },
       examples_coverage: { 'ex1' => { '/a.rb' => [1, nil, 2] } },
       boot_set: { 'lib/boot.rb' => 'deadbeef', 'spec/spec_helper.rb' => 'cafef00d' },
-      wsi_snapshot: { 'Gemfile.lock' => 'feedc0de', '.ruby-version' => 'b16b00b5' }
+      wsi_snapshot: { 'Gemfile.lock' => 'feedc0de', '.ruby-version' => 'b16b00b5' },
+      env_snapshot: { 'API_KEY' => 'facade1', 'ROLE_CONFIG' => 'baadf00d' }
     )
   end
 
@@ -54,7 +55,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(described_class::FILENAMES).to be_frozen
     end
 
-    it 'lists exactly the 13 per-run files (M3.7 added boot_set.json; M4.3 added wsi_snapshot.json)' do
+    it 'lists exactly the 14 per-run files (boot_set+wsi_snapshot+env_snapshot added in M3.7+M4.3+M5.2)' do
       expect(described_class::FILENAMES).to eq(expected_filenames)
     end
 
@@ -64,7 +65,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
         interrupted_examples.json flaky_examples.json failed_examples.json
         pending_examples.json skipped_examples.json
         all_files.json dependency.json reverse_dependency.json examples_coverage.json
-        boot_set.json wsi_snapshot.json
+        boot_set.json wsi_snapshot.json env_snapshot.json
       ]
     end
   end
@@ -101,6 +102,41 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
 
       expect(loaded.boot_set).to eq({})
+    end
+  end
+
+  describe 'env_snapshot round-trip (M5.2)' do
+    it 'persists and reloads a non-empty env_snapshot' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_snapshot).to eq(sample_snapshot.env_snapshot)
+    end
+
+    it 'writes env_snapshot.json with a plain Hash[env_name => digest] body' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'env_snapshot.json')
+
+      expect(JSON.parse(File.read(path)))
+        .to eq('API_KEY' => 'facade1', 'ROLE_CONFIG' => 'baadf00d')
+    end
+
+    it 'tolerates a malformed env_snapshot.json (returns {})' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'env_snapshot.json')
+      File.binwrite(path, "\x00 garbage".b)
+      loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_snapshot).to eq({})
+    end
+
+    it 'coerces a non-Hash JSON body (e.g. array) to {}' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'env_snapshot.json')
+      File.write(path, JSON.dump(%w[not a hash]))
+      loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_snapshot).to eq({})
     end
   end
 
@@ -320,7 +356,8 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
         reverse_dependency: { file_name => Set.new([example_id]) },
         examples_coverage: { example_id => { file_name => { '0' => 1, '2' => 3 } } },
         boot_set: { "lib/#{example_id}_boot.rb" => "boot#{example_id}" },
-        wsi_snapshot: { 'Gemfile.lock' => "wsi-#{run_id}" }
+        wsi_snapshot: { 'Gemfile.lock' => "wsi-#{run_id}" },
+        env_snapshot: { "ENV_#{example_id.upcase}" => "env-#{run_id}" }
       )
     end
 
@@ -336,7 +373,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(result).to be_nil
     end
 
-    it 'unions all_examples, all_files, dependency, boot_set, wsi across peers' do
+    it 'unions all_examples, all_files, dependency, boot_set, wsi, env across peers' do
       write_peer(peer_one_path, peer_snapshot('p1', 'ex1', '/lib/a.rb', 'digest-a'))
       write_peer(peer_two_path, peer_snapshot('p2', 'ex2', '/lib/b.rb', 'digest-b'))
 
@@ -351,6 +388,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(merged.dependency['ex2']).to include('/lib/b.rb')
       expect(merged.boot_set.keys).to include('lib/ex1_boot.rb', 'lib/ex2_boot.rb')
       expect(merged.wsi_snapshot['Gemfile.lock']).to be_a(String)
+      expect(merged.env_snapshot.keys).to include('ENV_EX1', 'ENV_EX2')
     end
 
     it 'unions example-status ID sets' do

--- a/spec/storage/snapshot_spec.rb
+++ b/spec/storage/snapshot_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
     it 'defaults Hash-shaped fields to empty Hash' do
       %i[
         all_examples duplicate_examples all_files dependency reverse_dependency
-        examples_coverage boot_set wsi_snapshot
+        examples_coverage boot_set wsi_snapshot env_snapshot
       ].each { |field| expect(snapshot.send(field)).to eq({}) }
     end
 
@@ -33,6 +33,10 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
 
     it 'defaults wsi_snapshot to an empty Hash (M4.3 field)' do
       expect(snapshot.wsi_snapshot).to eq({})
+    end
+
+    it 'defaults env_snapshot to an empty Hash (M5.2 field)' do
+      expect(snapshot.env_snapshot).to eq({})
     end
   end
 
@@ -55,6 +59,14 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
       a = described_class.empty(schema_version: 3, run_id: 'x')
       b = described_class.empty(schema_version: 3, run_id: 'x')
       b.boot_set = { 'lib/a.rb' => 'deadbeef' }
+
+      expect(a).not_to eq(b)
+    end
+
+    it 'differs when env_snapshot differs' do
+      a = described_class.empty(schema_version: 3, run_id: 'x')
+      b = described_class.empty(schema_version: 3, run_id: 'x')
+      b.env_snapshot = { 'API_KEY' => 'facade1' }
 
       expect(a).not_to eq(b)
     end

--- a/spec/tracker/env_snapshot_spec.rb
+++ b/spec/tracker/env_snapshot_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'digest/md5'
+require 'set'
+require 'rspec_tracer/tracker/env_snapshot'
+
+RSpec.describe RSpecTracer::Tracker::EnvSnapshot do
+  let(:env) { { 'API_KEY' => 'secret', 'ROLE_CONFIG' => 'admin' } }
+  let(:observer) { described_class.new(env: env) }
+
+  describe '#digest_snapshot' do
+    it 'returns an empty Hash when no names are given' do
+      expect(observer.digest_snapshot([])).to eq({})
+    end
+
+    it 'digests the named env vars with MD5(ENV[name].to_s)' do
+      result = observer.digest_snapshot(%w[API_KEY])
+
+      expect(result['API_KEY']).to eq(Digest::MD5.hexdigest('secret'))
+    end
+
+    it 'digests missing env vars the same as an empty string' do
+      result = observer.digest_snapshot(%w[NOT_SET])
+
+      expect(result['NOT_SET']).to eq(Digest::MD5.hexdigest(''))
+    end
+
+    it 'handles multiple keys in one call' do
+      result = observer.digest_snapshot(%w[API_KEY ROLE_CONFIG])
+
+      expect(result.keys).to contain_exactly('API_KEY', 'ROLE_CONFIG')
+    end
+
+    it 'silently skips empty-string names' do
+      result = observer.digest_snapshot(['', 'API_KEY'])
+
+      expect(result.keys).to eq(['API_KEY'])
+    end
+
+    it 'coerces non-String names via to_s (Symbol support)' do
+      result = observer.digest_snapshot([:API_KEY])
+
+      expect(result.key?('API_KEY')).to be(true)
+    end
+
+    it 'accepts a Set argument' do
+      result = observer.digest_snapshot(Set.new(%w[API_KEY]))
+
+      expect(result['API_KEY']).to eq(Digest::MD5.hexdigest('secret'))
+    end
+  end
+
+  describe '#invalidated_keys' do
+    it 'is empty when previous matches current' do
+      prev = observer.digest_snapshot(%w[API_KEY])
+
+      expect(observer.invalidated_keys(prev, %w[API_KEY])).to eq(Set.new)
+    end
+
+    it 'includes keys whose digest differs' do
+      prev = { 'API_KEY' => Digest::MD5.hexdigest('other') }
+
+      expect(observer.invalidated_keys(prev, %w[API_KEY])).to eq(Set.new(%w[API_KEY]))
+    end
+
+    it 'includes keys missing from the previous snapshot' do
+      prev = {}
+
+      expect(observer.invalidated_keys(prev, %w[API_KEY])).to eq(Set.new(%w[API_KEY]))
+    end
+
+    it 'returns all tracked names when previous_snapshot is nil' do
+      expect(observer.invalidated_keys(nil, %w[API_KEY ROLE_CONFIG]))
+        .to eq(Set.new(%w[API_KEY ROLE_CONFIG]))
+    end
+
+    it 'only considers names in the names argument (narrow scope)' do
+      prev = { 'API_KEY' => 'old', 'OTHER' => 'zero' }
+
+      expect(observer.invalidated_keys(prev, %w[API_KEY])).to eq(Set.new(%w[API_KEY]))
+    end
+
+    it 'is empty when names is empty (no-op)' do
+      expect(observer.invalidated_keys({ 'API_KEY' => 'old' }, [])).to eq(Set.new)
+    end
+  end
+
+  describe 'default env source' do
+    it 'reads from ::ENV when no injection is provided' do
+      observer = described_class.new
+      result = observer.digest_snapshot(%w[RSPEC_TRACER_ENV_SPEC_PROBE])
+
+      expect(result['RSPEC_TRACER_ENV_SPEC_PROBE']).to eq(Digest::MD5.hexdigest(''))
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds the `tracks:` RSpec metadata key so users can declare per-example dependencies that Coverage + IO observation cannot see — the escape hatch for env-var branches and invisible file reads.
- Persists env-var digests in a new \`env_snapshot.json\` cache file (no schema_version bump; missing file coerces to \`{}\` per the M4.3 \`wsi_snapshot\` precedent).
- The elected worker's finalize path + the JSON backend's \`Merger\` both handle the new field; \`parallel_tests\` users get correct env-mismatch re-runs with no extra config.

## Shape

\`\`\`ruby
describe 'AdminController',
         tracks: { files: 'app/policies/**/*.rb', env: 'ROLE_CONFIG' } do
  # examples inherit the files + env declarations; nested groups
  # union additively (not RSpec's default replace-on-merge).
end
\`\`\`

Both keys accept a String or Array of Strings. Nested groups' \`tracks:\` hashes are unioned, not replaced — \`RSpec::Metadata.tracks_for\` walks ancestors explicitly.

## Where the env-change filter fires

\`RunnerHook\` runs two passes:
1. Walk \`RSpec.world.filtered_examples\` once — call \`Engine#register_tracks\` per example and cache the \`Example.from\` tracer-example by object identity so Pass 2 doesn't re-hash.
2. \`Engine#apply_env_filter_decisions\` unions env-changed reasons into \`@filtered_examples\` (strictly additive — never overwrites a stronger prior reason like \`files_changed\` / \`whole_suite_invalidator\`).
3. Walk again to make run/skip decisions as before.

## Test plan

- [x] \`task lint:ruby\` / \`lint:actions\` / \`lint:yaml\` clean
- [x] \`task check:bundle\` satisfied
- [x] \`task security:bundle-audit\` / \`security:trivy\` clean
- [x] \`task test:unit\` — 840 examples, 0 failures; coverage gate silent
- [x] \`task test:property\` — 25 examples, 0 failures (new property spec: 200 iterations x 2 invariants)
- [x] \`task test:mutation:smoke\` — 13 subjects, all ≥ 90% (Tracker::EnvSnapshot 98.27%, 114/116 kills)
- [x] \`task test:dogfood\` green
- [x] \`task test:integration\` — 16 examples
- [x] \`task test:integration:parallel\` — 6 examples
- [x] \`task test:features:rails\` — 12 scenarios, 2m32s (feature_flags_spec annotation does not regress any scenario)
- [x] \`task test:integration:per-example-dsl\` — 5 examples, 10s (new integration spec)
- [x] \`task benchmark:smoke\` — cold_ruby / warm_noop within ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)