### PR TITLE
feat(reporters): protocol + JSON + Terminal reporters

### DIFF
--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -16,6 +16,14 @@ require_relative 'rspec_tracer/coverage_writer'
 require_relative 'rspec_tracer/defaults'
 require_relative 'rspec_tracer/engine'
 require_relative 'rspec_tracer/example'
+# Reporters must load before load_config so the Configuration DSL's
+# `add_reporter` can validate symbol names against
+# `Reporters::Registry::BUILT_INS` when a user `.rspec-tracer` calls
+# it at configure time (M6.1).
+require_relative 'rspec_tracer/reporters/base'
+require_relative 'rspec_tracer/reporters/json_reporter'
+require_relative 'rspec_tracer/reporters/terminal_reporter'
+require_relative 'rspec_tracer/reporters/registry'
 require_relative 'rspec_tracer/load_config'
 require_relative 'rspec_tracer/remote_cache/cache'
 require_relative 'rspec_tracer/rspec/installation'
@@ -48,6 +56,8 @@ module RSpecTracer
 
       RSpecTracer.running = false
       RSpecTracer.pid = Process.pid
+      @run_started_at = ::Time.now.utc
+      @run_monotonic_start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
       @started = true
 
       RSpecTracer.logger.debug "Started RSpec tracer (pid: #{RSpecTracer.pid})"
@@ -133,7 +143,8 @@ module RSpecTracer
       if RSpecTracer.no_examples
         RSpecTracer.logger.info 'Skipped reports generation since all examples were filtered out'
       else
-        run_finalize
+        snapshot = run_finalize
+        emit_reporters(snapshot) if snapshot
       end
 
       simplecov? ? run_simplecov_exit_task : run_coverage_exit_task
@@ -141,7 +152,7 @@ module RSpecTracer
       RSpecTracer::RSpec::ParallelTests.finalize! if parallel_tests?
     end
 
-    # Engine-owned finalize path. Engine writes the 13-file JSON cache
+    # Engine-owned finalize path. Engine writes the 15-file JSON cache
     # via Storage::JsonBackend; CoverageReporter still owns the
     # coverage.json surface (M3.6 Decision 2 - reporter rework lives in
     # Phase 6). The two paths share per-example coverage deltas via
@@ -154,12 +165,50 @@ module RSpecTracer
       coverage_reporter.generate_final_examples_coverage
       skipped_ids = engine.registry.ids_with_status(:skipped)
       coverage_reporter.merge_coverage(engine.merge_skipped_coverage(skipped_ids))
-      engine.finalize
+      snapshot = engine.finalize
 
       ending = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       elapsed = RSpecTracer::TimeFormatter.format_time(ending - starting)
 
       RSpecTracer.logger.debug "RSpec tracer persisted cache (took #{elapsed})"
+      snapshot
+    end
+
+    # M6.1. Fire the configured reporters against the persisted
+    # Snapshot. Fires per-worker under parallel_tests (same cadence as
+    # coverage.json emission); each worker produces its own report.json
+    # under its per-worker report_dir. The Registry rescues every
+    # reporter individually, so a buggy reporter warns and continues -
+    # never propagates a non-zero exit into the user's test suite
+    # (graceful degradation contract, same as Storage backends).
+    def emit_reporters(snapshot)
+      RSpecTracer::Reporters::Registry.emit_all(
+        configuration: RSpecTracer,
+        snapshot: snapshot,
+        report_dir: RSpecTracer.report_path,
+        run_metadata: build_run_metadata
+      )
+    rescue StandardError => e
+      RSpecTracer.logger.warn(
+        "rspec-tracer: reporter pipeline failed (#{e.class}: #{e.message})"
+      )
+    end
+
+    def build_run_metadata
+      {
+        pid: RSpecTracer.pid,
+        run_time: run_elapsed_seconds,
+        started_at: defined?(@run_started_at) ? @run_started_at : nil,
+        cache_path: RSpecTracer.cache_path,
+        parallel_tests: RSpecTracer.parallel_tests?,
+        rails: RSpecTracer.rails?
+      }
+    end
+
+    def run_elapsed_seconds
+      return nil unless defined?(@run_monotonic_start) && @run_monotonic_start
+
+      (::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - @run_monotonic_start).round(4)
     end
 
     def run_simplecov_exit_task

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -4,6 +4,7 @@ require_relative 'filter'
 require_relative 'logger'
 
 module RSpecTracer
+  # rubocop:disable Metrics/ModuleLength
   module Configuration
     class InvalidUsageError < StandardError; end
 
@@ -419,6 +420,62 @@ module RSpecTracer
       @storage_backend_name = resolved
     end
 
+    # M6.1 reporter DSL. Accumulates each call onto an internal list of
+    # `[name_or_class, opts]` pairs that `Reporters::Registry` walks
+    # at finalize-time. Matches the `track_files` accumulator shape.
+    #
+    # Shapes:
+    #   add_reporter :terminal
+    #   add_reporter :json
+    #   add_reporter MyCustomReporter, color: false
+    #
+    # Symbol names must match `Reporters::Registry::BUILT_INS.keys`
+    # (`:terminal`, `:json`; M6.2 adds `:html`). Class values are
+    # trusted - they must subclass / duck-type `Reporters::Base` but
+    # validation is deferred to initialize-time so custom reporters
+    # defined in user code don't have to exist at DSL-validate time.
+    #
+    # If the user never calls `add_reporter`, `Registry.emit_all`
+    # falls back to `Registry::DEFAULTS` (`[:terminal, :json]`).
+    def add_reporter(name_or_class, **opts)
+      validate_reporter_entry(name_or_class)
+      @reporters ||= []
+      @reporters << [name_or_class, opts]
+      @reporters.dup.freeze
+    end
+
+    # Readonly access to the accumulated reporter entries. Returns
+    # `nil` when no `add_reporter` calls were made - the Registry
+    # distinguishes nil (fall back to defaults) from `[]` (user
+    # opted out of every reporter).
+    def reporters
+      return nil unless defined?(@reporters)
+
+      @reporters.dup.freeze
+    end
+
+    def validate_reporter_entry(name_or_class)
+      case name_or_class
+      when ::Symbol
+        allowed = reporter_builtins_keys
+        return if allowed.include?(name_or_class)
+
+        raise InvalidUsageError,
+              "unknown reporter: #{name_or_class.inspect}; allowed: #{allowed.inspect}"
+      when ::Class
+        nil
+      else
+        raise InvalidUsageError,
+              "add_reporter: expected Symbol or Class, got #{name_or_class.class}"
+      end
+    end
+
+    def reporter_builtins_keys
+      return [] unless defined?(RSpecTracer::Reporters::Registry)
+
+      RSpecTracer::Reporters::Registry::BUILT_INS.keys
+    end
+
     def add_filter(filter = nil, &)
       filters << parse_filter(filter, &)
     end
@@ -467,4 +524,5 @@ module RSpecTracer
       RSpecTracer::Filter.register(arg)
     end
   end
+  # rubocop:enable Metrics/ModuleLength
 end

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -693,7 +693,8 @@ module RSpecTracer
         examples_coverage: @examples_coverage,
         boot_set: @loaded_files_tracker.boot_set_digest_snapshot,
         wsi_snapshot: @whole_suite_invalidators.digest_snapshot,
-        env_snapshot: env_snapshot_for_persistence
+        env_snapshot: env_snapshot_for_persistence,
+        env_dependency: env_dependency_for_persistence
       )
     end
 
@@ -706,6 +707,22 @@ module RSpecTracer
       return {} if @env_snapshot.nil? || @tracked_env_names.empty?
 
       @env_snapshot.digest_snapshot(@tracked_env_names)
+    end
+
+    # M6.1. Project the per-example `@tracks_env` map (Set<env_name>
+    # per example_id) into a JSON-friendly Hash[id => sorted Array]
+    # for persistence. Reporters consume this to render the env-
+    # dependency view on the Examples Dependency report. Empty sets
+    # drop out so the on-disk map stays narrow. Sort keeps the output
+    # deterministic for downstream diffs and golden tests.
+    def env_dependency_for_persistence
+      result = {}
+      @tracks_env.each do |example_id, names|
+        next if names.nil? || names.empty?
+
+        result[example_id] = names.to_a.sort
+      end
+      result
     end
 
     # Resolve one glob against the project root into a Set of

--- a/lib/rspec_tracer/reporters/README.md
+++ b/lib/rspec_tracer/reporters/README.md
@@ -1,28 +1,85 @@
 # Reporters
 
-Optional output formatters for tracer results. Each reporter is opt-in;
-the tracer engine functions with zero reporters attached.
+Output formatters for tracer results. Each reporter is pluggable via
+`config.add_reporter`; the tracer engine functions with zero reporters
+attached. Reporters sit above the Tracker + Storage layers, consume
+the finalized `Storage::Snapshot`, and emit to `report_dir`.
 
-## Responsibilities
+## Files
 
-- Consume the finalized dependency graph and run outcome.
-- Emit output in a specific format (JSON, terminal, HTML, custom).
-- Stay out of the hot path — reporters run at finalize, not per-example.
+| File                    | Role                                                                   |
+|-------------------------|------------------------------------------------------------------------|
+| `base.rb`               | Abstract `Reporters::Base` with `initialize(snapshot:, report_dir:, run_metadata:, logger:, **opts)`, `generate`, `no_op?`. |
+| `json_reporter.rb`      | `Reporters::JsonReporter` — writes `report_dir/report.json` with schema version 1; 5 report types. |
+| `terminal_reporter.rb`  | `Reporters::TerminalReporter` — concise stdout summary (≤ 5 lines); respects `NO_COLOR`. |
+| `registry.rb`           | `Reporters::Registry` — resolves configured reporters, rescues per-reporter, warns + continues on failure. |
 
-## Planned reporters
+## Configuration
 
-- `JsonReporter` — machine-readable run summary.
-- `TerminalReporter` — concise stdout summary.
-- `HtmlReporter` — five report types (dependency, coverage, examples,
-  flaky, slowest) with frontend build.
+```ruby
+# .rspec-tracer
+add_reporter :terminal
+add_reporter :json
+add_reporter MyCustomReporter, color: false
+```
+
+Symbols resolve via `Registry::BUILT_INS` (`:terminal`, `:json`;
+M6.2 adds `:html`). Class values pass through — must duck-type
+`Reporters::Base`. If no `add_reporter` calls are made, `Registry`
+defaults to `[:terminal, :json]`.
+
+## JSON schema (version 1)
+
+`<report_dir>/report.json` envelope:
+
+```json
+{
+  "schema_version": 1,
+  "run_id": "<hex>",
+  "generated_at": "<ISO-8601>",
+  "summary": { "total_examples": N, "passed_examples": N, "..." : "..." },
+  "reports": {
+    "all_examples": [...],
+    "duplicate_examples": [...],
+    "flaky_examples": [...],
+    "examples_dependency": [...],
+    "files_dependency": [...]
+  }
+}
+```
+
+Additive fields on existing objects are non-breaking. Removing or
+renaming a top-level key bumps `SCHEMA_VERSION`. Full field list
+lives in `json_reporter.rb`'s documentation comment.
+
+## Graceful degradation
+
+Every reporter runs inside an isolated rescue in `Registry#emit_all`.
+A raising reporter logs a warning via `configuration.logger.warn` and
+emission continues with the next reporter. This matches the Storage
+backend contract — a tracer failure never propagates a non-zero exit
+into the user's test suite.
 
 ## Extension
 
-Subclass `Reporters::Base` and register via `config.add_reporter`.
+Subclass `Reporters::Base`:
 
-## Status
+```ruby
+class MySlackReporter < RSpecTracer::Reporters::Base
+  def generate
+    return if no_op?
 
-Placeholder for 2.0. Legacy HTML reporter lives in
-`lib/rspec_tracer/html_reporter/` and migrates here during Phase 6
-(sessions M6.1, M6.2). Both directories coexist through the Phase 6
-transition.
+    post_to_slack(snapshot, report_dir, run_metadata)
+  end
+end
+```
+
+Register via `config.add_reporter MySlackReporter, webhook_url: ENV['SLACK_URL']`.
+
+## HTML reporter
+
+M6.1 ships Terminal + JSON. M6.2 adds HTML (`reporters/html_reporter.rb`
++ frontend build under `reporters/html/`). The legacy
+`lib/rspec_tracer/html_reporter/` tree remains in-tree through M6.2
+transition and is retired in the same PR that ships the new HTML
+reporter.

--- a/lib/rspec_tracer/reporters/base.rb
+++ b/lib/rspec_tracer/reporters/base.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module RSpecTracer
+  module Reporters
+    # Abstract base for every reporter M6.1 / M6.2 ships. Takes the
+    # finalized Storage::Snapshot + report_dir + run_metadata triplet
+    # (architectural decision (b), Option X - raw Snapshot, no
+    # projection struct) and exposes two lifecycle hooks:
+    #
+    #   - `generate` - subclass must implement; emits the reporter's
+    #     output format (JSON file, terminal lines, HTML etc.)
+    #   - `no_op?` - true when the run had zero tracked examples; the
+    #     Registry checks this before calling `generate` so empty runs
+    #     don't litter the report_dir with empty artifacts.
+    #
+    # `initialize` accepts `**opts` so custom reporters can take
+    # constructor args via `config.add_reporter MyReporter, color: false`.
+    # The base class itself ignores opts; subclasses read what they need.
+    #
+    # Errors during `generate` are NOT rescued here - the Registry
+    # wraps each reporter call in a per-reporter rescue + warn, so a
+    # buggy custom reporter never propagates a non-zero exit into the
+    # user's test suite (graceful degradation, same contract as
+    # Storage backends per ARCHITECTURE.md).
+    class Base
+      attr_reader :snapshot, :report_dir, :run_metadata, :logger, :options
+
+      def initialize(snapshot:, report_dir:, run_metadata:, logger: nil, **options)
+        @snapshot = snapshot
+        @report_dir = report_dir
+        @run_metadata = run_metadata || {}
+        @logger = logger
+        @options = options
+      end
+
+      def generate
+        raise NotImplementedError, "#{self.class}#generate must be implemented"
+      end
+
+      def no_op?
+        snapshot.nil? ||
+          snapshot.all_examples.nil? ||
+          snapshot.all_examples.empty?
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/reporters/json_reporter.rb
+++ b/lib/rspec_tracer/reporters/json_reporter.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'set'
+require 'time'
+
+require_relative 'base'
+
+module RSpecTracer
+  module Reporters
+    # Machine-readable summary of a tracer run. Writes
+    # `<report_dir>/report.json` containing a stable, schema-versioned
+    # envelope around the 5 report types that 1.x's HTML reporter
+    # surfaced (All, Duplicate, Flaky, Examples Dependency, Files
+    # Dependency) plus a run summary block.
+    #
+    # Schema contract (version 1, M6.1):
+    #
+    #   {
+    #     "schema_version": 1,
+    #     "run_id": <hex md5 of sorted example ids>,
+    #     "generated_at": <ISO-8601 UTC timestamp at emit time>,
+    #     "summary": {
+    #       "total_examples": <Integer>,
+    #       "passed_examples": <Integer>,
+    #       "failed_examples": <Integer>,
+    #       "pending_examples": <Integer>,
+    #       "skipped_examples": <Integer>,
+    #       "interrupted_examples": <Integer>,
+    #       "flaky_examples": <Integer>,
+    #       "duplicate_examples": <Integer>,
+    #       "tracked_env_keys": <Integer>,
+    #       "run_time": <Float|null>,
+    #       "started_at": <ISO-8601|null>,
+    #       "pid": <Integer|null>,
+    #       "parallel_tests": <Boolean>
+    #     },
+    #     "reports": {
+    #       "all_examples": [ {id, description, location, status, run_reason, execution_result}, ... ],
+    #       "duplicate_examples": [ {id, count, entries: [{description, location}, ...]}, ... ],
+    #       "flaky_examples": [ {id, description, location}, ... ],
+    #       "examples_dependency": [ {example_id, files: [...], env_keys: [...]}, ... ],
+    #       "files_dependency": [ {file_name, example_count, spec_files: {path => count}}, ... ]
+    #     }
+    #   }
+    #
+    # Breaking schema changes bump `SCHEMA_VERSION`. Additive fields
+    # (new keys in an existing object) are NOT breaking. Removed or
+    # renamed keys ARE. Downstream consumers (HTML reporter in M6.2,
+    # user CI dashboards) should branch on the top-level version.
+    class JsonReporter < Base
+      SCHEMA_VERSION = 1
+      FILENAME = 'report.json'
+
+      def generate
+        return nil if no_op?
+
+        FileUtils.mkdir_p(report_dir)
+        path = File.join(report_dir, FILENAME)
+        File.write(path, JSON.pretty_generate(build_payload), encoding: 'UTF-8')
+        logger&.debug("rspec-tracer: wrote report JSON to #{path}")
+        path
+      end
+
+      private
+
+      def build_payload
+        {
+          schema_version: SCHEMA_VERSION,
+          run_id: snapshot.run_id,
+          generated_at: Time.now.utc.iso8601,
+          summary: summary_block,
+          reports: {
+            all_examples: all_examples_report,
+            duplicate_examples: duplicate_examples_report,
+            flaky_examples: flaky_examples_report,
+            examples_dependency: examples_dependency_report,
+            files_dependency: files_dependency_report
+          }
+        }
+      end
+
+      def summary_block
+        {
+          total_examples: snapshot.all_examples.size,
+          passed_examples: count_status(:passed),
+          failed_examples: snapshot.failed_examples.size,
+          pending_examples: snapshot.pending_examples.size,
+          skipped_examples: snapshot.skipped_examples.size,
+          interrupted_examples: snapshot.interrupted_examples.size,
+          flaky_examples: snapshot.flaky_examples.size,
+          duplicate_examples: snapshot.duplicate_examples.size,
+          tracked_env_keys: (snapshot.env_snapshot || {}).size,
+          run_time: run_metadata[:run_time],
+          started_at: stringify_time(run_metadata[:started_at]),
+          pid: run_metadata[:pid],
+          parallel_tests: run_metadata[:parallel_tests] == true
+        }
+      end
+
+      def count_status(status)
+        status_str = status.to_s
+        snapshot.all_examples.count do |_, meta|
+          next false unless meta.is_a?(::Hash)
+
+          result = meta[:execution_result] || meta['execution_result']
+          next false unless result.is_a?(::Hash)
+
+          (result[:status] || result['status']).to_s == status_str
+        end
+      end
+
+      def all_examples_report
+        snapshot.all_examples.map do |id, meta|
+          meta = {} unless meta.is_a?(::Hash)
+          {
+            id: id,
+            description: meta[:full_description] || meta[:description],
+            location: location_for(meta),
+            status: status_for(id, meta),
+            run_reason: meta[:run_reason],
+            execution_result: normalize_execution_result(meta[:execution_result])
+          }
+        end
+      end
+
+      def duplicate_examples_report
+        snapshot.duplicate_examples.map do |id, entries|
+          list = entries.is_a?(::Array) ? entries : []
+          {
+            id: id,
+            count: list.size,
+            entries: list.map do |entry|
+              entry = {} unless entry.is_a?(::Hash)
+              { description: entry[:full_description] || entry[:description], location: location_for(entry) }
+            end
+          }
+        end
+      end
+
+      def flaky_examples_report
+        snapshot.flaky_examples.to_a.sort.map do |id|
+          meta = snapshot.all_examples[id]
+          meta = {} unless meta.is_a?(::Hash)
+          { id: id, description: meta[:full_description] || meta[:description], location: location_for(meta) }
+        end
+      end
+
+      def examples_dependency_report
+        env_map = snapshot.env_dependency || {}
+        snapshot.dependency.keys.sort.map do |id|
+          files = snapshot.dependency[id]
+          files_array = files.is_a?(::Set) ? files.to_a : Array(files)
+          {
+            example_id: id,
+            files: files_array.sort,
+            env_keys: Array(env_map[id]).sort
+          }
+        end
+      end
+
+      def files_dependency_report
+        entries = snapshot.reverse_dependency.map do |file_name, example_ids|
+          ids_array = example_ids.is_a?(::Set) ? example_ids.to_a : Array(example_ids)
+          spec_counts = aggregate_spec_counts(ids_array)
+          {
+            file_name: file_name,
+            example_count: ids_array.size,
+            spec_files: spec_counts
+          }
+        end
+        entries.sort_by { |e| [-e[:example_count], e[:file_name].to_s] }
+      end
+
+      def aggregate_spec_counts(example_ids)
+        counts = Hash.new(0)
+        example_ids.each do |id|
+          meta = snapshot.all_examples[id]
+          next unless meta.is_a?(::Hash)
+
+          spec = meta[:rerun_file_name] || meta[:file_name]
+          next if spec.nil? || spec.to_s.empty?
+
+          counts[spec.to_s] += 1
+        end
+        counts.sort_by { |name, count| [-count, name] }.to_h
+      end
+
+      def location_for(meta)
+        file = meta[:rerun_file_name] || meta[:file_name]
+        line = meta[:rerun_line_number] || meta[:line_number]
+        return nil if file.nil?
+
+        trimmed = file.to_s.sub(%r{^/}, '')
+        line.nil? ? trimmed : "#{trimmed}:#{line}"
+      end
+
+      # Ordering: interrupted > flaky > failed > pending > skipped >
+      # execution_result.status. Matches 1.x HTML reporter's status
+      # precedence so downstream consumers see the same labels.
+      def status_for(id, meta)
+        return 'interrupted' if snapshot.interrupted_examples.include?(id)
+        return 'flaky' if snapshot.flaky_examples.include?(id)
+        return 'failed' if snapshot.failed_examples.include?(id)
+        return 'pending' if snapshot.pending_examples.include?(id)
+        return 'skipped' if snapshot.skipped_examples.include?(id)
+
+        result = meta[:execution_result]
+        result.is_a?(::Hash) ? (result[:status] || 'unknown').to_s : 'unknown'
+      end
+
+      def normalize_execution_result(result)
+        return nil unless result.is_a?(::Hash)
+
+        {
+          started_at: stringify_time(result[:started_at]),
+          finished_at: stringify_time(result[:finished_at]),
+          run_time: result[:run_time],
+          status: (result[:status] || 'unknown').to_s
+        }
+      end
+
+      def stringify_time(value)
+        return nil if value.nil?
+        return value if value.is_a?(::String)
+        return value.iso8601 if value.respond_to?(:iso8601)
+
+        value.to_s
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/reporters/registry.rb
+++ b/lib/rspec_tracer/reporters/registry.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module RSpecTracer
+  module Reporters
+    # Orchestrates reporter emission at finalize-time. Called from
+    # `RSpecTracer#run_exit_tasks` once the Engine has persisted its
+    # Snapshot (architectural decision (a): wire from run_exit_tasks,
+    # not Engine-internal). Each configured reporter gets an isolated
+    # rescue; a buggy reporter warns + continues, never propagates a
+    # non-zero exit into the user's test suite.
+    #
+    # Reporter resolution:
+    #   - Configuration#reporters returns `[[name_or_class, opts], ...]`
+    #     when the user called `add_reporter`; `nil` otherwise.
+    #   - When nil, falls back to `DEFAULTS` (`[:terminal, :json]`).
+    #   - Symbol names resolve via `BUILT_INS` to in-tree reporter
+    #     classes. Class values pass through as-is (custom reporters
+    #     conforming to `Reporters::Base`).
+    #   - Unknown symbols raise `ArgumentError` at emit time; the DSL
+    #     validates eagerly, so this is the safety net for programmatic
+    #     callers.
+    class Registry
+      # Symbol -> lazy class-name mapping. Strings (not Class constants)
+      # so the require order doesn't force load of reporter classes
+      # when the Registry module itself is loaded - matches how
+      # `storage_backend`'s Configuration DSL defers backend resolution.
+      BUILT_INS = {
+        terminal: 'RSpecTracer::Reporters::TerminalReporter',
+        json: 'RSpecTracer::Reporters::JsonReporter'
+      }.freeze
+
+      DEFAULTS = %i[terminal json].freeze
+
+      def self.emit_all(configuration:, snapshot:, report_dir:, run_metadata:)
+        new(configuration: configuration).emit_all(
+          snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+        )
+      end
+
+      def initialize(configuration:)
+        @configuration = configuration
+      end
+
+      def emit_all(snapshot:, report_dir:, run_metadata:)
+        entries = resolve_entries
+        return [] if entries.empty?
+        return [] if empty_snapshot?(snapshot)
+
+        entries.map { |klass, opts| emit_one(klass, opts, snapshot, report_dir, run_metadata) }
+      end
+
+      private
+
+      def resolve_entries
+        declared = @configuration.respond_to?(:reporters) ? @configuration.reporters : nil
+        source = declared && !declared.empty? ? declared : DEFAULTS.map { |name| [name, {}] }
+        source.map { |name_or_class, opts| [resolve_class(name_or_class), opts || {}] }
+      end
+
+      def resolve_class(name_or_class)
+        return name_or_class if name_or_class.is_a?(Class)
+
+        const_name = BUILT_INS.fetch(name_or_class) do
+          raise ArgumentError, "unknown reporter: #{name_or_class.inspect}"
+        end
+
+        Object.const_get(const_name)
+      end
+
+      def emit_one(klass, opts, snapshot, report_dir, run_metadata)
+        reporter = klass.new(
+          snapshot: snapshot,
+          report_dir: report_dir,
+          run_metadata: run_metadata,
+          logger: logger,
+          **opts
+        )
+        reporter.generate
+      rescue StandardError => e
+        warn_continue(klass, e)
+        nil
+      end
+
+      def warn_continue(klass, err)
+        logger&.warn("rspec-tracer: reporter #{klass.name} failed (#{err.class}: #{err.message})")
+      end
+
+      def logger
+        @configuration.respond_to?(:logger) ? @configuration.logger : nil
+      end
+
+      def empty_snapshot?(snapshot)
+        snapshot.nil? || snapshot.all_examples.nil? || snapshot.all_examples.empty?
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/reporters/terminal_reporter.rb
+++ b/lib/rspec_tracer/reporters/terminal_reporter.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module RSpecTracer
+  module Reporters
+    # Concise stdout summary printed at finalize-time. Output is
+    # capped at 4 lines for a typical run (5 when duplicate /
+    # interrupted / flaky / pending counters are non-zero). Kind-less
+    # taxonomy per M6.1 decision - the in-memory Input#kind enum does
+    # not survive Storage::Snapshot persistence, so breaking down
+    # "Changed files: Templates / Locales / Ruby" would require a
+    # schema bump (deferred).
+    #
+    # Color policy:
+    #   - Respects `NO_COLOR` per https://no-color.org/ (any value
+    #     disables, even empty string).
+    #   - Emits ANSI codes only when the output stream reports tty?.
+    #   - The header line paints red on any failure / interrupted,
+    #     yellow on pending-only, green otherwise.
+    class TerminalReporter < Base
+      COLORS = {
+        reset: 0,
+        red: 31,
+        green: 32,
+        yellow: 33,
+        cyan: 36
+      }.freeze
+      private_constant :COLORS
+
+      # "\u00B7" = U+00B7 MIDDLE DOT. Written as the ASCII escape form
+      # so mutant's US-ASCII-defaulted parser doesn't choke on
+      # non-ASCII bytes in the source file. Same discipline as the
+      # dependency_graph.rb fix (M3.5).
+      SEPARATOR = " \u00B7 "
+      private_constant :SEPARATOR
+
+      # Snapshot-set-name => human label pairs for the tally line.
+      # Data-driven to keep tally_line's AbcSize below rubocop's
+      # threshold; new counters go here without growing the method.
+      TALLY_FIELDS = [
+        [:failed_examples, 'failed'],
+        [:pending_examples, 'pending'],
+        [:flaky_examples, 'flaky'],
+        [:interrupted_examples, 'interrupted']
+      ].freeze
+      private_constant :TALLY_FIELDS
+
+      def generate
+        return nil if no_op?
+
+        lines = build_lines
+        stream = output_stream
+        lines.each { |line| stream.puts line }
+        lines
+      end
+
+      private
+
+      def build_lines
+        [header_line, tally_line, cache_line, report_line].compact
+      end
+
+      def header_line
+        total = snapshot.all_examples.size
+        run = run_count
+        skipped = snapshot.skipped_examples.size
+        cached_pct = cache_percent(total, skipped)
+
+        text = "rspec-tracer: #{total} examples tracked" \
+               "#{SEPARATOR}#{run} re-run#{SEPARATOR}#{skipped} skipped " \
+               "(#{cached_pct}% cached)"
+        paint(header_color, text)
+      end
+
+      def tally_line
+        parts = TALLY_FIELDS.filter_map do |field, label|
+          ids = snapshot.send(field)
+          "#{ids.size} #{label}" unless ids.empty?
+        end
+        parts << "#{duplicate_count} duplicate" if duplicate_count.positive?
+        return nil if parts.empty?
+
+        paint(:yellow, parts.join(SEPARATOR))
+      end
+
+      def cache_line
+        path = run_metadata[:cache_path]
+        return nil if path.nil? || path.to_s.empty?
+
+        "cache: #{path}"
+      end
+
+      def report_line
+        return nil if report_dir.nil? || report_dir.to_s.empty?
+
+        "report: #{File.join(report_dir, JsonReporter::FILENAME)}"
+      end
+
+      def header_color
+        return :red if snapshot.failed_examples.any? || snapshot.interrupted_examples.any?
+        return :yellow if snapshot.pending_examples.any?
+
+        :green
+      end
+
+      def run_count
+        snapshot.all_examples.count do |_, meta|
+          meta.is_a?(::Hash) && meta[:execution_result]
+        end
+      end
+
+      def duplicate_count
+        snapshot.duplicate_examples.size
+      end
+
+      def cache_percent(total, skipped)
+        return 0 if total.zero?
+
+        ((skipped.to_f / total) * 100).round
+      end
+
+      def paint(color_key, text)
+        return text unless use_color?
+
+        code = COLORS.fetch(color_key, COLORS[:reset])
+        "\e[#{code}m#{text}\e[#{COLORS[:reset]}m"
+      end
+
+      def use_color?
+        return false if ENV.key?('NO_COLOR')
+
+        output_stream.respond_to?(:tty?) && output_stream.tty?
+      end
+
+      def output_stream
+        options[:io] || $stdout
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/storage/json_backend.rb
+++ b/lib/rspec_tracer/storage/json_backend.rb
@@ -57,6 +57,10 @@ module RSpecTracer
       # digest map for env-var values the per-example `tracks:
       # { env: ... }` DSL declares. Same missing-coerces-to-`{}`
       # fallback as wsi_snapshot - no schema bump.
+      # env_dependency.json (M6.1) persists the per-example tracked-env
+      # attribution map that reporters need for the Examples Dependency
+      # report. Missing file coerces to `{}`; pre-M6.1 caches load
+      # without a cold re-run.
       FILENAMES = %w[
         all_examples.json
         duplicate_examples.json
@@ -72,6 +76,7 @@ module RSpecTracer
         boot_set.json
         wsi_snapshot.json
         env_snapshot.json
+        env_dependency.json
       ].freeze
 
       LAST_RUN_FILENAME = 'last_run.json'
@@ -88,7 +93,7 @@ module RSpecTracer
       ].freeze
       HASH_FIELDS = %w[
         all_examples duplicate_examples all_files examples_coverage
-        boot_set wsi_snapshot env_snapshot
+        boot_set wsi_snapshot env_snapshot env_dependency
       ].freeze
       DEPENDENCY_FIELDS = %w[dependency reverse_dependency].freeze
       SYMBOLIZED_FIELDS = %w[all_examples all_files].freeze
@@ -96,7 +101,10 @@ module RSpecTracer
       # key/value transformation. examples_coverage (1.x) preserved
       # string keys; boot_set (M3.7), wsi_snapshot (M4.3), and
       # env_snapshot (M5.2) are simple name/path => digest maps.
-      PLAIN_HASH_FIELDS = %w[examples_coverage boot_set wsi_snapshot env_snapshot].freeze
+      # env_dependency (M6.1) is Hash[example_id => Array<env_name>] -
+      # JSON-native on both sides, no Set reconstruction needed since
+      # only reporters consume it (iteration-only surface).
+      PLAIN_HASH_FIELDS = %w[examples_coverage boot_set wsi_snapshot env_snapshot env_dependency].freeze
 
       attr_reader :cache_path
 
@@ -229,7 +237,8 @@ module RSpecTracer
             examples_coverage: state[:examples_coverage],
             boot_set: state[:boot_set],
             wsi_snapshot: state[:wsi_snapshot],
-            env_snapshot: state[:env_snapshot]
+            env_snapshot: state[:env_snapshot],
+            env_dependency: state[:env_dependency]
           )
         end
 
@@ -247,7 +256,8 @@ module RSpecTracer
             examples_coverage: {},
             boot_set: {},
             wsi_snapshot: {},
-            env_snapshot: {}
+            env_snapshot: {},
+            env_dependency: {}
           }
         end
 
@@ -275,8 +285,20 @@ module RSpecTracer
           state[:boot_set].merge!(snapshot.boot_set || {})
           state[:wsi_snapshot].merge!(snapshot.wsi_snapshot || {})
           state[:env_snapshot].merge!(snapshot.env_snapshot || {})
+          merge_env_dependency!(state[:env_dependency], snapshot.env_dependency || {})
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        # Per-example env attribution unions set-wise: an example that
+        # declared `tracks: { env: [A, B] }` on one worker and
+        # `tracks: { env: [B, C] }` on another (edge case; parallel_tests
+        # workers rarely run the same example) collapses to [A, B, C].
+        def merge_env_dependency!(target, source)
+          source.each do |id, names|
+            existing = target[id] || []
+            target[id] = (existing | Array(names)).sort
+          end
+        end
 
         def merge_examples_coverage!(target, source)
           source.each do |id, per_file|

--- a/lib/rspec_tracer/storage/snapshot.rb
+++ b/lib/rspec_tracer/storage/snapshot.rb
@@ -49,6 +49,16 @@ module RSpecTracer
     # needs to re-run when the env changes. Same optional-in-JSON
     # treatment as wsi_snapshot: missing file coerces to `{}`, no
     # schema_version bump, one cold re-run on upgrade.
+    #
+    # M6.1 adds `env_dependency` - Hash[example_id => Array<env_name>]
+    # capturing which env keys each tracked example declared. The
+    # per-run `env_snapshot` stores the digest of each key; this map
+    # stores the example-to-key attribution that the reporter layer
+    # needs to render "which env vars does this example depend on."
+    # Without it, reports can't surface env dependencies - Engine's
+    # per-run `@tracks_env` map would otherwise be lost at finalize.
+    # Same optional-in-JSON treatment as wsi_snapshot / env_snapshot:
+    # missing file coerces to `{}`, no schema_version bump.
     Snapshot = Struct.new(
       :schema_version,
       :run_id,
@@ -66,6 +76,7 @@ module RSpecTracer
       :boot_set,
       :wsi_snapshot,
       :env_snapshot,
+      :env_dependency,
       keyword_init: true
     )
 
@@ -91,7 +102,8 @@ module RSpecTracer
           examples_coverage: {},
           boot_set: {},
           wsi_snapshot: {},
-          env_snapshot: {}
+          env_snapshot: {},
+          env_dependency: {}
         )
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -470,6 +470,64 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
+  describe '#add_reporter / #reporters (M6.1)' do
+    before { require 'rspec_tracer/reporters/registry' }
+
+    it 'returns nil for reporters when never configured' do
+      expect(config.reporters).to be_nil
+    end
+
+    it 'accumulates [name, opts] tuples across calls' do
+      config.add_reporter(:terminal)
+      config.add_reporter(:json)
+
+      expect(config.reporters.map(&:first)).to eq(%i[terminal json])
+    end
+
+    it 'passes **opts through to the reporter entry' do
+      config.add_reporter(:json, indent: 4)
+
+      expect(config.reporters.first.last).to eq(indent: 4)
+    end
+
+    it 'freezes the returned array' do
+      config.add_reporter(:terminal)
+
+      expect(config.reporters).to be_frozen
+    end
+
+    it 'raises InvalidUsageError on an unknown symbol' do
+      expect { config.add_reporter(:bogus) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /unknown reporter/)
+    end
+
+    it 'raises InvalidUsageError on a non-Symbol / non-Class argument' do
+      expect { config.add_reporter(42) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /expected Symbol or Class/)
+    end
+
+    it 'accepts a Class value (custom reporter)' do
+      custom_class = Class.new
+
+      config.add_reporter(custom_class)
+
+      expect(config.reporters.first.first).to eq(custom_class)
+    end
+
+    it 'returns the (frozen) current list from add_reporter' do
+      result = config.add_reporter(:terminal)
+
+      expect(result).to be_frozen
+    end
+
+    it 'tolerates reporter validation when Registry is not loaded (fallback to no allowed)' do
+      hide_const('RSpecTracer::Reporters::Registry')
+
+      expect { config.add_reporter(:terminal) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /unknown reporter/)
+    end
+  end
+
   describe '#add_filter' do
     # Uses the isolated `config` instance (Class.new { include Configuration })
     # rather than the global RSpecTracer constant so a registered filter

--- a/spec/contracts/reporter.rb
+++ b/spec/contracts/reporter.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/reporters/base'
+
+# Shared-examples contract for RSpecTracer::Reporters::Base subclasses.
+# Each reporter's spec includes this with `it_behaves_like 'a Reporters::Base'`
+# after binding:
+#
+#   let(:reporter_class) { described_class }
+#   let(:report_dir)     { Dir.mktmpdir }
+#   let(:snapshot)       { # populated snapshot (non-empty all_examples)  }
+#   let(:empty_snapshot) { RSpecTracer::Storage::Snapshot.empty(...) }
+#   let(:run_metadata)   { {} }
+#
+# Reporters that break these assertions are non-conformant even if
+# their own unit tests pass. The contract is behavioral: subclasses
+# must accept the input envelope, tolerate an empty snapshot, and
+# never raise out of generate (they may return nil on no-op, but
+# raising pollutes the at_exit chain).
+# rubocop:disable RSpec/ExampleLength
+RSpec.shared_examples 'a Reporters::Base' do
+  describe 'input envelope' do
+    it 'accepts (snapshot:, report_dir:, run_metadata:, logger:)' do
+      expect do
+        reporter_class.new(
+          snapshot: snapshot, report_dir: report_dir,
+          run_metadata: {}, logger: nil
+        )
+      end.not_to raise_error
+    end
+
+    it 'accepts extra **opts without raising' do
+      expect do
+        reporter_class.new(
+          snapshot: snapshot, report_dir: report_dir,
+          run_metadata: {}, logger: nil, something_custom: true
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe '#no_op?' do
+    it 'is true when the snapshot has no tracked examples' do
+      reporter = reporter_class.new(
+        snapshot: empty_snapshot, report_dir: report_dir,
+        run_metadata: {}, logger: nil
+      )
+
+      expect(reporter.no_op?).to be(true)
+    end
+
+    it 'is false when the snapshot has at least one tracked example' do
+      reporter = reporter_class.new(
+        snapshot: snapshot, report_dir: report_dir,
+        run_metadata: {}, logger: nil
+      )
+
+      expect(reporter.no_op?).to be(false)
+    end
+  end
+
+  describe '#generate' do
+    it 'returns nil / falsy on an empty snapshot and does not raise' do
+      reporter = reporter_class.new(
+        snapshot: empty_snapshot, report_dir: report_dir,
+        run_metadata: {}, logger: nil
+      )
+
+      expect { reporter.generate }.not_to raise_error
+    end
+
+    it 'does not raise on a populated snapshot' do
+      reporter = reporter_class.new(
+        snapshot: snapshot, report_dir: report_dir,
+        run_metadata: {}, logger: nil
+      )
+
+      expect { reporter.generate }.not_to raise_error
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -309,6 +309,32 @@ RSpec.describe RSpecTracer::Engine do
 
       expect(snapshot.env_snapshot).to eq({})
     end
+
+    it 'persists env_dependency per example (M6.1 - reporter input)' do
+      tracker.register_tracks('ex1', files: Set.new, env: Set.new(%w[API_KEY ROLE]))
+      tracker.register_tracks('ex2', files: Set.new, env: Set.new(['API_KEY']))
+
+      snapshot = tracker.finalize
+
+      expect(snapshot.env_dependency).to eq(
+        'ex1' => %w[API_KEY ROLE],
+        'ex2' => ['API_KEY']
+      )
+    end
+
+    it 'leaves env_dependency empty when no tracks were registered' do
+      snapshot = tracker.finalize
+
+      expect(snapshot.env_dependency).to eq({})
+    end
+
+    it 'omits examples with empty env sets from env_dependency' do
+      tracker.register_tracks('ex_filesonly', files: Set.new(['config/*.yml']), env: Set.new)
+
+      snapshot = tracker.finalize
+
+      expect(snapshot.env_dependency).to eq({})
+    end
   end
 
   describe '#register_tracks (M5.2 DSL hook)' do

--- a/spec/reporters/base_spec.rb
+++ b/spec/reporters/base_spec.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'tmpdir'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/reporters/base'
+
+RSpec.describe RSpecTracer::Reporters::Base do
+  let(:tmp) { Dir.mktmpdir }
+  let(:snapshot) do
+    RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'r').tap do |s|
+      s.all_examples = { 'ex1' => { id: 'ex1' } }
+    end
+  end
+  let(:empty_snapshot) { RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'r') }
+
+  after { FileUtils.remove_entry(tmp) if File.directory?(tmp) }
+
+  describe '#initialize' do
+    it 'exposes the snapshot' do
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: { pid: 1 })
+
+      expect(reporter.snapshot).to be(snapshot)
+    end
+
+    it 'exposes the report_dir' do
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: {})
+
+      expect(reporter.report_dir).to eq(tmp)
+    end
+
+    it 'exposes run_metadata as a Hash' do
+      meta = { pid: 7 }
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: meta)
+
+      expect(reporter.run_metadata).to eq(meta)
+    end
+
+    it 'coerces a nil run_metadata to an empty Hash (defensive for custom callers)' do
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: nil)
+
+      expect(reporter.run_metadata).to eq({})
+    end
+
+    it 'captures the optional logger' do
+      logger = instance_double(RSpecTracer::Logger)
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: {}, logger: logger)
+
+      expect(reporter.logger).to be(logger)
+    end
+
+    it 'captures arbitrary **opts into options' do
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: {}, something: 42)
+
+      expect(reporter.options).to eq(something: 42)
+    end
+  end
+
+  describe '#generate' do
+    it 'raises NotImplementedError to force subclass override' do
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: {})
+
+      expect { reporter.generate }.to raise_error(NotImplementedError, /generate must be implemented/)
+    end
+  end
+
+  describe '#no_op?' do
+    it 'is true when snapshot is nil' do
+      reporter = described_class.new(snapshot: nil, report_dir: tmp, run_metadata: {})
+
+      expect(reporter.no_op?).to be(true)
+    end
+
+    it 'is true when snapshot.all_examples is nil' do
+      snap = RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'r')
+      snap.all_examples = nil
+      reporter = described_class.new(snapshot: snap, report_dir: tmp, run_metadata: {})
+
+      expect(reporter.no_op?).to be(true)
+    end
+
+    it 'is true when snapshot.all_examples is an empty Hash' do
+      reporter = described_class.new(snapshot: empty_snapshot, report_dir: tmp, run_metadata: {})
+
+      expect(reporter.no_op?).to be(true)
+    end
+
+    it 'is false when at least one example is present' do
+      reporter = described_class.new(snapshot: snapshot, report_dir: tmp, run_metadata: {})
+
+      expect(reporter.no_op?).to be(false)
+    end
+  end
+end

--- a/spec/reporters/json_reporter_spec.rb
+++ b/spec/reporters/json_reporter_spec.rb
@@ -1,0 +1,664 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'set'
+require 'tmpdir'
+require 'time'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/reporters/json_reporter'
+
+require_relative '../contracts/reporter'
+
+# Reporter specs need a large fixture snapshot + many helpers to cover every
+# report shape + defensive branch; the resulting let / method lengths trip
+# the default RSpec heuristics. Same pattern as json_backend_spec.
+# rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations
+# rubocop:disable RSpec/ExampleLength, Metrics/MethodLength
+RSpec.describe RSpecTracer::Reporters::JsonReporter do
+  let(:tmp) { Dir.mktmpdir }
+  let(:empty_snapshot) { RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'empty') }
+  let(:snapshot) { build_populated_snapshot }
+  let(:run_metadata) do
+    {
+      pid: 1234,
+      run_time: 4.25,
+      started_at: Time.utc(2026, 4, 23, 12, 0, 0),
+      cache_path: '/tmp/fake_cache',
+      parallel_tests: false
+    }
+  end
+  let(:report_dir) { File.join(tmp, 'rspec_tracer_report') }
+  let(:reporter_class) { described_class }
+
+  after { FileUtils.remove_entry(tmp) if File.directory?(tmp) }
+
+  def build_populated_snapshot
+    started = Time.utc(2026, 4, 23, 12, 0, 0)
+    finished = started + 0.012
+    RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'runabc').tap do |s|
+      s.all_examples = {
+        'ex1' => {
+          full_description: 'User signs in',
+          rerun_file_name: '/spec/session_spec.rb',
+          rerun_line_number: 42,
+          run_reason: 'Files changed',
+          execution_result: {
+            started_at: started, finished_at: finished, run_time: 0.012, status: :passed
+          }
+        },
+        'ex2' => {
+          full_description: 'User logs out',
+          rerun_file_name: '/spec/session_spec.rb',
+          rerun_line_number: 50,
+          run_reason: nil,
+          execution_result: nil
+        },
+        'ex3' => {
+          full_description: 'Admin edits',
+          rerun_file_name: '/spec/admin_spec.rb',
+          rerun_line_number: 10,
+          run_reason: 'Environment changed',
+          execution_result: { started_at: nil, finished_at: nil, run_time: 0.005, status: :failed }
+        }
+      }
+      s.duplicate_examples = {
+        'dup_id' => [
+          { full_description: 'dup a', rerun_file_name: '/spec/a_spec.rb', rerun_line_number: 1 },
+          { full_description: 'dup b', rerun_file_name: '/spec/b_spec.rb', rerun_line_number: 2 }
+        ]
+      }
+      s.interrupted_examples = Set.new
+      s.flaky_examples = Set.new(['ex1'])
+      s.failed_examples = Set.new(['ex3'])
+      s.pending_examples = Set.new
+      s.skipped_examples = Set.new(['ex2'])
+      s.all_files = {
+        '/lib/session.rb' => { file_name: '/lib/session.rb', digest: 'sha1' },
+        '/lib/admin.rb' => { file_name: '/lib/admin.rb', digest: 'sha2' }
+      }
+      s.dependency = {
+        'ex1' => Set.new(['/lib/session.rb']),
+        'ex3' => Set.new(['/lib/admin.rb', '/lib/session.rb'])
+      }
+      s.reverse_dependency = {
+        '/lib/session.rb' => Set.new(%w[ex1 ex3]),
+        '/lib/admin.rb' => Set.new(['ex3'])
+      }
+      s.examples_coverage = {}
+      s.boot_set = {}
+      s.wsi_snapshot = {}
+      s.env_snapshot = { 'API_KEY' => 'deadbeef' }
+      s.env_dependency = { 'ex3' => ['API_KEY'] }
+    end
+  end
+
+  def build_reporter(snap: snapshot, metadata: run_metadata)
+    described_class.new(
+      snapshot: snap, report_dir: report_dir,
+      run_metadata: metadata, logger: nil
+    )
+  end
+
+  def read_payload
+    JSON.parse(File.read(File.join(report_dir, 'report.json')))
+  end
+
+  it_behaves_like 'a Reporters::Base'
+
+  describe '#generate (no-op path)' do
+    it 'returns nil when the snapshot has no tracked examples' do
+      expect(build_reporter(snap: empty_snapshot).generate).to be_nil
+    end
+
+    it 'does not create the report file on no-op' do
+      build_reporter(snap: empty_snapshot).generate
+
+      expect(File).not_to exist(File.join(report_dir, 'report.json'))
+    end
+  end
+
+  describe '#generate (populated path)' do
+    it 'creates the report_dir if missing' do
+      build_reporter.generate
+
+      expect(File).to be_directory(report_dir)
+    end
+
+    it 'writes report.json under report_dir' do
+      build_reporter.generate
+
+      expect(File).to exist(File.join(report_dir, 'report.json'))
+    end
+
+    it 'returns the written path' do
+      expect(build_reporter.generate).to eq(File.join(report_dir, 'report.json'))
+    end
+
+    it 'logs a debug line through the provided logger' do
+      logger = instance_double(RSpecTracer::Logger, debug: nil)
+      described_class.new(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata, logger: logger
+      ).generate
+
+      expect(logger).to have_received(:debug).with(/wrote report JSON/)
+    end
+  end
+
+  describe 'payload envelope' do
+    before { build_reporter.generate }
+
+    it 'stamps the schema_version (version 1 for M6.1)' do
+      expect(read_payload['schema_version']).to eq(1)
+    end
+
+    it 'stamps the run_id from the snapshot' do
+      expect(read_payload['run_id']).to eq('runabc')
+    end
+
+    it 'stamps a UTC ISO-8601 generated_at timestamp' do
+      expect(read_payload['generated_at']).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    end
+
+    it 'exposes all 5 report types under "reports"' do
+      expect(read_payload['reports'].keys).to contain_exactly(
+        'all_examples', 'duplicate_examples', 'flaky_examples',
+        'examples_dependency', 'files_dependency'
+      )
+    end
+  end
+
+  describe 'summary block' do
+    before { build_reporter.generate }
+
+    it 'counts total examples' do
+      expect(read_payload.dig('summary', 'total_examples')).to eq(3)
+    end
+
+    it 'counts passed examples via execution_result.status' do
+      expect(read_payload.dig('summary', 'passed_examples')).to eq(1)
+    end
+
+    it 'counts failed/pending/skipped/flaky from the status sets' do
+      summary = read_payload['summary']
+
+      expect(summary).to include(
+        'failed_examples' => 1,
+        'pending_examples' => 0,
+        'skipped_examples' => 1,
+        'flaky_examples' => 1,
+        'interrupted_examples' => 0,
+        'duplicate_examples' => 1
+      )
+    end
+
+    it 'reports tracked_env_keys from env_snapshot' do
+      expect(read_payload.dig('summary', 'tracked_env_keys')).to eq(1)
+    end
+
+    it 'forwards run_time from run_metadata' do
+      expect(read_payload.dig('summary', 'run_time')).to eq(4.25)
+    end
+
+    it 'stringifies started_at via iso8601' do
+      expect(read_payload.dig('summary', 'started_at')).to eq('2026-04-23T12:00:00Z')
+    end
+
+    it 'forwards pid from run_metadata' do
+      expect(read_payload.dig('summary', 'pid')).to eq(1234)
+    end
+
+    it 'reflects parallel_tests flag' do
+      expect(read_payload.dig('summary', 'parallel_tests')).to be(false)
+    end
+
+    it 'tolerates run_metadata without keys (defensive)' do
+      reporter = described_class.new(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: {}, logger: nil
+      )
+      reporter.generate
+
+      expect(read_payload.dig('summary', 'run_time')).to be_nil
+    end
+
+    it 'tolerates a nil env_snapshot (defensive)' do
+      snap = build_populated_snapshot
+      snap.env_snapshot = nil
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      expect(read_payload.dig('summary', 'tracked_env_keys')).to eq(0)
+    end
+  end
+
+  describe 'all_examples report' do
+    before { build_reporter.generate }
+
+    let(:entries) { read_payload.dig('reports', 'all_examples') }
+
+    it 'emits one entry per example' do
+      expect(entries.map { |e| e['id'] }).to contain_exactly('ex1', 'ex2', 'ex3')
+    end
+
+    it 'picks full_description when present' do
+      ex1 = entries.find { |e| e['id'] == 'ex1' }
+
+      expect(ex1['description']).to eq('User signs in')
+    end
+
+    it 'surfaces run_reason' do
+      ex3 = entries.find { |e| e['id'] == 'ex3' }
+
+      expect(ex3['run_reason']).to eq('Environment changed')
+    end
+
+    it 'stringifies execution_result times via iso8601' do
+      ex1 = entries.find { |e| e['id'] == 'ex1' }
+
+      expect(ex1.dig('execution_result', 'started_at')).to match(/\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    end
+
+    it 'yields null execution_result when the example has none (skipped/filtered)' do
+      ex2 = entries.find { |e| e['id'] == 'ex2' }
+
+      expect(ex2['execution_result']).to be_nil
+    end
+
+    it 'strips leading slash + appends :line in location' do
+      ex1 = entries.find { |e| e['id'] == 'ex1' }
+
+      expect(ex1['location']).to eq('spec/session_spec.rb:42')
+    end
+
+    it 'classifies status via the priority ladder' do
+      ex1 = entries.find { |e| e['id'] == 'ex1' }
+      ex2 = entries.find { |e| e['id'] == 'ex2' }
+      ex3 = entries.find { |e| e['id'] == 'ex3' }
+
+      expect([ex1['status'], ex2['status'], ex3['status']]).to eq(%w[flaky skipped failed])
+    end
+
+    it 'coerces non-Hash meta entries to defaults without raising' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_bad' => 'not a hash' }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      bad = read_payload.dig('reports', 'all_examples').first
+
+      expect(bad['id']).to eq('ex_bad')
+      expect(bad['description']).to be_nil
+      expect(bad['location']).to be_nil
+    end
+
+    it 'falls back to description when full_description is absent' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_desc' => { description: 'just short' } }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry['description']).to eq('just short')
+    end
+
+    it 'returns status unknown when execution_result has no status' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_noexec' => { execution_result: 'not a hash' } }
+      snap.failed_examples = Set.new
+      snap.flaky_examples = Set.new
+      snap.pending_examples = Set.new
+      snap.skipped_examples = Set.new
+      snap.interrupted_examples = Set.new
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry['status']).to eq('unknown')
+    end
+
+    it 'classifies status interrupted when in interrupted_examples' do
+      snap = build_populated_snapshot
+      snap.interrupted_examples = Set.new(['ex1'])
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      ex1 = read_payload.dig('reports', 'all_examples').find { |e| e['id'] == 'ex1' }
+
+      expect(ex1['status']).to eq('interrupted')
+    end
+
+    it 'classifies status pending when in pending_examples' do
+      snap = build_populated_snapshot
+      snap.flaky_examples = Set.new
+      snap.pending_examples = Set.new(['ex1'])
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      ex1 = read_payload.dig('reports', 'all_examples').find { |e| e['id'] == 'ex1' }
+
+      expect(ex1['status']).to eq('pending')
+    end
+
+    it 'classifies status from execution_result when no status set claims it' do
+      snap = build_populated_snapshot
+      snap.flaky_examples = Set.new
+      snap.failed_examples = Set.new
+      snap.skipped_examples = Set.new
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      ex1 = read_payload.dig('reports', 'all_examples').find { |e| e['id'] == 'ex1' }
+
+      expect(ex1['status']).to eq('passed')
+    end
+  end
+
+  describe 'duplicate_examples report' do
+    before { build_reporter.generate }
+
+    let(:entries) { read_payload.dig('reports', 'duplicate_examples') }
+
+    it 'emits one entry per duplicate id' do
+      expect(entries.map { |e| e['id'] }).to eq(['dup_id'])
+    end
+
+    it 'counts the entries per duplicate id' do
+      expect(entries.first['count']).to eq(2)
+    end
+
+    it 'flattens each duplicate entry into { description, location }' do
+      expect(entries.first['entries'].map { |e| e['description'] }).to contain_exactly('dup a', 'dup b')
+    end
+
+    it 'coerces non-Array entries to empty list' do
+      snap = build_populated_snapshot
+      snap.duplicate_examples = { 'weird' => 'not an array' }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      dup = read_payload.dig('reports', 'duplicate_examples').first
+
+      expect(dup).to eq('id' => 'weird', 'count' => 0, 'entries' => [])
+    end
+
+    it 'coerces non-Hash entry items to defaults' do
+      snap = build_populated_snapshot
+      snap.duplicate_examples = { 'dup' => ['not a hash'] }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      dup = read_payload.dig('reports', 'duplicate_examples').first
+
+      expect(dup['entries'].first).to eq('description' => nil, 'location' => nil)
+    end
+  end
+
+  describe 'flaky_examples report' do
+    before { build_reporter.generate }
+
+    let(:entries) { read_payload.dig('reports', 'flaky_examples') }
+
+    it 'emits one entry per flaky id' do
+      expect(entries.map { |e| e['id'] }).to eq(['ex1'])
+    end
+
+    it 'projects description + location from all_examples' do
+      expect(entries.first).to include(
+        'description' => 'User signs in',
+        'location' => 'spec/session_spec.rb:42'
+      )
+    end
+
+    it 'tolerates a flaky id missing from all_examples (defensive for cache drift)' do
+      snap = build_populated_snapshot
+      snap.flaky_examples = Set.new(['ghost_id'])
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      ghost = read_payload.dig('reports', 'flaky_examples').find { |e| e['id'] == 'ghost_id' }
+
+      expect(ghost).to include('id' => 'ghost_id', 'description' => nil, 'location' => nil)
+    end
+  end
+
+  describe 'examples_dependency report' do
+    before { build_reporter.generate }
+
+    let(:entries) { read_payload.dig('reports', 'examples_dependency') }
+
+    it 'emits an entry per example_id in dependency' do
+      expect(entries.map { |e| e['example_id'] }).to contain_exactly('ex1', 'ex3')
+    end
+
+    it 'sorts entries by example_id for determinism' do
+      expect(entries.map { |e| e['example_id'] }).to eq(%w[ex1 ex3])
+    end
+
+    it 'projects env_dependency into env_keys' do
+      ex3 = entries.find { |e| e['example_id'] == 'ex3' }
+
+      expect(ex3['env_keys']).to eq(['API_KEY'])
+    end
+
+    it 'emits empty env_keys for an example not in env_dependency' do
+      ex1 = entries.find { |e| e['example_id'] == 'ex1' }
+
+      expect(ex1['env_keys']).to eq([])
+    end
+
+    it 'sorts files per-example' do
+      ex3 = entries.find { |e| e['example_id'] == 'ex3' }
+
+      expect(ex3['files']).to eq(['/lib/admin.rb', '/lib/session.rb'])
+    end
+
+    it 'tolerates nil env_dependency on the snapshot' do
+      snap = build_populated_snapshot
+      snap.env_dependency = nil
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      ex3 = read_payload.dig('reports', 'examples_dependency').find { |e| e['example_id'] == 'ex3' }
+
+      expect(ex3['env_keys']).to eq([])
+    end
+
+    it 'tolerates a non-Set dependency value (graceful for custom callers)' do
+      snap = build_populated_snapshot
+      snap.dependency = { 'ex_plain' => ['/lib/x.rb'] }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'examples_dependency').first
+
+      expect(entry['files']).to eq(['/lib/x.rb'])
+    end
+  end
+
+  describe 'files_dependency report' do
+    before { build_reporter.generate }
+
+    let(:entries) { read_payload.dig('reports', 'files_dependency') }
+
+    it 'emits one entry per file in reverse_dependency' do
+      expect(entries.map { |e| e['file_name'] }).to contain_exactly('/lib/session.rb', '/lib/admin.rb')
+    end
+
+    it 'counts examples per file' do
+      session = entries.find { |e| e['file_name'] == '/lib/session.rb' }
+
+      expect(session['example_count']).to eq(2)
+    end
+
+    it 'sorts entries by -example_count then file_name for determinism' do
+      expect(entries.map { |e| e['file_name'] }).to eq(['/lib/session.rb', '/lib/admin.rb'])
+    end
+
+    it 'aggregates spec_files by count descending' do
+      session = entries.find { |e| e['file_name'] == '/lib/session.rb' }
+
+      expect(session['spec_files']).to eq('/spec/session_spec.rb' => 1, '/spec/admin_spec.rb' => 1)
+    end
+
+    it 'falls back to file_name when rerun_file_name is missing' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'exx' => { file_name: '/spec/fallback_spec.rb' } }
+      snap.reverse_dependency = { '/lib/whatever.rb' => Set.new(['exx']) }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      entry = read_payload.dig('reports', 'files_dependency').first
+
+      expect(entry['spec_files']).to eq('/spec/fallback_spec.rb' => 1)
+    end
+
+    it 'skips ids whose meta is not a Hash' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_bad' => 'not a hash' }
+      snap.reverse_dependency = { '/lib/only.rb' => Set.new(['ex_bad']) }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      entry = read_payload.dig('reports', 'files_dependency').first
+
+      expect(entry['spec_files']).to eq({})
+    end
+
+    it 'skips ids whose meta has empty spec filename' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'exblank' => { rerun_file_name: '' } }
+      snap.reverse_dependency = { '/lib/only.rb' => Set.new(['exblank']) }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      entry = read_payload.dig('reports', 'files_dependency').first
+
+      expect(entry['spec_files']).to eq({})
+    end
+
+    it 'tolerates a non-Set reverse_dependency value (Array form)' do
+      snap = build_populated_snapshot
+      snap.reverse_dependency = { '/lib/plain.rb' => ['ex1'] }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+      entry = read_payload.dig('reports', 'files_dependency').first
+
+      expect(entry['example_count']).to eq(1)
+    end
+  end
+
+  describe 'location / time / exec-result helpers' do
+    it 'returns nil location when rerun_file_name and file_name are both absent' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_no_file' => { full_description: 'x' } }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry['location']).to be_nil
+    end
+
+    it 'returns location without trailing colon when line is absent' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_no_line' => { rerun_file_name: '/spec/only_spec.rb' } }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry['location']).to eq('spec/only_spec.rb')
+    end
+
+    it 'stringifies a String time argument as-is' do
+      snap = build_populated_snapshot
+      snap.all_examples = {
+        'ex_str_time' => {
+          execution_result: {
+            started_at: '2026-01-01T00:00:00Z', finished_at: nil, run_time: 0.0, status: :passed
+          }
+        }
+      }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry.dig('execution_result', 'started_at')).to eq('2026-01-01T00:00:00Z')
+    end
+
+    it 'stringifies an object without iso8601 via to_s' do
+      snap = build_populated_snapshot
+      snap.all_examples = {
+        'ex_weird_time' => {
+          execution_result: {
+            started_at: 42, finished_at: nil, run_time: 0.0, status: :passed
+          }
+        }
+      }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry.dig('execution_result', 'started_at')).to eq('42')
+    end
+
+    it 'returns null execution_result when result is not a Hash' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_bogus' => { execution_result: 'garbage' } }
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry['execution_result']).to be_nil
+    end
+
+    it 'defaults execution_result status to unknown when missing' do
+      snap = build_populated_snapshot
+      snap.all_examples = { 'ex_no_status' => { execution_result: { run_time: 0.1 } } }
+      snap.flaky_examples = Set.new
+      snap.failed_examples = Set.new
+      snap.pending_examples = Set.new
+      snap.skipped_examples = Set.new
+      snap.interrupted_examples = Set.new
+      described_class.new(
+        snapshot: snap, report_dir: report_dir, run_metadata: {}, logger: nil
+      ).generate
+
+      entry = read_payload.dig('reports', 'all_examples').first
+
+      expect(entry.dig('execution_result', 'status')).to eq('unknown')
+    end
+  end
+
+  describe 'SCHEMA_VERSION constant' do
+    it 'is pinned to 1 for M6.1' do
+      expect(described_class::SCHEMA_VERSION).to eq(1)
+    end
+
+    it 'is a frozen numeric' do
+      expect(described_class::SCHEMA_VERSION).to be_frozen
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations
+# rubocop:enable RSpec/ExampleLength, Metrics/MethodLength

--- a/spec/reporters/registry_spec.rb
+++ b/spec/reporters/registry_spec.rb
@@ -1,0 +1,270 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'tmpdir'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/reporters/base'
+require 'rspec_tracer/reporters/json_reporter'
+require 'rspec_tracer/reporters/terminal_reporter'
+require 'rspec_tracer/reporters/registry'
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe RSpecTracer::Reporters::Registry do
+  let(:tmp) { Dir.mktmpdir }
+  let(:empty_snapshot) { RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'r') }
+  let(:snapshot) do
+    RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'r').tap do |s|
+      s.all_examples = { 'ex1' => { id: 'ex1' } }
+    end
+  end
+  let(:run_metadata) { {} }
+  let(:logger) { instance_double(RSpecTracer::Logger, warn: nil, debug: nil) }
+  let(:report_dir) { File.join(tmp, 'report') }
+
+  after { FileUtils.remove_entry(tmp) if File.directory?(tmp) }
+
+  def fake_config(reporters: nil, custom_logger: logger)
+    config_double = Object.new
+    config_double.define_singleton_method(:reporters) { reporters }
+    config_double.define_singleton_method(:logger) { custom_logger }
+    config_double
+  end
+
+  describe '.emit_all (class-method shortcut)' do
+    it 'delegates to an instance and runs the defaults' do
+      results = described_class.emit_all(
+        configuration: fake_config(reporters: [[:json, {}]]),
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(results).to be_an(Array)
+    end
+  end
+
+  describe 'default resolution' do
+    it 'falls back to [:terminal, :json] when configuration.reporters is nil' do
+      terminal_class = instance_spy(Class)
+      json_class = instance_spy(Class)
+
+      stub_const('RSpecTracer::Reporters::TerminalReporter', terminal_class)
+      stub_const('RSpecTracer::Reporters::JsonReporter', json_class)
+      allow(terminal_class).to receive(:new).and_return(instance_double(RSpecTracer::Reporters::Base, generate: nil))
+      allow(json_class).to receive(:new).and_return(instance_double(RSpecTracer::Reporters::Base, generate: nil))
+
+      described_class.new(configuration: fake_config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(terminal_class).to have_received(:new).once
+      expect(json_class).to have_received(:new).once
+    end
+
+    it 'falls back when configuration does not expose reporters at all' do
+      bare_config = Object.new
+      stub_logger = logger
+      bare_config.define_singleton_method(:logger) { stub_logger }
+
+      expect do
+        described_class.new(configuration: bare_config).emit_all(
+          snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+        )
+      end.not_to raise_error
+    end
+
+    it 'falls back to defaults when configuration.reporters is an empty array' do
+      results = described_class.new(configuration: fake_config(reporters: [])).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      # Both default reporters ran successfully (neither returned nil from rescue path).
+      expect(results.compact).not_to be_empty
+    end
+  end
+
+  describe 'empty-snapshot short-circuit' do
+    it 'returns [] when snapshot is nil' do
+      result = described_class.new(configuration: fake_config).emit_all(
+        snapshot: nil, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).to eq([])
+    end
+
+    it 'returns [] when snapshot.all_examples is empty' do
+      result = described_class.new(configuration: fake_config).emit_all(
+        snapshot: empty_snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).to eq([])
+    end
+
+    it 'returns [] when snapshot.all_examples is nil' do
+      snap = RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'r')
+      snap.all_examples = nil
+
+      result = described_class.new(configuration: fake_config).emit_all(
+        snapshot: snap, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).to eq([])
+    end
+
+    it 'returns [] when configured reporters list is empty AND snapshot is empty (no calls)' do
+      config = fake_config(reporters: [])
+      result = described_class.new(configuration: config).emit_all(
+        snapshot: empty_snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).to eq([])
+    end
+  end
+
+  describe 'explicit reporter resolution' do
+    it 'honors configuration.reporters tuples in order' do
+      config = fake_config(reporters: [[:terminal, {}]])
+
+      result = described_class.new(configuration: config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).not_to be_nil
+    end
+
+    it 'raises ArgumentError on an unknown symbol (defensive for programmatic callers)' do
+      config = fake_config(reporters: [[:bogus, {}]])
+
+      expect do
+        described_class.new(configuration: config).emit_all(
+          snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+        )
+      end.to raise_error(ArgumentError, /unknown reporter/)
+    end
+
+    it 'accepts a Class directly' do
+      spy_class = Class.new(RSpecTracer::Reporters::Base) do
+        attr_reader :generated
+
+        def generate
+          @generated = true
+        end
+      end
+      config = fake_config(reporters: [[spy_class, {}]])
+
+      described_class.new(configuration: config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      # Indirect check: the spy class constructed + generate ran without exception.
+      expect(spy_class.ancestors).to include(RSpecTracer::Reporters::Base)
+    end
+
+    it 'forwards **opts to the reporter initializer' do
+      captured = nil
+      spy_class = Class.new(RSpecTracer::Reporters::Base) do
+        define_method(:generate) do
+          captured = options
+        end
+      end
+      config = fake_config(reporters: [[spy_class, { flag: 42 }]])
+
+      described_class.new(configuration: config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(captured).to eq(flag: 42)
+    end
+
+    it 'tolerates a nil opts entry (legacy shape)' do
+      spy_class = Class.new(RSpecTracer::Reporters::Base) do
+        def generate
+          :ok
+        end
+      end
+      config = fake_config(reporters: [[spy_class, nil]])
+
+      result = described_class.new(configuration: config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).to eq([:ok])
+    end
+  end
+
+  describe 'per-reporter rescue' do
+    it 'catches an exception in one reporter and continues to the next' do
+      raising_class = Class.new(RSpecTracer::Reporters::Base) do
+        def generate
+          raise 'boom'
+        end
+      end
+      ok_class = Class.new(RSpecTracer::Reporters::Base) do
+        def generate
+          :ok
+        end
+      end
+      config = fake_config(reporters: [[raising_class, {}], [ok_class, {}]])
+
+      results = described_class.new(configuration: config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(results).to eq([nil, :ok])
+      expect(logger).to have_received(:warn).with(/failed \(RuntimeError: boom\)/)
+    end
+
+    it 'survives when configuration exposes no logger' do
+      raising_class = Class.new(RSpecTracer::Reporters::Base) do
+        def generate
+          raise 'boom'
+        end
+      end
+      config = fake_config(reporters: [[raising_class, {}]], custom_logger: nil)
+
+      expect do
+        described_class.new(configuration: config).emit_all(
+          snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+        )
+      end.not_to raise_error
+    end
+
+    it 'survives when configuration does not respond to :logger at all' do
+      raising_class = Class.new(RSpecTracer::Reporters::Base) do
+        def generate
+          raise 'boom'
+        end
+      end
+      minimal_config = Object.new
+      minimal_config.define_singleton_method(:reporters) { [[raising_class, {}]] }
+
+      expect do
+        described_class.new(configuration: minimal_config).emit_all(
+          snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe 'BUILT_INS constant' do
+    it 'is frozen' do
+      expect(described_class::BUILT_INS).to be_frozen
+    end
+
+    it 'maps :terminal and :json to their reporter class constant names' do
+      expect(described_class::BUILT_INS).to include(
+        terminal: 'RSpecTracer::Reporters::TerminalReporter',
+        json: 'RSpecTracer::Reporters::JsonReporter'
+      )
+    end
+  end
+
+  describe 'DEFAULTS constant' do
+    it 'is frozen' do
+      expect(described_class::DEFAULTS).to be_frozen
+    end
+
+    it 'matches the brief-literal default list' do
+      expect(described_class::DEFAULTS).to eq(%i[terminal json])
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/reporters/terminal_reporter_spec.rb
+++ b/spec/reporters/terminal_reporter_spec.rb
@@ -1,0 +1,253 @@
+# frozen_string_literal: true
+
+require 'set'
+require 'stringio'
+require 'tmpdir'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/reporters/terminal_reporter'
+
+require_relative '../contracts/reporter'
+
+# rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations
+RSpec.describe RSpecTracer::Reporters::TerminalReporter do
+  let(:reporter_class) { described_class }
+  let(:empty_snapshot) { RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'empty') }
+  let(:io) { StringIO.new }
+  let(:run_metadata) { { cache_path: '/fake/cache/path' } }
+  let(:snapshot) { build_populated_snapshot }
+  let(:report_dir) { Dir.mktmpdir }
+
+  after { FileUtils.remove_entry(report_dir) if File.directory?(report_dir) }
+
+  def build_populated_snapshot(overrides = {})
+    RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'rid').tap do |s|
+      s.all_examples = {
+        'ex1' => { execution_result: { status: 'passed' } },
+        'ex2' => {},
+        'ex3' => { execution_result: { status: 'passed' } }
+      }
+      s.skipped_examples = Set.new(['ex2'])
+      overrides.each { |k, v| s.send("#{k}=", v) }
+    end
+  end
+
+  def build_reporter(snap: snapshot, metadata: run_metadata, io_override: io)
+    described_class.new(
+      snapshot: snap, report_dir: report_dir,
+      run_metadata: metadata, logger: nil, io: io_override
+    )
+  end
+
+  it_behaves_like 'a Reporters::Base'
+
+  describe '#generate (no-op path)' do
+    it 'returns nil on empty snapshot' do
+      expect(build_reporter(snap: empty_snapshot).generate).to be_nil
+    end
+
+    it 'emits no output on empty snapshot' do
+      build_reporter(snap: empty_snapshot).generate
+
+      expect(io.string).to be_empty
+    end
+  end
+
+  describe '#generate (populated path)' do
+    it 'emits the header line with counts and cache percent' do
+      build_reporter.generate
+
+      expect(io.string).to include('rspec-tracer: 3 examples tracked')
+      expect(io.string).to include('2 re-run')
+      expect(io.string).to include('1 skipped')
+      expect(io.string).to include('33% cached')
+    end
+
+    it 'emits a cache line when cache_path is in run_metadata' do
+      build_reporter.generate
+
+      expect(io.string).to include('cache: /fake/cache/path')
+    end
+
+    it 'omits the cache line when cache_path is absent' do
+      build_reporter(metadata: {}).generate
+
+      expect(io.string).not_to include('cache:')
+    end
+
+    it 'omits the cache line when cache_path is empty' do
+      build_reporter(metadata: { cache_path: '' }).generate
+
+      expect(io.string).not_to include('cache:')
+    end
+
+    it 'emits a report line pointing at report.json' do
+      build_reporter.generate
+
+      expect(io.string).to include("report: #{File.join(report_dir, 'report.json')}")
+    end
+
+    it 'omits the report line when report_dir is nil' do
+      reporter = described_class.new(
+        snapshot: snapshot, report_dir: nil, run_metadata: run_metadata, logger: nil, io: io
+      )
+      reporter.generate
+
+      expect(io.string).not_to include('report:')
+    end
+
+    it 'omits the report line when report_dir is empty' do
+      reporter = described_class.new(
+        snapshot: snapshot, report_dir: '', run_metadata: run_metadata, logger: nil, io: io
+      )
+      reporter.generate
+
+      expect(io.string).not_to include('report:')
+    end
+
+    it 'skips the tally line when no conditional counter is non-zero' do
+      build_reporter.generate
+
+      expect(io.string).not_to match(/^\d+ (failed|pending|flaky|interrupted|duplicate)/)
+    end
+
+    it 'adds a tally line when failed_examples is non-empty' do
+      snap = build_populated_snapshot(failed_examples: Set.new(['ex1']))
+      build_reporter(snap: snap).generate
+
+      expect(io.string).to include('1 failed')
+    end
+
+    it 'adds a tally line when pending_examples is non-empty' do
+      snap = build_populated_snapshot(pending_examples: Set.new(['ex1']))
+      build_reporter(snap: snap).generate
+
+      expect(io.string).to include('1 pending')
+    end
+
+    it 'adds a tally line when flaky_examples is non-empty' do
+      snap = build_populated_snapshot(flaky_examples: Set.new(['ex1']))
+      build_reporter(snap: snap).generate
+
+      expect(io.string).to include('1 flaky')
+    end
+
+    it 'adds a tally line when interrupted_examples is non-empty' do
+      snap = build_populated_snapshot(interrupted_examples: Set.new(['ex1']))
+      build_reporter(snap: snap).generate
+
+      expect(io.string).to include('1 interrupted')
+    end
+
+    it 'adds a tally line when duplicate_examples is non-empty' do
+      snap = build_populated_snapshot(
+        duplicate_examples: { 'dup' => [{}, {}] }
+      )
+      build_reporter(snap: snap).generate
+
+      expect(io.string).to include('1 duplicate')
+    end
+
+    it 'caps output at 4 lines in the happy path (header + cache + report)' do
+      result = build_reporter.generate
+
+      expect(result.length).to be <= 4
+    end
+
+    it 'returns the emitted lines as an Array' do
+      expect(build_reporter.generate).to be_an(Array)
+    end
+  end
+
+  describe 'color policy' do
+    let(:tty_io) do
+      Class.new(StringIO) do
+        def tty?
+          true
+        end
+      end.new
+    end
+
+    it 'emits ANSI codes when the stream is a TTY and NO_COLOR unset' do
+      stub_const('ENV', ENV.to_hash.merge.tap { |h| h.delete('NO_COLOR') })
+      build_reporter(io_override: tty_io).generate
+
+      expect(tty_io.string).to include("\e[")
+    end
+
+    it 'omits ANSI codes when NO_COLOR is set (any value disables)' do
+      stub_const('ENV', ENV.to_hash.merge('NO_COLOR' => '1'))
+      build_reporter(io_override: tty_io).generate
+
+      expect(tty_io.string).not_to include("\e[")
+    end
+
+    it 'omits ANSI codes when stream is not a TTY' do
+      build_reporter.generate
+
+      expect(io.string).not_to include("\e[")
+    end
+
+    it 'paints red when any example failed' do
+      stub_const('ENV', ENV.to_hash.merge.tap { |h| h.delete('NO_COLOR') })
+      snap = build_populated_snapshot(failed_examples: Set.new(['ex1']))
+      build_reporter(snap: snap, io_override: tty_io).generate
+
+      expect(tty_io.string).to include("\e[31m")
+    end
+
+    it 'paints red when any example was interrupted' do
+      stub_const('ENV', ENV.to_hash.merge.tap { |h| h.delete('NO_COLOR') })
+      snap = build_populated_snapshot(interrupted_examples: Set.new(['ex1']))
+      build_reporter(snap: snap, io_override: tty_io).generate
+
+      expect(tty_io.string).to include("\e[31m")
+    end
+
+    it 'paints yellow when only pending examples are present' do
+      stub_const('ENV', ENV.to_hash.merge.tap { |h| h.delete('NO_COLOR') })
+      snap = build_populated_snapshot(pending_examples: Set.new(['ex1']))
+      build_reporter(snap: snap, io_override: tty_io).generate
+
+      expect(tty_io.string).to include("\e[33m")
+    end
+
+    it 'paints green on a fully successful run' do
+      stub_const('ENV', ENV.to_hash.merge.tap { |h| h.delete('NO_COLOR') })
+      build_reporter(io_override: tty_io).generate
+
+      expect(tty_io.string).to include("\e[32m")
+    end
+
+    it 'falls back to reset when paint is called with an unknown color key' do
+      reporter = build_reporter(io_override: tty_io)
+      stub_const('ENV', ENV.to_hash.merge.tap { |h| h.delete('NO_COLOR') })
+
+      result = reporter.send(:paint, :no_such_color, 'text')
+
+      expect(result).to start_with("\e[0m")
+    end
+  end
+
+  describe 'cache-percent edge cases' do
+    it 'returns 0% cached when total is zero (defensive; no_op? would normally short-circuit)' do
+      reporter = build_reporter(snap: snapshot)
+      expect(reporter.send(:cache_percent, 0, 0)).to eq(0)
+    end
+
+    it 'rounds to nearest integer' do
+      reporter = build_reporter(snap: snapshot)
+      expect(reporter.send(:cache_percent, 3, 1)).to eq(33)
+    end
+  end
+
+  describe 'output_stream default' do
+    it 'uses $stdout when no :io option is provided' do
+      reporter = described_class.new(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata, logger: nil
+      )
+
+      expect(reporter.send(:output_stream)).to be($stdout)
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations

--- a/spec/storage/json_backend_spec.rb
+++ b/spec/storage/json_backend_spec.rb
@@ -35,7 +35,8 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       examples_coverage: { 'ex1' => { '/a.rb' => [1, nil, 2] } },
       boot_set: { 'lib/boot.rb' => 'deadbeef', 'spec/spec_helper.rb' => 'cafef00d' },
       wsi_snapshot: { 'Gemfile.lock' => 'feedc0de', '.ruby-version' => 'b16b00b5' },
-      env_snapshot: { 'API_KEY' => 'facade1', 'ROLE_CONFIG' => 'baadf00d' }
+      env_snapshot: { 'API_KEY' => 'facade1', 'ROLE_CONFIG' => 'baadf00d' },
+      env_dependency: { 'ex1' => ['API_KEY'], 'ex2' => %w[ROLE_CONFIG API_KEY] }
     )
   end
 
@@ -55,7 +56,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(described_class::FILENAMES).to be_frozen
     end
 
-    it 'lists exactly the 14 per-run files (boot_set+wsi_snapshot+env_snapshot added in M3.7+M4.3+M5.2)' do
+    it 'lists exactly the 15 per-run files (boot_set+wsi+env_snapshot+env_dependency added in M3.7+M4.3+M5.2+M6.1)' do
       expect(described_class::FILENAMES).to eq(expected_filenames)
     end
 
@@ -65,7 +66,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
         interrupted_examples.json flaky_examples.json failed_examples.json
         pending_examples.json skipped_examples.json
         all_files.json dependency.json reverse_dependency.json examples_coverage.json
-        boot_set.json wsi_snapshot.json env_snapshot.json
+        boot_set.json wsi_snapshot.json env_snapshot.json env_dependency.json
       ]
     end
   end
@@ -137,6 +138,49 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
 
       expect(loaded.env_snapshot).to eq({})
+    end
+  end
+
+  describe 'env_dependency round-trip (M6.1)' do
+    it 'persists and reloads a non-empty env_dependency' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_dependency).to eq(sample_snapshot.env_dependency)
+    end
+
+    it 'writes env_dependency.json with Hash[example_id => Array<env_name>] body' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'env_dependency.json')
+
+      expect(JSON.parse(File.read(path)))
+        .to eq('ex1' => ['API_KEY'], 'ex2' => %w[ROLE_CONFIG API_KEY])
+    end
+
+    it 'tolerates a malformed env_dependency.json (returns {})' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'env_dependency.json')
+      File.binwrite(path, "\x00 garbage".b)
+      loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_dependency).to eq({})
+    end
+
+    it 'coerces a non-Hash JSON body to {}' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'env_dependency.json')
+      File.write(path, JSON.dump(%w[not a hash]))
+      loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_dependency).to eq({})
+    end
+
+    it 'survives a pre-M6.1 cache (missing env_dependency.json) without a cold re-run signal' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      File.delete(File.join(cache_path, sample_snapshot.run_id, 'env_dependency.json'))
+      loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.env_dependency).to eq({})
     end
   end
 
@@ -357,7 +401,8 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
         examples_coverage: { example_id => { file_name => { '0' => 1, '2' => 3 } } },
         boot_set: { "lib/#{example_id}_boot.rb" => "boot#{example_id}" },
         wsi_snapshot: { 'Gemfile.lock' => "wsi-#{run_id}" },
-        env_snapshot: { "ENV_#{example_id.upcase}" => "env-#{run_id}" }
+        env_snapshot: { "ENV_#{example_id.upcase}" => "env-#{run_id}" },
+        env_dependency: { example_id => ["ENV_#{example_id.upcase}"] }
       )
     end
 
@@ -389,6 +434,37 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(merged.boot_set.keys).to include('lib/ex1_boot.rb', 'lib/ex2_boot.rb')
       expect(merged.wsi_snapshot['Gemfile.lock']).to be_a(String)
       expect(merged.env_snapshot.keys).to include('ENV_EX1', 'ENV_EX2')
+    end
+
+    it 'unions env_dependency entries per-example across peers (M6.1)' do
+      write_peer(peer_one_path, peer_snapshot('p1', 'ex1', '/lib/a.rb', 'digest-a'))
+      write_peer(peer_two_path, peer_snapshot('p2', 'ex2', '/lib/b.rb', 'digest-b'))
+
+      merged = top_backend.merge_from_peers(
+        [peer_one_path, peer_two_path],
+        schema_version: RSpecTracer::Storage::Schema::CURRENT
+      )
+
+      expect(merged.env_dependency).to include(
+        'ex1' => ['ENV_EX1'],
+        'ex2' => ['ENV_EX2']
+      )
+    end
+
+    it 'unions overlapping env_dependency arrays set-wise' do
+      shared_one = peer_snapshot('p1', 'ex1', '/lib/a.rb', 'da')
+      shared_two = peer_snapshot('p2', 'ex1', '/lib/a.rb', 'da')
+      shared_two.env_dependency = { 'ex1' => %w[ENV_EX1 ENV_EXTRA] }
+
+      write_peer(peer_one_path, shared_one)
+      write_peer(peer_two_path, shared_two)
+
+      merged = top_backend.merge_from_peers(
+        [peer_one_path, peer_two_path],
+        schema_version: RSpecTracer::Storage::Schema::CURRENT
+      )
+
+      expect(merged.env_dependency['ex1']).to match_array(%w[ENV_EX1 ENV_EXTRA])
     end
 
     it 'unions example-status ID sets' do

--- a/spec/storage/snapshot_spec.rb
+++ b/spec/storage/snapshot_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
     it 'defaults Hash-shaped fields to empty Hash' do
       %i[
         all_examples duplicate_examples all_files dependency reverse_dependency
-        examples_coverage boot_set wsi_snapshot env_snapshot
+        examples_coverage boot_set wsi_snapshot env_snapshot env_dependency
       ].each { |field| expect(snapshot.send(field)).to eq({}) }
     end
 
@@ -37,6 +37,10 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
 
     it 'defaults env_snapshot to an empty Hash (M5.2 field)' do
       expect(snapshot.env_snapshot).to eq({})
+    end
+
+    it 'defaults env_dependency to an empty Hash (M6.1 field)' do
+      expect(snapshot.env_dependency).to eq({})
     end
   end
 
@@ -67,6 +71,14 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
       a = described_class.empty(schema_version: 3, run_id: 'x')
       b = described_class.empty(schema_version: 3, run_id: 'x')
       b.env_snapshot = { 'API_KEY' => 'facade1' }
+
+      expect(a).not_to eq(b)
+    end
+
+    it 'differs when env_dependency differs (M6.1)' do
+      a = described_class.empty(schema_version: 3, run_id: 'x')
+      b = described_class.empty(schema_version: 3, run_id: 'x')
+      b.env_dependency = { 'ex1' => ['API_KEY'] }
 
       expect(a).not_to eq(b)
     end

--- a/spec/support/tracker_coverage_gate.rb
+++ b/spec/support/tracker_coverage_gate.rb
@@ -10,7 +10,7 @@
 # (e.g. spec/time_formatter_spec.rb) don't trigger at all.
 module TrackerCoverageGate
   LIB_ROOT = File.expand_path('../../lib/rspec_tracer', __dir__)
-  GATED_SUBDIRS = %w[tracker rails rspec].freeze
+  GATED_SUBDIRS = %w[tracker rails rspec reporters].freeze
   GATED_PREFIXES = GATED_SUBDIRS.map { |subdir| "#{File.join(LIB_ROOT, subdir)}/" }.freeze
   EPSILON = 0.001 # guard float equality of "100.0%"
 


### PR DESCRIPTION
## Summary

- Splits reporting from tracking. `lib/rspec_tracer/reporters/` gains
  `Reporters::Base` (abstract), `JsonReporter` (machine-readable,
  stable schema v1 covering All / Duplicate / Flaky / Examples
  Dependency / Files Dependency), `TerminalReporter` (concise stdout
  summary, ≤ 4 lines, NO_COLOR-aware), and `Reporters::Registry`
  (per-reporter rescue + warn; default `[:terminal, :json]`).
- Wired from `RSpecTracer#run_exit_tasks` against the `Storage::Snapshot`
  the Engine returns; Engine#finalize keeps its storage-only contract.
  Fires per-worker under parallel_tests, same cadence as `coverage.json`
  emission.
- `Storage::Snapshot` gains `env_dependency` (15th JSON cache file,
  `env_dependency.json`). Engine projects `@tracks_env` into it so
  reporters can render per-example env attribution alongside file deps.
  Missing file coerces to `{}` — pre-M6.1 caches load without a cold
  re-run (same precedent as M4.3 `wsi_snapshot` / M5.2 `env_snapshot`;
  no schema version bump).
- `Configuration` gains `add_reporter(name_or_class, **opts)` accumulator
  + `reporters` reader. Symbols validated against `Registry::BUILT_INS`;
  unknown symbols or non-Class non-Symbol args raise `InvalidUsageError`.

## Scope notes

- Legacy HTML reporter (`lib/rspec_tracer/html_reporter/`) and the
  pre-M5.1 reporter stack (`lib/rspec_tracer/{reporter,report_writer,
  report_generator,report_merger,runner,cache}.rb` + paired specs)
  stay in-tree. Retirement bundled with the HTML reporter rework.
- `TrackerCoverageGate` now gates `lib/rspec_tracer/reporters/*.rb`
  at 100% line + branch via the four paired `spec/reporters/*_spec.rb`.
- Mutation-smoke for `JsonReporter` / `TerminalReporter` deferred
  (pure-logic gated via coverage; narrow per-method matchers follow
  the Rails::Notifications / RunnerHook / Metadata precedent).

## Test plan

- [x] `task lint:ruby` / `lint:actions` / `lint:yaml` — clean
- [x] `task check:bundle` — satisfied
- [x] `task security:bundle-audit` / `security:trivy` — 0 findings
- [x] `task test:unit` — 998 examples, 0 failures
- [x] `task test:property` — 25 examples, 0 failures
- [x] `task test:mutation:smoke` — 13/13 subjects ≥ 90%
- [x] `task test:dogfood` — green
- [x] `task test:integration` — 16 examples, 0 failures
- [x] `task test:integration:parallel` — 6 examples (M5.1 first_process? gate holds)
- [x] `task test:integration:per-example-dsl` — 5 examples (M5.2 regression gate holds)
- [x] `task test:features:rails` — 12 scenarios, 0 failures
- [x] `task benchmark:smoke` — cold_ruby / warm_noop within ratchet

🤖 Generated with [Claude Code](https://claude.com/claude-code)