### PR TITLE
feat(remote_cache): LocalFS + Redis backends + cross-tier prune_all

### DIFF
--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -32,6 +32,19 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
+      # Redis provides the real wire surface for the M7.2 RedisBackend
+      # integration spec. 7.4 is the current stable; pin the minor to
+      # keep CI reproducible across Redis's periodic protocol tweaks.
+      redis:
+        image: redis:7.4-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping | grep -q PONG"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -116,8 +129,21 @@ jobs:
       - name: Install — awslocal (LocalStack CLI wrapper)
         run: pip install --user awscli-local
 
+      - name: Install — redis-cli (for health probe + local smoke)
+        run: sudo apt-get install -y --no-install-recommends redis-tools
+
       - name: Wait — LocalStack ready + smoke probe
         run: task ci:localstack:ready
 
       - name: Test — Integration (remote cache + LocalStack)
         run: task test:integration:remote-cache
+
+      - name: Wait — Redis ready + smoke probe
+        env:
+          REDIS_URL: redis://localhost:6379/15
+        run: task ci:redis:ready
+
+      - name: Test — Integration (remote cache + Redis)
+        env:
+          REDIS_URL: redis://localhost:6379/15
+        run: task test:integration:remote-cache:redis

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --require spec_helper
 --format documentation
---exclude-pattern "spec/fixtures/**/*_spec.rb,spec/integration/rails_app_spec.rb,spec/integration/parallel_tests_spec.rb,spec/integration/per_example_dsl_spec.rb,spec/integration/remote_cache_spec.rb"
+--exclude-pattern "spec/fixtures/**/*_spec.rb,spec/integration/rails_app_spec.rb,spec/integration/parallel_tests_spec.rb,spec/integration/per_example_dsl_spec.rb,spec/integration/remote_cache_spec.rb,spec/integration/remote_cache_redis_spec.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -13,11 +13,16 @@ group :development do
   gem 'rantly', '~> 2.0'
   # redis is a dev dep so we can exercise RedisBackend's real wire path
   # in the integration spec (spec/integration/remote_cache_spec.rb)
-  # against a localhost Redis service, and so the GEM_AVAILABLE=true
-  # branch in the backend file is exercisable in unit specs. End users
+  # against a localhost Redis service, and so the lazy `require 'redis'`
+  # path in the backend file is exercisable in unit specs. End users
   # who want RedisBackend add the gem to their OWN Gemfile - we do not
   # ship it as a runtime dep per USER_FACING_SURFACE.md.
   gem 'redis', '~> 5.3'
+  # connection_pool is a transitive dep of redis-client. 3.x requires
+  # Ruby >= 3.2, which breaks our Ruby 3.1 + JRuby 9.4 matrix cells
+  # at `bundle install` time. redis-client accepts any connection_pool
+  # version, so pinning 2.x here keeps the whole matrix installable.
+  gem 'connection_pool', '~> 2.5'
   gem 'rspec', '~> 3.13'
   gem 'rubocop', '~> 1.60'
   gem 'rubocop-performance', '~> 1.20'

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,13 @@ group :development do
   gem 'pry', '~> 0.14'
   gem 'rake', '~> 13.2'
   gem 'rantly', '~> 2.0'
+  # redis is a dev dep so we can exercise RedisBackend's real wire path
+  # in the integration spec (spec/integration/remote_cache_spec.rb)
+  # against a localhost Redis service, and so the GEM_AVAILABLE=true
+  # branch in the backend file is exercisable in unit specs. End users
+  # who want RedisBackend add the gem to their OWN Gemfile - we do not
+  # ship it as a runtime dep per USER_FACING_SURFACE.md.
+  gem 'redis', '~> 5.3'
   gem 'rspec', '~> 3.13'
   gem 'rubocop', '~> 1.60'
   gem 'rubocop-performance', '~> 1.20'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     builder (3.3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     contracts (0.17.3)
     cucumber (9.2.1)
       builder (~> 3.2)
@@ -222,6 +222,7 @@ PLATFORMS
 
 DEPENDENCIES
   aruba (~> 2.2)
+  connection_pool (~> 2.5)
   cucumber (~> 9.2)
   mutant-rspec (~> 0.16)
   parallel (~> 1.26)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ GEM
     builder (3.3.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
     contracts (0.17.3)
     cucumber (9.2.1)
       builder (~> 3.2)
@@ -128,6 +129,10 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redis (5.4.1)
+      redis-client (>= 0.22.0)
+    redis-client (0.28.0)
+      connection_pool
     regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -224,6 +229,7 @@ DEPENDENCIES
   pry (~> 0.14)
   rake (~> 13.2)
   rantly (~> 2.0)
+  redis (~> 5.3)
   rspec (~> 3.13)
   rspec-tracer!
   rubocop (~> 1.60)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -443,6 +443,55 @@ tasks:
     cmds:
       - bundle exec rspec --no-color spec/integration/remote_cache_spec.rb
 
+  ci:redis:ready:
+    desc: >-
+      Wait for Redis to be healthy on REDIS_URL (default redis://localhost:6379/15)
+      and run a small smoke probe. Skips (exits 0) when `redis-cli` is absent
+      so local dev without Redis does not fail the broader task graph.
+    vars:
+      URL:
+        sh: echo "${REDIS_URL:-redis://localhost:6379/15}"
+    cmds:
+      - |
+        if ! command -v redis-cli >/dev/null 2>&1; then
+          echo "skip: redis-cli not on PATH (install: brew install redis)"
+          exit 0
+        fi
+
+        # Step 1: poll PING for up to 30s.
+        ready=0
+        for _ in $(seq 1 30); do
+          if redis-cli -u "{{.URL}}" PING 2>/dev/null | grep -q PONG; then
+            echo "redis ready"
+            ready=1
+            break
+          fi
+          sleep 1
+        done
+        if [ "$ready" -ne 1 ]; then
+          echo "ERROR: redis did not respond to PING within 30s at {{.URL}}" >&2
+          exit 1
+        fi
+
+        # Step 2: smoke probe the exact op set RedisBackend uses.
+        bucket="rspec-tracer-smoke-$$"
+        redis-cli -u "{{.URL}}" SET "${bucket}:probe" "probe-value" >/dev/null
+        redis-cli -u "{{.URL}}" GET "${bucket}:probe" | grep -q probe-value
+        redis-cli -u "{{.URL}}" HSET "${bucket}:hash" field value >/dev/null
+        redis-cli -u "{{.URL}}" HGET "${bucket}:hash" field | grep -q value
+        redis-cli -u "{{.URL}}" DEL "${bucket}:probe" "${bucket}:hash" >/dev/null
+        echo "redis smoke probe OK"
+
+  test:integration:remote-cache:redis:
+    desc: >-
+      M7.2 RedisBackend integration test against a real Redis server.
+      End-to-end round-trip (upload + download + branch_refs + retention
+      + prune_all) against localhost:6379 (override via REDIS_URL).
+      Depends on ci:redis:ready so CI fails fast if Redis is not reachable.
+    deps: [ci:redis:ready]
+    cmds:
+      - bundle exec rspec --no-color spec/integration/remote_cache_redis_spec.rb
+
   test:features:jruby:
     desc: >-
       M5.1 ruby_app integration test on JRuby (swapped from cucumber for the

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -188,10 +188,15 @@ module RSpecTracer
       end
     end
 
-    # Convenience DSL: `remote_cache_uri 's3://bucket/prefix'` parses
-    # the URI and calls `remote_cache_backend`. Also accepts ENV
-    # `RSPEC_TRACER_REMOTE_CACHE_URI`. Scheme dispatch is the extension
-    # point for M7.2's `:local_fs` / `:redis` backends.
+    # Convenience DSL: `remote_cache_uri '<scheme>://...'` parses the
+    # URI and calls `remote_cache_backend` with the right backend +
+    # connection params. Also accepts ENV `RSPEC_TRACER_REMOTE_CACHE_URI`.
+    # Supported schemes:
+    #   s3://<bucket>/<prefix>             -> S3Backend
+    #   file:///absolute/path              -> LocalFsBackend (root:)
+    #   redis://[user:pass@]host:port/<db> -> RedisBackend (prefix: 'rspec-tracer')
+    # Users who need finer control (custom Redis prefix, LocalFs on a
+    # relative path) use `remote_cache_backend` directly.
     def remote_cache_uri(uri = nil)
       return @remote_cache_uri if defined?(@remote_cache_uri) && uri.nil?
 
@@ -199,27 +204,48 @@ module RSpecTracer
       return nil if value.nil?
 
       parsed = parse_remote_cache_uri(value)
-      case parsed.scheme
-      when 's3'
-        prefix = parsed.path.to_s.sub(%r{^/}, '')
-        remote_cache_backend(:s3, bucket: parsed.host, prefix: prefix)
-      else
-        raise InvalidUsageError,
-              "unsupported remote_cache_uri scheme: #{parsed.scheme.inspect} (only 's3' is supported in 2.0)"
-      end
+      dispatch_remote_cache_uri(parsed)
 
       @remote_cache_uri = value
     end
 
+    def dispatch_remote_cache_uri(parsed)
+      case parsed.scheme
+      when 's3'
+        prefix = parsed.path.to_s.sub(%r{^/}, '')
+        remote_cache_backend(:s3, bucket: parsed.host, prefix: prefix)
+      when 'file'
+        remote_cache_backend(:local_fs, root: parsed.path.to_s)
+      when 'redis', 'rediss'
+        remote_cache_backend(:redis, url: parsed.to_s, prefix: 'rspec-tracer')
+      else
+        raise InvalidUsageError,
+              "unsupported remote_cache_uri scheme: #{parsed.scheme.inspect} " \
+              "(supported: 's3', 'file', 'redis', 'rediss')"
+      end
+    end
+
+    # Validate a parsed URI per the active scheme. Host presence is the
+    # common structural signal for S3 / Redis; `file://` uses path
+    # instead (host is optional and usually empty).
     def parse_remote_cache_uri(value)
       parsed = URI.parse(value)
-      unless parsed.scheme && parsed.host && !parsed.host.empty?
-        raise InvalidUsageError, "invalid remote_cache_uri: #{value.inspect}"
-      end
+      raise InvalidUsageError, "invalid remote_cache_uri: #{value.inspect}" unless valid_remote_cache_uri?(parsed)
 
       parsed
     rescue URI::InvalidURIError => e
       raise InvalidUsageError, "invalid remote_cache_uri: #{value.inspect} (#{e.message})"
+    end
+
+    def valid_remote_cache_uri?(parsed)
+      return false if parsed.scheme.nil?
+
+      case parsed.scheme
+      when 'file'
+        !parsed.path.to_s.empty?
+      else
+        !parsed.host.nil? && !parsed.host.empty?
+      end
     end
 
     # Retention knobs (closes issue #20). Mutually exclusive: count

--- a/lib/rspec_tracer/remote_cache.rb
+++ b/lib/rspec_tracer/remote_cache.rb
@@ -9,6 +9,8 @@
 require_relative 'remote_cache/backend'
 require_relative 'remote_cache/validator'
 require_relative 'remote_cache/git_ancestry'
+require_relative 'remote_cache/local_fs_backend'
+require_relative 'remote_cache/redis_backend'
 require_relative 'remote_cache/s3_backend'
 require_relative 'remote_cache/user_tasks'
 

--- a/lib/rspec_tracer/remote_cache/README.md
+++ b/lib/rspec_tracer/remote_cache/README.md
@@ -1,6 +1,6 @@
 # Remote cache
 
-Optional cross-machine cache layer — downloads a prior run's dependency
+Optional cross-machine cache layer. Downloads a prior run's dependency
 graph so a fresh checkout (CI, new contributor) starts warm.
 
 ## Responsibilities
@@ -17,59 +17,124 @@ graph so a fresh checkout (CI, new contributor) starts warm.
 ```ruby
 module RSpecTracer::RemoteCache::Backend
   REQUIRED_METHODS = %i[
-    download upload branch_refs write_branch_refs prune!
+    download upload branch_refs write_branch_refs prune! prune_all!
   ].freeze
 
   def self.conforms?(backend); end
 end
 ```
 
-The shared-examples contract in
-`spec/contracts/remote_cache_backend.rb` asserts the full behavioral
-contract on every implementation.
-
-## Layout (S3 backend)
-
-Two-tier S3 layout with per-ref tar+gzip archives, paired with the
-`schema_version` bump (1.x caches are refused cleanly; one cold run on
-upgrade):
-
-```
-s3://<bucket>/<prefix>/
-  main/<sha>/[<test_suite_id>/]cache.tar.gz
-  pr/<branch>/<sha>/[<test_suite_id>/]cache.tar.gz
-  pr/<branch>/branch_refs.json
-```
-
-Each `cache.tar.gz` packs `last_run.json` + the `<run_id>/` directory
-(the 15-file local layout documented in `USER_FACING_SURFACE.md` §6).
-Upload = 1 PUT; download = 1 GET. Local disk layout is unchanged
-after unpack — external tooling that walks `rspec_tracer_cache/` still
-sees the full 15-file breakdown.
-
-Tier is determined from `$GIT_BRANCH` vs `$GIT_DEFAULT_BRANCH`. PR
-downloads try their own `pr/<branch>/` tier first, then fall back to
-`main/` for the same ref (catches cherry-picks from main).
+The shared-examples contract in `spec/contracts/remote_cache_backend.rb`
+asserts the full behavioral contract on every implementation.
 
 ## Shipped backends
 
-- `S3Backend` — primary target, shell-out to `aws`/`awslocal` CLI.
+All three share the two-tier layout (main + per-PR-branch), the same
+schema_version validator, and the same retention knobs.
 
-## Planned backends (M7.2)
+- **`S3Backend`** — primary target. Shells out to `aws` / `awslocal`
+  CLI. Cache is one `cache.tar.gz` per ref.
+- **`LocalFsBackend`** — shared directory (NFS, dev cache, CI
+  workspace). Same `cache.tar.gz` archive format as S3 — a LocalFs
+  root can be rsync'd to/from S3 with no transform. Atomic uploads via
+  tmp-write + rename. No locking (unreliable over NFS; last-write-wins
+  on same SHA is correct because archive bytes are deterministic).
+- **`RedisBackend`** — each ref stored as a Redis hash (field-per-file)
+  keyed under `<prefix>:main:<sha>` / `<prefix>:pr:<branch>:<sha>`.
+  `redis` gem is an OPTIONAL dependency — users add it to their own
+  Gemfile. A missing gem logs a clear warning and falls back to a cold
+  run instead of crashing the test suite.
 
-- `LocalFsBackend` — shared mount / NFS for on-prem CI.
-- `RedisBackend` — ephemeral CI agents.
+## Layout
+
+### S3 / LocalFS (archive-per-ref)
+
+```
+<root>/main/<sha>/[<test_suite_id>/]cache.tar.gz
+<root>/pr/<branch>/<sha>/[<test_suite_id>/]cache.tar.gz
+<root>/pr/<branch>/branch_refs.json
+```
+
+(`<root>` is `s3://<bucket>/<prefix>` for S3, a local/NFS path for
+LocalFs.) Each `cache.tar.gz` packs `last_run.json` + the `<run_id>/`
+directory (the 15-file local layout documented in
+`USER_FACING_SURFACE.md` §6). Upload = 1 PUT; download = 1 GET. Local
+disk layout is unchanged after unpack — external tooling that walks
+`rspec_tracer_cache/` still sees the full 15-file breakdown.
+
+### Redis (hash-per-ref)
+
+```
+<prefix>:main:<sha>[:<test_suite_id>]           -> HASH
+<prefix>:pr:<branch>:<sha>[:<test_suite_id>]    -> HASH
+<prefix>:pr:<branch>:branch_refs                -> STRING (JSON)
+```
+
+Hash fields: `_timestamp` (epoch), `last_run.json`, and one field per
+file in the 15-file layout (`<run_id>/<file>.json`). Keeps Redis-native
+inspection (`HGETALL`, `HKEYS`) usable without extracting an archive.
+
+## Tier routing
+
+Tier is determined from `$GIT_BRANCH` vs `$GIT_DEFAULT_BRANCH`. PR
+builds write to the PR tier; main builds write to the main tier. PR
+downloads try their own tier first, then fall back to main tier for
+the same ref (catches cherry-picks from main).
 
 ## User-facing surface
 
-The Rakefile (`lib/rspec_tracer/remote_cache/Rakefile`) defines the
-two tasks `rspec_tracer:remote_cache:download` and `:upload`. Users
-load it from their own Rakefile:
+The Rakefile (`lib/rspec_tracer/remote_cache/Rakefile`) defines three
+tasks:
+
+- `rspec_tracer:remote_cache:download`
+- `rspec_tracer:remote_cache:upload`
+- `rspec_tracer:remote_cache:prune_all` — maintenance task that walks
+  every PR branch and drops ones idle longer than
+  `cache_retention_pr_branch_ttl`. Intended for a nightly cron.
+
+Users load the Rakefile from their own Rakefile:
 
 ```ruby
 spec = Gem::Specification.find_by_name('rspec-tracer')
 load "#{spec.gem_dir}/lib/rspec_tracer/remote_cache/Rakefile"
 ```
 
-Env vars required: `GIT_DEFAULT_BRANCH`, `GIT_BRANCH`, and
-`TEST_SUITE_ID` (optional; scopes the S3 path when set).
+Env vars: `GIT_DEFAULT_BRANCH` (required), `GIT_BRANCH` (required for
+download/upload; defaults to `GIT_DEFAULT_BRANCH` for prune_all), and
+`TEST_SUITE_ID` (optional; scopes the cache key when set).
+
+## Configuration
+
+Shortest path — one `remote_cache_uri` call:
+
+```ruby
+RSpecTracer.configure do
+  remote_cache_uri 's3://my-bucket/rspec-tracer'
+  # or: remote_cache_uri 'file:///mnt/shared-cache'
+  # or: remote_cache_uri 'redis://redis.internal:6379/0'
+  cache_retention_count 100            # keep newest N on main tier
+  cache_retention_pr_branch_ttl '14 days' # idle-branch cutoff on pr tier
+end
+```
+
+Structured form for cases the URI cannot express:
+
+```ruby
+RSpecTracer.configure do
+  remote_cache_backend :s3,       bucket: 'my-bucket', prefix: 'rspec-tracer'
+  # or:
+  remote_cache_backend :local_fs, root: '/mnt/shared-cache'
+  # or:
+  remote_cache_backend :redis,    url: ENV.fetch('REDIS_URL'), prefix: 'rspec-tracer'
+end
+```
+
+## Caveats
+
+- **LocalFS over NFS**: cross-node consistency is eventual. A
+  download issued by node B immediately after an upload on node A may
+  miss; retries converge. Not a backend correctness bug.
+- **Redis memory**: hash-per-ref without gzip compression uses ~2-5x
+  more bytes than the S3/LocalFS tar+gzip archive. Fine for realistic
+  cache sizes (a few hundred refs × ~100 KB raw); budget Redis memory
+  accordingly for very large fleets.

--- a/lib/rspec_tracer/remote_cache/Rakefile
+++ b/lib/rspec_tracer/remote_cache/Rakefile
@@ -48,6 +48,14 @@ namespace :rspec_tracer do
         env: ENV
       )
     end
+
+    desc 'Prune dead PR branches across the whole remote cache (maintenance task)'
+    task :prune_all do
+      RSpecTracer::RemoteCache::UserTasks.prune_all!(
+        configuration: RSpecTracer,
+        env: ENV
+      )
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/lib/rspec_tracer/remote_cache/archive.rb
+++ b/lib/rspec_tracer/remote_cache/archive.rb
@@ -111,8 +111,10 @@ module RSpecTracer
       private_class_method :write_entry
 
       # Refuse absolute paths or `..` traversal. Both are illegal in a
-      # well-formed cache archive; silently dropping them beats trusting
-      # an S3-sourced blob to write anywhere on disk.
+      # well-formed cache entry name; silently dropping them beats
+      # trusting a remote-sourced value to write anywhere on disk.
+      # Public because RedisBackend reuses the same guard on hash field
+      # names (the Redis equivalent of tar entry names).
       def self.safe_entry_name(name)
         return nil if name.nil? || name.empty?
         return nil if name.start_with?('/')
@@ -120,7 +122,6 @@ module RSpecTracer
 
         name
       end
-      private_class_method :safe_entry_name
     end
   end
 end

--- a/lib/rspec_tracer/remote_cache/backend.rb
+++ b/lib/rspec_tracer/remote_cache/backend.rb
@@ -2,11 +2,10 @@
 
 module RSpecTracer
   module RemoteCache
-    # Protocol every remote-cache backend must satisfy. S3Backend is the
-    # only shipping implementation in M7.1; LocalFsBackend + RedisBackend
-    # arrive in M7.2. The shared-examples group in
-    # `spec/contracts/remote_cache_backend.rb` asserts the full contract
-    # on every implementation.
+    # Protocol every remote-cache backend must satisfy. S3Backend,
+    # LocalFsBackend, and RedisBackend all implement it. The shared-
+    # examples group in `spec/contracts/remote_cache_backend.rb` asserts
+    # the full contract on every implementation.
     #
     # Tier routing lives inside each backend, not in the protocol. A
     # backend is constructed with branch + default_branch + test_suite_id
@@ -22,13 +21,19 @@ module RSpecTracer
     #     report a meaningful exit status, but the orchestrator wraps
     #     the call in a rescue so test runs never propagate non-zero.
     #   - `branch_refs(branch_name)` returns `{}` when no refs file
-    #     exists. Missing !=  error.
+    #     exists. Missing is not an error.
     #   - `write_branch_refs(branch_name, refs)` is a no-op for main
-    #     tier writes (main branches don't use branch_refs — history
+    #     tier writes (main branches do not use branch_refs; history
     #     rewrites are not expected on the default branch).
     #   - `prune!(...)` returns the count of refs removed and never
     #     raises on a LIST / DELETE wire error (logs + returns what it
-    #     managed to delete).
+    #     managed to delete). Scoped to the backend's own tier.
+    #   - `prune_all!(pr_branch_ttl_seconds:)` walks every PR branch
+    #     under the configured prefix, applies the ttl to each, and
+    #     deletes dead branches whole. Cross-tier (every pr branch),
+    #     unlike `prune!` which is own-tier only. Returns the count of
+    #     refs removed across all branches. Never raises. No-op when
+    #     ttl is nil / non-positive.
     #
     # This module is intentionally documentation-only - it does not
     # define stubs that raise NotImplementedError, because mutant would
@@ -41,6 +46,7 @@ module RSpecTracer
         branch_refs
         write_branch_refs
         prune!
+        prune_all!
       ].freeze
 
       def self.conforms?(backend)

--- a/lib/rspec_tracer/remote_cache/local_fs_backend.rb
+++ b/lib/rspec_tracer/remote_cache/local_fs_backend.rb
@@ -1,0 +1,371 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'securerandom'
+
+require_relative 'archive'
+require_relative 'backend'
+require_relative 'validator'
+
+module RSpecTracer
+  module RemoteCache
+    # Filesystem implementation of `RemoteCache::Backend`. Target is
+    # a shared directory: an NFS mount, a per-host dev cache, or a CI
+    # workspace volume. Two-tier layout mirrors `S3Backend` bit-for-bit;
+    # a LocalFs root directory can be rsync'd to/from S3 without any
+    # transform (same `cache.tar.gz` per ref, same `branch_refs.json`
+    # path, same tier prefixes).
+    #
+    #   <root>/main/<sha>/[<test_suite_id>/]cache.tar.gz
+    #   <root>/pr/<branch>/<sha>/[<test_suite_id>/]cache.tar.gz
+    #   <root>/pr/<branch>/branch_refs.json
+    #
+    # Uploads are atomic: the archive is staged at a sibling tmp path
+    # on the same filesystem, then `File.rename`d into place. POSIX
+    # rename is atomic on same-filesystem moves, which covers every
+    # shared-mount topology LocalFs targets.
+    #
+    # Concurrent writes to the same ref: last-write-wins is correct
+    # because the archive content is a deterministic function of the
+    # local cache (two workers on the same SHA produce identical bytes).
+    # No file locking - flock is unreliable over NFS (lockd sharp
+    # edges) and buys nothing when contents match.
+    #
+    # NFS caveat: on a network filesystem, cross-node consistency is
+    # eventual. A download issued by node B immediately after an upload
+    # on node A may miss; retries converge. Document as user concern,
+    # not a backend correctness issue.
+    class LocalFsBackend
+      class LocalFsBackendError < StandardError; end
+
+      MAIN_TIER = 'main'
+      PR_TIER = 'pr'
+      BRANCH_REFS_FILENAME = 'branch_refs.json'
+      LAST_RUN_FILENAME = 'last_run.json'
+      CACHE_ARCHIVE_FILENAME = Archive::CACHE_FILENAME
+      ENCODING = 'UTF-8'
+
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(root:, branch:, default_branch:, cache_path:,
+                     test_suite_id: nil, logger: nil)
+        validate_required!(root: root, branch: branch,
+                           default_branch: default_branch, cache_path: cache_path)
+
+        @root = File.expand_path(root.to_s)
+        @branch = branch.to_s.chomp
+        @default_branch = default_branch.to_s.chomp
+        @test_suite_id = normalize_test_suite_id(test_suite_id)
+        @cache_path = cache_path.to_s
+        @logger = logger
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      # Download the cache for `ref` into `cache_path`. Tries the
+      # backend's own tier first; on miss, falls back to the main tier
+      # for the same ref. Validates via `schema_version` before
+      # declaring success. Returns true on validated success, false
+      # otherwise. Cleans up partially-extracted state on failure.
+      def download(ref)
+        return false if blank?(ref)
+
+        tiers_to_try = [own_tier_prefix]
+        tiers_to_try << main_tier_prefix if pr_tier?
+
+        tiers_to_try.any? { |tier| try_download_from(tier, ref) }
+      end
+
+      # Upload the local cache to this backend's own tier under `ref`.
+      # Packs the 15-file local layout into a `cache.tar.gz` via
+      # `Archive.pack`, renames into place atomically. Raises on a
+      # malformed local cache or an I/O failure.
+      def upload(ref)
+        raise LocalFsBackendError, 'ref is required' if blank?(ref)
+
+        run_id = read_local_run_id
+        raise LocalFsBackendError, "no local cache to upload (missing #{LAST_RUN_FILENAME})" if run_id.nil?
+
+        dest = archive_path(own_tier_prefix, ref)
+        FileUtils.mkdir_p(File.dirname(dest))
+        staging = "#{dest}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
+        begin
+          Archive.pack(cache_path: @cache_path, run_id: run_id, dest_path: staging)
+          File.rename(staging, dest)
+          log_debug("uploaded cache for #{ref} to #{own_tier_prefix} (#{File.size(dest)} bytes)")
+        ensure
+          FileUtils.rm_f(staging)
+        end
+      end
+
+      # Read branch_refs for the given branch. Returns `{sha => ts_epoch}`
+      # or `{}` on missing / malformed. PR tier only.
+      def branch_refs(branch_name)
+        return {} if blank?(branch_name)
+
+        path = branch_refs_path(branch_name)
+        return {} unless File.file?(path)
+
+        parsed = JSON.parse(File.read(path, encoding: ENCODING))
+        parsed.is_a?(Hash) ? parsed.transform_values(&:to_i) : {}
+      rescue StandardError => e
+        log_debug("branch_refs read failed (#{e.class}: #{e.message}); treating as empty")
+        {}
+      end
+
+      # Persist branch_refs for the given branch. No-op for main-branch
+      # writes. Atomic via tmp+rename. Raises on I/O failure for PR
+      # tier.
+      def write_branch_refs(branch_name, refs)
+        return if blank?(branch_name)
+        return if branch_name.to_s.chomp == @default_branch
+        return if refs.nil? || refs.empty?
+
+        path = branch_refs_path(branch_name)
+        FileUtils.mkdir_p(File.dirname(path))
+        staging = "#{path}.tmp.#{Process.pid}.#{SecureRandom.hex(4)}"
+        begin
+          File.write(staging, JSON.pretty_generate(refs), encoding: ENCODING)
+          File.rename(staging, path)
+          log_debug("wrote branch_refs for #{branch_name}")
+        ensure
+          FileUtils.rm_f(staging)
+        end
+      end
+
+      # Apply retention to the backend's own tier. Returns count removed.
+      # Semantics match S3Backend: count keeps newest N, duration prunes
+      # by mtime, pr_branch_ttl deletes the whole branch prefix when
+      # idle. Two or more params may be set simultaneously; all nil/0
+      # is a no-op. Never raises on partial I/O failure.
+      def prune!(count: nil, duration_seconds: nil, pr_branch_ttl_seconds: nil)
+        removed = 0
+        removed += prune_by_count!(count) if count&.positive?
+        removed += prune_by_duration!(duration_seconds) if duration_seconds&.positive?
+        removed += prune_dead_pr_branch!(pr_branch_ttl_seconds) if pr_tier? && pr_branch_ttl_seconds&.positive?
+        removed
+      end
+
+      # Cross-tier PR-branch cleanup. Enumerates every branch dir under
+      # `pr/`, applies the ttl to each, deletes branches with no ref
+      # newer than the cutoff. Returns total refs removed. No-op on
+      # nil / non-positive ttl.
+      def prune_all!(pr_branch_ttl_seconds: nil)
+        return 0 unless pr_branch_ttl_seconds&.positive?
+
+        cutoff = Time.now.to_i - pr_branch_ttl_seconds.to_i
+        pr_root = File.join(@root, PR_TIER)
+        return 0 unless File.directory?(pr_root)
+
+        branch_dirs(pr_root).sum { |branch_dir| maybe_prune_branch(branch_dir, cutoff) }
+      end
+
+      # Warn when the main tier has grown beyond a soft threshold and
+      # no retention is configured. Called from the orchestrator.
+      def unbounded_warning(warn_threshold: 500)
+        refs = list_refs_in_tier(MAIN_TIER)
+        return nil unless refs.length > warn_threshold
+
+        "rspec-tracer remote cache has #{refs.length} refs in #{@root}/#{MAIN_TIER}; " \
+          'configure cache_retention_count or cache_retention_duration to cap growth'
+      end
+
+      private
+
+      def blank?(value)
+        value.nil? || value.to_s.empty?
+      end
+
+      def validate_required!(**opts)
+        opts.each do |key, value|
+          raise LocalFsBackendError, "#{key} is required" if blank?(value)
+        end
+      end
+
+      def normalize_test_suite_id(raw)
+        return nil if raw.nil?
+
+        value = raw.to_s
+        value.empty? ? nil : value
+      end
+
+      def pr_tier?
+        @branch != @default_branch
+      end
+
+      def own_tier_prefix
+        pr_tier? ? "#{PR_TIER}/#{@branch}" : MAIN_TIER
+      end
+
+      def main_tier_prefix
+        MAIN_TIER
+      end
+
+      def archive_path(tier_prefix, ref)
+        File.join(*[@root, tier_prefix, ref, @test_suite_id, CACHE_ARCHIVE_FILENAME].compact)
+      end
+
+      def ref_dir(tier_prefix, ref)
+        File.join(@root, tier_prefix, ref)
+      end
+
+      def tier_dir(tier_prefix)
+        File.join(@root, tier_prefix)
+      end
+
+      def branch_refs_path(branch_name)
+        File.join(@root, PR_TIER, branch_name.chomp, BRANCH_REFS_FILENAME)
+      end
+
+      def local_last_run_path
+        File.join(@cache_path, LAST_RUN_FILENAME)
+      end
+
+      def local_run_dir(run_id)
+        File.join(@cache_path, run_id)
+      end
+
+      def read_local_run_id
+        return nil unless File.file?(local_last_run_path)
+
+        manifest = JSON.parse(File.read(local_last_run_path, encoding: ENCODING))
+        return nil unless manifest.is_a?(Hash)
+
+        run_id = manifest['run_id']
+        return nil if blank?(run_id)
+
+        run_id
+      rescue StandardError
+        nil
+      end
+
+      # Attempt extraction from (tier_prefix, ref). Returns true on
+      # validated success. Rolls back any partially-extracted state on
+      # failure so the next caller doesn't observe half-landed cache.
+      # rubocop:disable Naming/PredicateMethod
+      def try_download_from(tier_prefix, ref)
+        src = archive_path(tier_prefix, ref)
+        return false unless File.file?(src)
+
+        extract_and_validate(src, tier_prefix, ref)
+      end
+
+      def extract_and_validate(src, tier_prefix, ref)
+        begin
+          Archive.extract(archive_path: src, dest_dir: @cache_path)
+        rescue StandardError => e
+          log_debug("extract failed for #{tier_prefix}/#{ref}: #{e.class}: #{e.message}")
+          rollback_extracted_cache
+          return false
+        end
+
+        return true if Validator.valid_file?(local_last_run_path)
+
+        log_debug("rejected #{tier_prefix}/#{ref}: schema_version mismatch")
+        rollback_extracted_cache
+        false
+      end
+      # rubocop:enable Naming/PredicateMethod
+
+      def rollback_extracted_cache
+        run_id = read_local_run_id
+        FileUtils.rm_f(local_last_run_path)
+        FileUtils.rm_rf(local_run_dir(run_id)) if run_id
+      end
+
+      # Enumerate refs in `tier_prefix` as Array<[ref, mtime_epoch]>,
+      # newest-first. Uses the archive's mtime as the timestamp proxy -
+      # a fresh upload overwrites the archive via atomic rename so
+      # mtime tracks upload time correctly.
+      def list_refs_in_tier(tier_prefix)
+        dir = tier_dir(tier_prefix)
+        return [] unless File.directory?(dir)
+
+        refs = []
+        Dir.each_child(dir) do |ref|
+          archive = archive_path(tier_prefix, ref)
+          next unless File.file?(archive)
+
+          refs << [ref, File.mtime(archive).to_i]
+        end
+        refs.sort_by { |_, ts| -ts }
+      end
+
+      def prune_by_count!(count)
+        refs = list_refs_in_tier(own_tier_prefix)
+        return 0 if refs.length <= count
+
+        to_delete = refs[count..] || []
+        delete_refs(to_delete.map(&:first), own_tier_prefix)
+      end
+
+      def prune_by_duration!(duration_seconds)
+        cutoff = Time.now.to_i - duration_seconds.to_i
+        stale = list_refs_in_tier(own_tier_prefix).select { |_, ts| ts < cutoff }.map(&:first)
+        delete_refs(stale, own_tier_prefix)
+      end
+
+      def delete_refs(refs, tier_prefix)
+        removed = 0
+        refs.each do |ref|
+          FileUtils.rm_rf(ref_dir(tier_prefix, ref))
+          removed += 1
+          log_debug("pruned ref #{tier_prefix}/#{ref}")
+        rescue StandardError => e
+          log_warn("failed to prune ref #{tier_prefix}/#{ref}: #{e.class}: #{e.message}")
+        end
+        removed
+      end
+
+      def prune_dead_pr_branch!(ttl_seconds)
+        refs = list_refs_in_tier(own_tier_prefix)
+        return 0 if refs.empty?
+
+        newest_ts = refs.first[1]
+        return 0 if newest_ts >= Time.now.to_i - ttl_seconds.to_i
+
+        delete_branch_prefix(own_tier_prefix, refs.length)
+      end
+
+      # Delete every descendant of `<root>/<tier_prefix>` (cache dirs +
+      # branch_refs.json). Returns the supplied `ref_count` on success,
+      # 0 on failure.
+      def delete_branch_prefix(tier_prefix, ref_count)
+        FileUtils.rm_rf(tier_dir(tier_prefix))
+        log_debug("pruned dead PR branch #{tier_prefix}")
+        ref_count
+      rescue StandardError => e
+        log_warn("failed to prune dead PR branch #{tier_prefix}: #{e.class}: #{e.message}")
+        0
+      end
+
+      def branch_dirs(pr_root)
+        Dir.each_child(pr_root)
+          .map { |name| File.join(pr_root, name) }
+          .select { |path| File.directory?(path) }
+      end
+
+      # Apply the TTL to a single PR branch dir. Deletes whole branch
+      # when its newest ref is older than cutoff. Returns the count of
+      # refs removed (0 when branch is alive).
+      def maybe_prune_branch(branch_dir, cutoff)
+        branch_name = File.basename(branch_dir)
+        tier_prefix = "#{PR_TIER}/#{branch_name}"
+        refs = list_refs_in_tier(tier_prefix)
+        return 0 if refs.empty?
+
+        newest_ts = refs.first[1]
+        return 0 if newest_ts >= cutoff
+
+        delete_branch_prefix(tier_prefix, refs.length)
+      end
+
+      def log_debug(message)
+        @logger&.debug("rspec-tracer remote_cache: #{message}")
+      end
+
+      def log_warn(message)
+        @logger&.warn("rspec-tracer remote_cache: #{message}")
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/remote_cache/redis_backend.rb
+++ b/lib/rspec_tracer/remote_cache/redis_backend.rb
@@ -1,0 +1,432 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+
+require_relative 'archive'
+require_relative 'backend'
+require_relative 'validator'
+
+module RSpecTracer
+  module RemoteCache
+    # Redis implementation of `RemoteCache::Backend`. Each cache ref is
+    # one Redis hash keyed under the two-tier layout:
+    #
+    #   <prefix>:main:<sha>[:<test_suite_id>]           -> HASH
+    #   <prefix>:pr:<branch>:<sha>[:<test_suite_id>]    -> HASH
+    #   <prefix>:pr:<branch>:branch_refs                -> STRING (JSON)
+    #
+    # Hash fields per ref:
+    #   _timestamp       -> epoch float (string; microsecond resolution
+    #                        to keep within-second orderings stable for
+    #                        count-based prune)
+    #   last_run.json    -> JSON content verbatim
+    #   <run_id>/<f>.json -> JSON content per file in the 15-file layout
+    #
+    # Why hashmap and not a binary archive (like S3 / LocalFs): hash-
+    # per-ref is the idiomatic Redis data model, matches the brief, and
+    # gives operational visibility via `redis-cli HGETALL` /
+    # `HKEYS` / `HLEN` without extracting an archive first. The storage
+    # cost (no gzip) is negligible for realistic cache sizes.
+    #
+    # Retention: identical dispatch to S3 / LocalFs. The orchestrator
+    # calls `prune!(count:, duration_seconds:, pr_branch_ttl_seconds:)`
+    # after each upload; this backend enumerates via SCAN + HGET on the
+    # per-ref `_timestamp` field, then DELs stale keys. TTL-on-SET (i.e.
+    # letting Redis EXPIRE handle it natively) is a reasonable ergonomic
+    # followup but is not required for correctness - the explicit prune
+    # pass already achieves the same eviction outcome.
+    #
+    # Graceful-degradation contract:
+    #   - `redis` gem missing -> constructor raises RedisBackendError;
+    #     UserTasks rescues at the top, logs a clear "add gem to your
+    #     Gemfile" message, falls back to cold run. Never propagates.
+    #   - Wire failure (connection refused, timeout) -> redis-rb raises
+    #     Redis::BaseError subclasses. `download` catches and returns
+    #     false; `upload` lets them propagate for the Rake task to log.
+    #     Same rescue model as S3Backend.
+    #
+    # The `redis` gem is an OPTIONAL runtime dependency - users add
+    # `gem 'redis'` to their own Gemfile to use RedisBackend. The
+    # constructor calls `require 'redis'` lazily and raises a clear
+    # RedisBackendError if the gem is absent, which UserTasks converts
+    # into a warning + cold run.
+    class RedisBackend
+      class RedisBackendError < StandardError; end
+
+      MAIN_TIER = 'main'
+      PR_TIER = 'pr'
+      BRANCH_REFS_SUFFIX = 'branch_refs'
+      LAST_RUN_FIELD = 'last_run.json'
+      TIMESTAMP_FIELD = '_timestamp'
+      ENCODING = 'UTF-8'
+      DEFAULT_SCAN_COUNT = 200
+
+      # rubocop:disable Metrics/ParameterLists
+      def initialize(prefix:, branch:, default_branch:, cache_path:,
+                     url: nil, redis_client: nil, test_suite_id: nil, logger: nil)
+        validate_required!(prefix: prefix, branch: branch,
+                           default_branch: default_branch, cache_path: cache_path)
+        validate_connection_source!(url: url, redis_client: redis_client)
+
+        @prefix = trim_trailing_colons(prefix.to_s)
+        @branch = branch.to_s.chomp
+        @default_branch = default_branch.to_s.chomp
+        @test_suite_id = normalize_test_suite_id(test_suite_id)
+        @cache_path = cache_path.to_s
+        @logger = logger
+        @redis = redis_client || build_client(url)
+      end
+      # rubocop:enable Metrics/ParameterLists
+
+      # Download cache for `ref`. Tries own tier, falls back to main
+      # tier. Returns true on validated success, false otherwise.
+      # Cleans up partially-written files on failure.
+      def download(ref)
+        return false if blank?(ref)
+
+        tiers_to_try = [own_tier_segment]
+        tiers_to_try << MAIN_TIER if pr_tier?
+
+        tiers_to_try.any? { |tier| try_download_from(tier, ref) }
+      end
+
+      # Upload local cache as a hash under own-tier key. Raises on I/O
+      # or Redis wire failure.
+      def upload(ref)
+        raise RedisBackendError, 'ref is required' if blank?(ref)
+
+        run_id = read_local_run_id
+        raise RedisBackendError, "no local cache to upload (missing #{LAST_RUN_FIELD})" if run_id.nil?
+
+        fields = build_upload_fields(run_id)
+        key = ref_key(own_tier_segment, ref)
+        write_hash(key, fields)
+        log_debug("uploaded cache for #{ref} to #{own_tier_segment} (#{fields.size} fields)")
+      end
+
+      # Read branch_refs for the given branch. Returns
+      # `{sha => ts_epoch}` or `{}` when missing / malformed.
+      def branch_refs(branch_name)
+        return {} if blank?(branch_name)
+
+        raw = @redis.get(branch_refs_key(branch_name))
+        return {} if raw.nil? || raw.empty?
+
+        parsed = JSON.parse(raw)
+        parsed.is_a?(Hash) ? parsed.transform_values(&:to_i) : {}
+      rescue StandardError => e
+        log_debug("branch_refs read failed (#{e.class}: #{e.message}); treating as empty")
+        {}
+      end
+
+      # Persist branch_refs for the given branch. No-op for main-branch
+      # writes. Raises on Redis wire failure for PR tier.
+      def write_branch_refs(branch_name, refs)
+        return if blank?(branch_name)
+        return if branch_name.to_s.chomp == @default_branch
+        return if refs.nil? || refs.empty?
+
+        @redis.set(branch_refs_key(branch_name), JSON.pretty_generate(refs))
+        log_debug("wrote branch_refs for #{branch_name}")
+      end
+
+      # Apply retention to own tier. Returns count removed. Two or more
+      # knobs may be set; each applies independently. Never raises - a
+      # wire-level Redis error on any sub-prune logs + is absorbed.
+      # rubocop:disable Metrics/PerceivedComplexity
+      def prune!(count: nil, duration_seconds: nil, pr_branch_ttl_seconds: nil)
+        removed = 0
+        removed += prune_by_count!(count) if count&.positive?
+        removed += prune_by_duration!(duration_seconds) if duration_seconds&.positive?
+        removed += prune_dead_pr_branch!(pr_branch_ttl_seconds) if pr_tier? && pr_branch_ttl_seconds&.positive?
+        removed
+      rescue StandardError => e
+        log_warn("prune! failed (#{e.class}: #{e.message}); returning #{removed}")
+        removed
+      end
+      # rubocop:enable Metrics/PerceivedComplexity
+
+      # Cross-tier PR-branch cleanup. Enumerates every PR branch under
+      # the configured prefix (by scanning for `<prefix>:pr:<branch>:branch_refs`
+      # keys and deriving branch names), applies the TTL to each,
+      # deletes dead branches whole. Returns total refs removed. No-op
+      # on nil / non-positive TTL.
+      def prune_all!(pr_branch_ttl_seconds: nil)
+        return 0 unless pr_branch_ttl_seconds&.positive?
+
+        cutoff = Time.now.to_i - pr_branch_ttl_seconds.to_i
+        branches = discover_pr_branches
+        branches.sum { |branch| maybe_prune_branch(branch, cutoff) }
+      rescue StandardError => e
+        log_warn("prune_all! failed (#{e.class}: #{e.message})")
+        0
+      end
+
+      # Warn when main tier has grown beyond threshold and no retention
+      # is configured.
+      def unbounded_warning(warn_threshold: 500)
+        count = count_tier_refs(MAIN_TIER)
+        return nil unless count > warn_threshold
+
+        "rspec-tracer remote cache has #{count} refs in #{@prefix}:#{MAIN_TIER}; " \
+          'configure cache_retention_count or cache_retention_duration to cap growth'
+      end
+
+      private
+
+      def blank?(value)
+        value.nil? || value.to_s.empty?
+      end
+
+      def validate_required!(**opts)
+        opts.each do |key, value|
+          raise RedisBackendError, "#{key} is required" if blank?(value)
+        end
+      end
+
+      def validate_connection_source!(url:, redis_client:)
+        return if redis_client
+        raise RedisBackendError, 'url or redis_client is required' if blank?(url)
+      end
+
+      def build_client(url)
+        require 'redis'
+        ::Redis.new(url: url)
+      rescue LoadError
+        raise RedisBackendError,
+              "redis gem is not installed; add `gem 'redis'` to your Gemfile to use RedisBackend"
+      end
+
+      def normalize_test_suite_id(raw)
+        return nil if raw.nil?
+
+        value = raw.to_s
+        value.empty? ? nil : value
+      end
+
+      def trim_trailing_colons(str)
+        value = str.dup
+        value.chop! while value.end_with?(':')
+        value
+      end
+
+      def pr_tier?
+        @branch != @default_branch
+      end
+
+      def own_tier_segment
+        pr_tier? ? "#{PR_TIER}:#{@branch}" : MAIN_TIER
+      end
+
+      def ref_key(tier_segment, ref)
+        [@prefix, tier_segment, ref, @test_suite_id].compact.reject(&:empty?).join(':')
+      end
+
+      def branch_refs_key(branch_name)
+        [@prefix, PR_TIER, branch_name.chomp, BRANCH_REFS_SUFFIX].join(':')
+      end
+
+      def local_last_run_path
+        File.join(@cache_path, LAST_RUN_FIELD)
+      end
+
+      def local_run_dir(run_id)
+        File.join(@cache_path, run_id)
+      end
+
+      def read_local_run_id
+        return nil unless File.file?(local_last_run_path)
+
+        manifest = JSON.parse(File.read(local_last_run_path, encoding: ENCODING))
+        return nil unless manifest.is_a?(Hash)
+
+        run_id = manifest['run_id']
+        return nil if blank?(run_id)
+
+        run_id
+      rescue StandardError
+        nil
+      end
+
+      def build_upload_fields(run_id)
+        # Float seconds, not integer - multiple uploads within the
+        # same clock second otherwise collide on _timestamp and make
+        # count-based prune pick arbitrary survivors. Float keeps
+        # microsecond ordering stable under realistic CI cadences.
+        fields = { TIMESTAMP_FIELD => Time.now.to_f.to_s }
+        fields[LAST_RUN_FIELD] = File.read(local_last_run_path, encoding: ENCODING)
+        Dir[File.join(local_run_dir(run_id), '*.json')].each do |path|
+          fields["#{run_id}/#{File.basename(path)}"] = File.read(path, encoding: ENCODING)
+        end
+        fields
+      end
+
+      # DEL + HSET atomically under MULTI. DEL drops any stale fields
+      # from a prior upload under the same ref before HSET installs
+      # the new field set (prevents partial overlay when a retried
+      # upload has a subset of keys the first attempt had).
+      def write_hash(key, fields)
+        @redis.multi do |tx|
+          tx.del(key)
+          tx.hset(key, fields)
+        end
+      end
+
+      def try_download_from(tier_segment, ref)
+        key = ref_key(tier_segment, ref)
+        fields = @redis.hgetall(key)
+        return false if fields.nil? || fields.empty?
+
+        extract_and_validate(fields, tier_segment, ref)
+      rescue StandardError => e
+        log_debug("download failed for #{tier_segment}/#{ref}: #{e.class}: #{e.message}")
+        rollback_extracted_cache
+        false
+      end
+
+      # Action-style method (writes files + cleans up on failure), not a
+      # pure predicate. The bool return is the "did we land a valid
+      # cache" signal; renaming to `?` would misread the method as a
+      # query that happens to perform I/O.
+      # rubocop:disable Naming/PredicateMethod
+      def extract_and_validate(fields, tier_segment, ref)
+        write_fields_to_disk(fields)
+
+        return true if Validator.valid_file?(local_last_run_path)
+
+        log_debug("rejected #{tier_segment}/#{ref}: schema_version mismatch")
+        rollback_extracted_cache
+        false
+      end
+      # rubocop:enable Naming/PredicateMethod
+
+      def write_fields_to_disk(fields)
+        FileUtils.mkdir_p(@cache_path)
+        fields.each do |field, content|
+          next if field == TIMESTAMP_FIELD
+
+          safe_name = Archive.safe_entry_name(field)
+          next if safe_name.nil?
+
+          dest = File.join(@cache_path, safe_name)
+          FileUtils.mkdir_p(File.dirname(dest))
+          File.write(dest, content, encoding: ENCODING)
+        end
+      end
+
+      def rollback_extracted_cache
+        run_id = read_local_run_id
+        FileUtils.rm_f(local_last_run_path)
+        FileUtils.rm_rf(local_run_dir(run_id)) if run_id
+      end
+
+      # List refs in `tier_segment` as Array<[key, ts_epoch]>,
+      # newest-first. Returns full Redis keys (not just the ref sha)
+      # because prune_by_* deletes those keys directly.
+      def list_refs_in_tier(tier_segment)
+        pattern = "#{@prefix}:#{tier_segment}:*"
+        keys = scan_matching_keys(pattern).reject { |k| branch_refs_key?(k) }
+        return [] if keys.empty?
+
+        entries = keys.map { |k| [k, fetch_timestamp(k)] }.reject { |(_, ts)| ts.nil? }
+        entries.sort_by { |(_, ts)| -ts }
+      end
+
+      def scan_matching_keys(pattern)
+        @redis.scan_each(match: pattern, count: DEFAULT_SCAN_COUNT).to_a
+      end
+
+      def branch_refs_key?(key)
+        key.end_with?(":#{BRANCH_REFS_SUFFIX}")
+      end
+
+      def fetch_timestamp(key)
+        raw = @redis.hget(key, TIMESTAMP_FIELD)
+        return nil if raw.nil?
+
+        raw.to_f
+      end
+
+      def count_tier_refs(tier_segment)
+        pattern = "#{@prefix}:#{tier_segment}:*"
+        scan_matching_keys(pattern).count { |k| !branch_refs_key?(k) }
+      end
+
+      def prune_by_count!(count)
+        entries = list_refs_in_tier(own_tier_segment)
+        return 0 if entries.length <= count
+
+        to_delete = entries[count..] || []
+        delete_keys(to_delete.map(&:first))
+      end
+
+      def prune_by_duration!(duration_seconds)
+        cutoff = Time.now.to_i - duration_seconds.to_i
+        stale_keys = list_refs_in_tier(own_tier_segment)
+          .select { |(_, ts)| ts < cutoff }
+          .map(&:first)
+        delete_keys(stale_keys)
+      end
+
+      def delete_keys(keys)
+        return 0 if keys.empty?
+
+        @redis.del(*keys)
+        keys.each { |k| log_debug("pruned key #{k}") }
+        keys.length
+      end
+
+      def prune_dead_pr_branch!(ttl_seconds)
+        entries = list_refs_in_tier(own_tier_segment)
+        return 0 if entries.empty?
+
+        newest_ts = entries.first[1]
+        return 0 if newest_ts >= Time.now.to_i - ttl_seconds.to_i
+
+        delete_branch_prefix(@branch, entries.length)
+      end
+
+      # Delete every cache key + branch_refs under a given PR branch.
+      # Returns the supplied `ref_count` on success, 0 on failure.
+      def delete_branch_prefix(branch_name, ref_count)
+        pattern = "#{@prefix}:#{PR_TIER}:#{branch_name}:*"
+        keys = scan_matching_keys(pattern)
+        @redis.del(*keys) unless keys.empty?
+        log_debug("pruned dead PR branch #{PR_TIER}:#{branch_name} (#{keys.length} keys)")
+        ref_count
+      rescue StandardError => e
+        log_warn("failed to prune dead PR branch #{PR_TIER}:#{branch_name}: #{e.class}: #{e.message}")
+        0
+      end
+
+      def discover_pr_branches
+        pattern = "#{@prefix}:#{PR_TIER}:*:#{BRANCH_REFS_SUFFIX}"
+        prefix_head = "#{@prefix}:#{PR_TIER}:"
+        scan_matching_keys(pattern).map do |key|
+          remainder = key[prefix_head.length..]
+          remainder.delete_suffix(":#{BRANCH_REFS_SUFFIX}")
+        end
+      end
+
+      def maybe_prune_branch(branch_name, cutoff)
+        tier_segment = "#{PR_TIER}:#{branch_name}"
+        entries = list_refs_in_tier(tier_segment)
+        return 0 if entries.empty?
+
+        newest_ts = entries.first[1]
+        return 0 if newest_ts >= cutoff
+
+        delete_branch_prefix(branch_name, entries.length)
+      end
+
+      def log_debug(message)
+        @logger&.debug("rspec-tracer remote_cache: #{message}")
+      end
+
+      def log_warn(message)
+        @logger&.warn("rspec-tracer remote_cache: #{message}")
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/remote_cache/s3_backend.rb
+++ b/lib/rspec_tracer/remote_cache/s3_backend.rb
@@ -3,6 +3,7 @@
 require 'json'
 require 'open3'
 require 'securerandom'
+require 'set'
 require 'time'
 require 'tmpdir'
 
@@ -58,6 +59,10 @@ module RSpecTracer
     #   - `branch_refs` returns `{}` on missing file.
     #   - `prune!` returns count removed, never raises.
     #
+    # S3 shells out via `aws` CLI - a single class is the natural unit
+    # of composition here. M8.3 mutation-smoke addition may push this
+    # over the limit further; splitting would be cosmetic.
+    # rubocop:disable Metrics/ClassLength
     class S3Backend
       class S3BackendError < StandardError; end
 
@@ -185,6 +190,22 @@ module RSpecTracer
         removed += prune_by_duration!(duration_seconds) if duration_seconds&.positive?
         removed += prune_dead_pr_branch!(pr_branch_ttl_seconds) if pr_tier? && pr_branch_ttl_seconds&.positive?
         removed
+      end
+
+      # Cross-tier PR-branch cleanup. Enumerates every PR branch under
+      # the configured prefix by listing the `pr/` subtree, applies the
+      # TTL to each branch, deletes dead branches whole. Returns total
+      # refs removed. No-op on nil / non-positive TTL. Never raises
+      # (graceful-degradation contract).
+      def prune_all!(pr_branch_ttl_seconds: nil)
+        return 0 unless pr_branch_ttl_seconds&.positive?
+
+        cutoff = Time.now.to_i - pr_branch_ttl_seconds.to_i
+        branches = discover_pr_branches
+        branches.sum { |branch| maybe_prune_branch(branch, cutoff) }
+      rescue StandardError => e
+        log_warn("prune_all! failed (#{e.class}: #{e.message})")
+        0
       end
 
       # Check whether the backend's own tier has accumulated more than
@@ -418,14 +439,76 @@ module RSpecTracer
         newest_ts = refs.first[1]
         return 0 if newest_ts >= Time.now.to_i - ttl_seconds.to_i
 
-        ok, _stdout, stderr = aws_rm_recursive_silent(s3_tier_prefix_url(own_tier_prefix))
+        delete_branch_prefix(own_tier_prefix, refs.length)
+      end
+
+      # Delete every object under `<prefix>/<tier_prefix>/` (cache refs
+      # + branch_refs.json). Returns the supplied `ref_count` on
+      # success, 0 on failure.
+      def delete_branch_prefix(tier_prefix, ref_count)
+        ok, _stdout, stderr = aws_rm_recursive_silent(s3_tier_prefix_url(tier_prefix))
         if ok
-          log_debug("pruned dead PR branch #{own_tier_prefix}")
-          refs.length
+          log_debug("pruned dead PR branch #{tier_prefix} (#{ref_count} refs)")
+          ref_count
         else
-          log_warn("failed to prune dead PR branch #{own_tier_prefix}: #{stderr.chomp}")
+          log_warn("failed to prune dead PR branch #{tier_prefix}: #{stderr.chomp}")
           0
         end
+      end
+
+      # Enumerate PR branches under the configured prefix. Returns an
+      # Array<String> of branch names (one per unique `pr/<branch>/`
+      # segment). Uses `list-objects-v2 --prefix pr/ --delimiter /` so
+      # we pay for one bucket listing instead of walking every object.
+      def discover_pr_branches
+        prefix_head = "#{join_key(@prefix, PR_TIER)}/"
+        common_prefixes = list_common_prefixes(prefix_head)
+        return [] if common_prefixes.empty?
+
+        branches = Set.new
+        common_prefixes.each do |entry|
+          value = entry['Prefix']
+          next if value.nil? || !value.start_with?(prefix_head)
+
+          branch = value[prefix_head.length..].delete_suffix('/')
+          branches << branch unless branch.empty?
+        end
+        branches.to_a
+      end
+
+      def list_common_prefixes(prefix)
+        stdout, stderr, status = Open3.capture3(
+          @cli_binary, 's3api', 'list-objects-v2',
+          '--bucket', @bucket,
+          '--prefix', prefix,
+          '--delimiter', '/',
+          '--output', 'json'
+        )
+        unless status.success?
+          log_debug("list-objects-v2 (delimited) #{prefix} failed: #{stderr.chomp}")
+          return []
+        end
+        return [] if stdout.strip.empty?
+
+        parsed = JSON.parse(stdout)
+        Array(parsed['CommonPrefixes'])
+      rescue StandardError => e
+        log_debug("list-objects-v2 (delimited) parse failed: #{e.class}: #{e.message}")
+        []
+      end
+
+      # Apply the TTL to a single PR branch. Deletes whole branch when
+      # its newest ref is older than `cutoff`. Returns the count of
+      # refs removed (0 when branch is alive).
+      def maybe_prune_branch(branch_name, cutoff)
+        tier_prefix = "#{PR_TIER}/#{branch_name}"
+        refs = list_refs_in_tier(tier_prefix)
+        return 0 if refs.empty?
+
+        newest_ts = refs.first[1]
+        return 0 if newest_ts >= cutoff
+
+        delete_branch_prefix(tier_prefix, refs.length)
       end
 
       def parse_s3_timestamp(iso_string)
@@ -479,5 +562,6 @@ module RSpecTracer
         @logger&.warn("rspec-tracer remote_cache: #{message}")
       end
     end
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/lib/rspec_tracer/remote_cache/user_tasks.rb
+++ b/lib/rspec_tracer/remote_cache/user_tasks.rb
@@ -4,6 +4,8 @@ require 'time'
 require 'uri'
 
 require_relative 'git_ancestry'
+require_relative 'local_fs_backend'
+require_relative 'redis_backend'
 require_relative 's3_backend'
 
 module RSpecTracer
@@ -26,7 +28,11 @@ module RSpecTracer
     #     the tests already passed; cache miss is recoverable next run.
     #
     class UserTasks
-      BUILT_IN_BACKENDS = { s3: S3Backend }.freeze
+      BUILT_IN_BACKENDS = {
+        s3: S3Backend,
+        local_fs: LocalFsBackend,
+        redis: RedisBackend
+      }.freeze
 
       def self.download!(configuration: RSpecTracer, env: ENV)
         new(configuration: configuration, env: env).download!
@@ -34,6 +40,10 @@ module RSpecTracer
 
       def self.upload!(configuration: RSpecTracer, env: ENV)
         new(configuration: configuration, env: env).upload!
+      end
+
+      def self.prune_all!(configuration: RSpecTracer, env: ENV)
+        new(configuration: configuration, env: env).prune_all!
       end
 
       def self.git_repo?
@@ -84,6 +94,30 @@ module RSpecTracer
         false
       end
 
+      # Cross-tier PR-branch prune. Walks every branch under the
+      # configured prefix and deletes whole branches idle longer than
+      # `cache_retention_pr_branch_ttl_seconds`. Designed as a periodic
+      # maintenance task (nightly cron) - dead PR branches whose tip is
+      # never re-uploaded otherwise accumulate forever because
+      # `maybe_prune` only scopes to the current upload's tier. Returns
+      # the total refs removed across all branches, or 0 on graceful
+      # failure.
+      def prune_all!
+        ttl = safe_config(:cache_retention_pr_branch_ttl_seconds)
+        if ttl.nil?
+          @logger.warn 'rspec-tracer remote_cache: prune_all requires cache_retention_pr_branch_ttl; skipping'
+          return 0
+        end
+
+        backend = build_backend(build_admin_ancestry)
+        removed = backend.prune_all!(pr_branch_ttl_seconds: ttl)
+        @logger.debug "rspec-tracer remote_cache: prune_all removed #{removed} refs"
+        removed
+      rescue StandardError => e
+        @logger.warn "rspec-tracer remote_cache: prune_all failed (#{e.class}: #{e.message})"
+        0
+      end
+
       private
 
       def build_ancestry
@@ -91,6 +125,20 @@ module RSpecTracer
           default_branch: require_env('GIT_DEFAULT_BRANCH'),
           branch: require_env('GIT_BRANCH')
         )
+      end
+
+      # Ancestry for cross-tier admin tasks (prune_all). Only
+      # GIT_DEFAULT_BRANCH is required; GIT_BRANCH defaults to it so
+      # the backend constructs in main-tier mode (prune_all walks every
+      # pr/ branch regardless of the backend's own tier, so the branch
+      # value does not affect behavior). Running prune_all from a
+      # cron/workflow that is not tied to a specific PR should work
+      # with just GIT_DEFAULT_BRANCH set.
+      def build_admin_ancestry
+        default = require_env('GIT_DEFAULT_BRANCH')
+        branch = @env['GIT_BRANCH']
+        branch = default if branch.nil? || branch.to_s.empty?
+        GitAncestry.new(default_branch: default, branch: branch)
       end
 
       def require_env(name)

--- a/spec/contracts/remote_cache_backend.rb
+++ b/spec/contracts/remote_cache_backend.rb
@@ -76,4 +76,22 @@ RSpec.shared_examples 'a RemoteCache::Backend' do
       expect(backend.prune!(count: 0, duration_seconds: 0, pr_branch_ttl_seconds: 0)).to eq(0)
     end
   end
+
+  describe '#prune_all!' do
+    it 'returns 0 when pr_branch_ttl_seconds is nil' do
+      expect(backend.prune_all!(pr_branch_ttl_seconds: nil)).to eq(0)
+    end
+
+    it 'returns 0 when pr_branch_ttl_seconds is zero' do
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 0)).to eq(0)
+    end
+
+    it 'returns 0 when pr_branch_ttl_seconds is negative' do
+      expect(backend.prune_all!(pr_branch_ttl_seconds: -1)).to eq(0)
+    end
+
+    it 'accepts a bare call (no kwargs) without raising' do
+      expect { backend.prune_all! }.not_to raise_error
+    end
+  end
 end

--- a/spec/integration/remote_cache_redis_spec.rb
+++ b/spec/integration/remote_cache_redis_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'securerandom'
+require 'tmpdir'
+
+require 'rspec_tracer/remote_cache/redis_backend'
+require 'rspec_tracer/storage/schema'
+
+# Integration test: RedisBackend round-trip against a real Redis
+# server. Skips gracefully when `redis` gem is missing or localhost:6379
+# is unreachable, so the task graph does not break for local dev
+# without Redis. CI provides a `redis:` services container (see
+# `.github/workflows/lint-and-specs.yml`); specs here run after that
+# wakes up.
+#
+# REDIS_URL overrides the default. We use db 15 (an uncommon choice)
+# to isolate from other local tooling on the same Redis instance.
+#
+# Asserts on the content of what was uploaded / downloaded (per the
+# feedback_v2_integration_exit_status memory: exit-status-only checks
+# mask cache-persistence bugs).
+#
+# rubocop:disable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable
+# rubocop:disable RSpec/LeakyConstantDeclaration, RSpec/ExampleLength, RSpec/MultipleExpectations
+# rubocop:disable Lint/ConstantDefinitionInBlock
+RSpec.describe 'RemoteCache::RedisBackend against localhost Redis', :integration, :redis do
+  REDIS_URL = ENV.fetch('REDIS_URL', 'redis://localhost:6379/15')
+
+  def redis_reachable?
+    require 'redis'
+    client = Redis.new(url: REDIS_URL, timeout: 1)
+    client.ping == 'PONG'
+  rescue LoadError, StandardError
+    false
+  ensure
+    client&.close
+  end
+
+  before(:all) do
+    skip 'Redis not reachable; skipping integration specs' unless redis_reachable?
+
+    require 'redis'
+    @prefix = "rspec-tracer-it-#{SecureRandom.hex(4)}"
+    @client = Redis.new(url: REDIS_URL)
+    # Start clean on this prefix in case a prior aborted run left keys.
+    flush_prefix
+  end
+
+  after(:all) do
+    flush_prefix if defined?(@client) && @client
+    @client&.close
+  end
+
+  def flush_prefix
+    cursor = 0
+    loop do
+      cursor, keys = @client.scan(cursor, match: "#{@prefix}:*", count: 200)
+      @client.del(*keys) unless keys.empty?
+      break if cursor.to_i.zero?
+    end
+  end
+
+  let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @cache_path = dir
+      example.run
+    end
+  end
+
+  before do
+    # Isolate each example from state left by previous ones. All tests
+    # share @prefix via before(:all), so without this reset the retention
+    # + prune_all tests see leftover keys from round-trip specs and
+    # mis-count deletions.
+    flush_prefix
+  end
+
+  def build_backend(branch:, default_branch: 'main', test_suite_id: nil)
+    RSpecTracer::RemoteCache::RedisBackend.new(
+      prefix: @prefix,
+      branch: branch,
+      default_branch: default_branch,
+      test_suite_id: test_suite_id,
+      cache_path: @cache_path,
+      url: REDIS_URL
+    )
+  end
+
+  def write_local_cache(run_id: 'run-abc-123')
+    File.write(
+      File.join(@cache_path, 'last_run.json'),
+      JSON.pretty_generate('schema_version' => current_schema, 'run_id' => run_id, 'timestamp' => Time.now.utc.iso8601)
+    )
+    FileUtils.mkdir_p(File.join(@cache_path, run_id))
+    File.write(File.join(@cache_path, run_id, 'all_examples.json'),
+               JSON.pretty_generate('examples' => { 'ex1' => 'passed' }))
+    File.write(File.join(@cache_path, run_id, 'dependency.json'),
+               JSON.pretty_generate('ex1' => ['lib/foo.rb']))
+  end
+
+  describe 'upload + download round-trip on main tier' do
+    it 'preserves last_run.json and the run directory contents' do
+      backend = build_backend(branch: 'main', default_branch: 'main')
+      write_local_cache(run_id: 'run-main')
+      original_content = File.read(File.join(@cache_path, 'run-main', 'all_examples.json'))
+
+      backend.upload('main-sha-1')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+
+      expect(backend.download('main-sha-1')).to be(true)
+      expect(File.read(File.join(@cache_path, 'run-main', 'all_examples.json'))).to eq(original_content)
+      manifest = JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))
+      expect(manifest['schema_version']).to eq(current_schema)
+    end
+  end
+
+  describe 'upload + download round-trip on pr tier' do
+    it 'uploads under pr:<branch>:<sha> and downloads cleanly' do
+      backend = build_backend(branch: 'feat-redis-1', default_branch: 'main')
+      write_local_cache(run_id: 'run-pr')
+
+      backend.upload('feat-sha-1')
+
+      # Inspect Redis directly to confirm the key lives where we expect.
+      expect(@client.exists?("#{@prefix}:pr:feat-redis-1:feat-sha-1")).to be(true)
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      expect(backend.download('feat-sha-1')).to be(true)
+    end
+  end
+
+  describe 'schema_version mismatch refuses cache' do
+    it 'returns false when the remote cache carries a different schema_version' do
+      backend = build_backend(branch: 'main', default_branch: 'main')
+      write_local_cache(run_id: 'run-bad-schema')
+      # Inject bad schema before upload.
+      File.write(
+        File.join(@cache_path, 'last_run.json'),
+        JSON.pretty_generate('schema_version' => current_schema + 99, 'run_id' => 'run-bad-schema')
+      )
+      backend.upload('bad-schema-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      expect(backend.download('bad-schema-sha')).to be(false)
+      expect(File.exist?(File.join(@cache_path, 'last_run.json'))).to be(false)
+    end
+  end
+
+  describe 'branch_refs round-trip' do
+    it 'writes and reads branch_refs on pr tier via Redis string key' do
+      backend = build_backend(branch: 'feat-refs', default_branch: 'main')
+      refs = { 'sha1' => 1_700_000_000, 'sha2' => 1_700_000_100 }
+
+      backend.write_branch_refs('feat-refs', refs)
+
+      expect(backend.branch_refs('feat-refs')).to eq(refs)
+    end
+
+    it 'returns {} when branch_refs have not been written' do
+      backend = build_backend(branch: 'feat-missing', default_branch: 'main')
+
+      expect(backend.branch_refs('feat-missing')).to eq({})
+    end
+  end
+
+  describe 'pr tier fallback to main tier' do
+    it 'downloads from main when the pr tier has no ref but main does' do
+      main_backend = build_backend(branch: 'main', default_branch: 'main')
+      write_local_cache(run_id: 'run-main-fallback')
+      main_backend.upload('shared-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      pr_backend = build_backend(branch: 'feat-fallback', default_branch: 'main')
+
+      expect(pr_backend.download('shared-sha')).to be(true)
+    end
+  end
+
+  describe 'retention: cache_retention_count' do
+    it 'prunes older refs when count exceeded' do
+      backend = build_backend(branch: 'main', default_branch: 'main')
+      5.times do |i|
+        write_local_cache(run_id: "run-#{i}")
+        backend.upload("count-sha-#{i}")
+        sleep 0.05
+      end
+
+      removed = backend.prune!(count: 2)
+
+      expect(removed).to eq(3)
+      remaining = (0..4).map { |i| "count-sha-#{i}" }
+        .select { |sha| @client.exists?("#{@prefix}:main:#{sha}") }
+      expect(remaining.size).to eq(2)
+      # The newest two survive; they are the last two uploaded.
+      expect(remaining).to include('count-sha-3', 'count-sha-4')
+    end
+  end
+
+  describe 'retention: pr_branch_ttl on pr tier' do
+    it 'leaves a fresh PR branch untouched when TTL is generous' do
+      backend = build_backend(branch: 'feat-live', default_branch: 'main')
+      write_local_cache(run_id: 'run-live')
+      backend.upload('live-sha')
+
+      removed = backend.prune!(pr_branch_ttl_seconds: 30 * 86_400)
+
+      expect(removed).to eq(0)
+      expect(@client.exists?("#{@prefix}:pr:feat-live:live-sha")).to be(true)
+    end
+  end
+
+  describe 'prune_all! cross-tier cleanup' do
+    it 'deletes dead branches but keeps live ones' do
+      # live
+      live = build_backend(branch: 'live-all', default_branch: 'main')
+      write_local_cache(run_id: 'run-live-all')
+      live.upload('live-all-sha')
+      live.write_branch_refs('live-all', 'live-all-sha' => Time.now.to_i)
+
+      # dead: backdate the _timestamp manually to simulate an old ref
+      dead = build_backend(branch: 'dead-all', default_branch: 'main')
+      write_local_cache(run_id: 'run-dead-all')
+      dead.upload('dead-all-sha')
+      old_ts = (Time.now.to_i - (30 * 86_400)).to_s
+      @client.hset("#{@prefix}:pr:dead-all:dead-all-sha", '_timestamp', old_ts)
+      dead.write_branch_refs('dead-all', 'dead-all-sha' => old_ts.to_i)
+
+      admin = build_backend(branch: 'main', default_branch: 'main')
+      removed = admin.prune_all!(pr_branch_ttl_seconds: 14 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(@client.exists?("#{@prefix}:pr:live-all:live-all-sha")).to be(true)
+      # Dead branch keys should be gone: both the cache hash and branch_refs
+      expect(@client.exists?("#{@prefix}:pr:dead-all:dead-all-sha")).to be(false)
+      expect(@client.exists?("#{@prefix}:pr:dead-all:branch_refs")).to be(false)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable
+# rubocop:enable RSpec/LeakyConstantDeclaration, RSpec/ExampleLength, RSpec/MultipleExpectations
+# rubocop:enable Lint/ConstantDefinitionInBlock

--- a/spec/remote_cache/backend_spec.rb
+++ b/spec/remote_cache/backend_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe RSpecTracer::RemoteCache::Backend do
 
     it 'lists the protocol methods' do
       expect(described_class::REQUIRED_METHODS).to match_array(%i[
-        download upload branch_refs write_branch_refs prune!
+        download upload branch_refs write_branch_refs prune! prune_all!
       ])
     end
   end
@@ -26,6 +26,7 @@ RSpec.describe RSpecTracer::RemoteCache::Backend do
         def branch_refs(_name); end
         def write_branch_refs(_name, _refs); end
         def prune!(**_opts); end
+        def prune_all!(**_opts); end
       end.new
 
       expect(described_class.conforms?(conformer)).to be(true)
@@ -35,7 +36,7 @@ RSpec.describe RSpecTracer::RemoteCache::Backend do
       partial = Class.new do
         def download(_ref); end
         def upload(_ref); end
-        # missing branch_refs, write_branch_refs, prune!
+        # missing branch_refs, write_branch_refs, prune!, prune_all!
       end.new
 
       expect(described_class.conforms?(partial)).to be(false)

--- a/spec/remote_cache/local_fs_backend_spec.rb
+++ b/spec/remote_cache/local_fs_backend_spec.rb
@@ -1,0 +1,463 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+require 'rspec_tracer/remote_cache/local_fs_backend'
+require 'rspec_tracer/storage/schema'
+require_relative '../contracts/remote_cache_backend'
+
+# rubocop:disable RSpec/InstanceVariable, RSpec/ExampleLength, RSpec/MultipleExpectations
+RSpec.describe RSpecTracer::RemoteCache::LocalFsBackend do
+  around do |example|
+    Dir.mktmpdir('rspec-tracer-local-cache-') do |cache|
+      Dir.mktmpdir('rspec-tracer-local-root-') do |root|
+        @cache_path = cache
+        @root = root
+        example.run
+      end
+    end
+  end
+
+  let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
+
+  def new_backend(branch: 'main', default_branch: 'main', test_suite_id: nil, root: nil)
+    described_class.new(
+      root: root || @root,
+      branch: branch,
+      default_branch: default_branch,
+      test_suite_id: test_suite_id,
+      cache_path: @cache_path
+    )
+  end
+
+  def write_local_cache(run_id: 'abc123', schema: current_schema)
+    File.write(
+      File.join(@cache_path, 'last_run.json'),
+      JSON.pretty_generate('schema_version' => schema, 'run_id' => run_id)
+    )
+    FileUtils.mkdir_p(File.join(@cache_path, run_id))
+    File.write(File.join(@cache_path, run_id, 'all_examples.json'), '{"ex1":"passed"}')
+    File.write(File.join(@cache_path, run_id, 'dependency.json'), '{"ex1":["lib/foo.rb"]}')
+  end
+
+  it_behaves_like 'a RemoteCache::Backend' do
+    let(:backend) { new_backend }
+  end
+
+  describe '#initialize' do
+    it 'raises on missing root' do
+      expect do
+        described_class.new(root: nil, branch: 'main', default_branch: 'main', cache_path: @cache_path)
+      end.to raise_error(described_class::LocalFsBackendError, /root/)
+    end
+
+    it 'raises on empty root' do
+      expect do
+        described_class.new(root: '', branch: 'main', default_branch: 'main', cache_path: @cache_path)
+      end.to raise_error(described_class::LocalFsBackendError, /root/)
+    end
+
+    it 'raises on missing branch' do
+      expect do
+        described_class.new(root: @root, branch: nil, default_branch: 'main', cache_path: @cache_path)
+      end.to raise_error(described_class::LocalFsBackendError, /branch/)
+    end
+
+    it 'raises on missing default_branch' do
+      expect do
+        described_class.new(root: @root, branch: 'main', default_branch: nil, cache_path: @cache_path)
+      end.to raise_error(described_class::LocalFsBackendError, /default_branch/)
+    end
+
+    it 'raises on missing cache_path' do
+      expect do
+        described_class.new(root: @root, branch: 'main', default_branch: 'main', cache_path: nil)
+      end.to raise_error(described_class::LocalFsBackendError, /cache_path/)
+    end
+
+    it 'expands a relative root to absolute' do
+      Dir.chdir(Dir.tmpdir) do
+        backend = described_class.new(root: '.', branch: 'main', default_branch: 'main', cache_path: @cache_path)
+        internal_root = backend.instance_variable_get(:@root)
+        expect(File.absolute_path?(internal_root)).to be(true)
+      end
+    end
+
+    it 'accepts an empty test_suite_id and normalizes to nil' do
+      backend = described_class.new(root: @root, branch: 'main', default_branch: 'main',
+                                    cache_path: @cache_path, test_suite_id: '')
+      expect(backend.instance_variable_get(:@test_suite_id)).to be_nil
+    end
+  end
+
+  describe '#download' do
+    it 'returns false for nil ref' do
+      expect(new_backend.download(nil)).to be(false)
+    end
+
+    it 'returns false for empty ref' do
+      expect(new_backend.download('')).to be(false)
+    end
+
+    it 'returns false when no archive exists at the expected path' do
+      expect(new_backend.download('missing-sha')).to be(false)
+    end
+
+    it 'round-trips a valid archive on main tier' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-main')
+      backend.upload('sha1')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+
+      expect(backend.download('sha1')).to be(true)
+      expect(File.exist?(File.join(@cache_path, 'last_run.json'))).to be(true)
+      expect(File.exist?(File.join(@cache_path, 'run-main', 'all_examples.json'))).to be(true)
+    end
+
+    it 'falls back to main tier from a pr backend when pr tier has no archive' do
+      main = new_backend(branch: 'main', default_branch: 'main')
+      write_local_cache(run_id: 'run-shared')
+      main.upload('shared-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+
+      expect(pr.download('shared-sha')).to be(true)
+    end
+
+    it 'rejects an archive with a mismatched schema_version' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-bad-schema', schema: current_schema + 99)
+      backend.upload('bad-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+
+      expect(backend.download('bad-sha')).to be(false)
+      expect(File.exist?(File.join(@cache_path, 'last_run.json'))).to be(false)
+    end
+
+    it 'rolls back on a malformed archive without leaving partial files' do
+      backend = new_backend
+      dest = File.join(@root, 'main', 'corrupt-sha', 'cache.tar.gz')
+      FileUtils.mkdir_p(File.dirname(dest))
+      File.write(dest, 'not-a-gzip')
+
+      expect(backend.download('corrupt-sha')).to be(false)
+      expect(Dir.children(@cache_path)).to be_empty
+    end
+
+    it 'scopes the archive under a test_suite_id subdirectory when set' do
+      backend = new_backend(test_suite_id: '3')
+      write_local_cache(run_id: 'run-suite-3')
+      backend.upload('sha-s')
+
+      archive = File.join(@root, 'main', 'sha-s', '3', 'cache.tar.gz')
+      expect(File.file?(archive)).to be(true)
+    end
+  end
+
+  describe '#upload' do
+    it 'raises on empty ref' do
+      expect { new_backend.upload('') }.to raise_error(described_class::LocalFsBackendError, /ref is required/)
+    end
+
+    it 'raises when no local cache to upload' do
+      expect { new_backend.upload('sha1') }.to raise_error(described_class::LocalFsBackendError, /no local cache/)
+    end
+
+    it 'raises when last_run.json is malformed JSON (treats as missing cache)' do
+      File.write(File.join(@cache_path, 'last_run.json'), '{not json')
+
+      expect { new_backend.upload('sha1') }.to raise_error(described_class::LocalFsBackendError, /no local cache/)
+    end
+
+    it 'places the archive at the expected pr-tier path' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      write_local_cache(run_id: 'run-pr')
+      backend.upload('feat-sha')
+
+      archive = File.join(@root, 'pr', 'feat', 'feat-sha', 'cache.tar.gz')
+      expect(File.file?(archive)).to be(true)
+    end
+
+    it 'cleans up the staging file if rename fails' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-failrename')
+      allow(File).to receive(:rename).and_raise(Errno::ENOSPC)
+
+      expect { backend.upload('fail-sha') }.to raise_error(Errno::ENOSPC)
+      # Staging files use .tmp.<pid>. suffix; none should remain.
+      dir = File.join(@root, 'main', 'fail-sha')
+      leftover = Dir.exist?(dir) ? Dir.children(dir).grep(/\.tmp\./) : []
+      expect(leftover).to be_empty
+    end
+  end
+
+  describe '#branch_refs' do
+    it 'returns {} for a nonexistent branch' do
+      expect(new_backend(branch: 'feat', default_branch: 'main').branch_refs('feat')).to eq({})
+    end
+
+    it 'writes and reads branch_refs atomically' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      refs = { 'sha1' => 1_700_000_000, 'sha2' => 1_700_000_100 }
+
+      backend.write_branch_refs('feat', refs)
+
+      path = File.join(@root, 'pr', 'feat', 'branch_refs.json')
+      expect(File.file?(path)).to be(true)
+      expect(backend.branch_refs('feat')).to eq(refs)
+    end
+
+    it 'returns {} when the file contains non-Hash JSON' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      path = File.join(@root, 'pr', 'feat', 'branch_refs.json')
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, '"not a hash"')
+
+      expect(backend.branch_refs('feat')).to eq({})
+    end
+
+    it 'returns {} when the file is malformed JSON' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      path = File.join(@root, 'pr', 'feat', 'branch_refs.json')
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, '{not json')
+
+      expect(backend.branch_refs('feat')).to eq({})
+    end
+  end
+
+  describe '#write_branch_refs' do
+    it 'is a no-op for main-branch writes' do
+      backend = new_backend(branch: 'main', default_branch: 'main')
+      backend.write_branch_refs('main', 'sha' => 1)
+
+      expect(File.exist?(File.join(@root, 'pr', 'main', 'branch_refs.json'))).to be(false)
+    end
+
+    it 'is a no-op on empty refs' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      backend.write_branch_refs('feat', {})
+
+      expect(File.exist?(File.join(@root, 'pr', 'feat', 'branch_refs.json'))).to be(false)
+    end
+
+    it 'cleans up staging file on rename failure' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      allow(File).to receive(:rename).and_raise(Errno::ENOSPC)
+
+      expect { backend.write_branch_refs('feat', 'sha1' => 1) }.to raise_error(Errno::ENOSPC)
+      dir = File.join(@root, 'pr', 'feat')
+      leftover = Dir.exist?(dir) ? Dir.children(dir).grep(/\.tmp\./) : []
+      expect(leftover).to be_empty
+    end
+  end
+
+  describe '#prune!' do
+    it 'no-ops when all knobs are nil or zero' do
+      expect(new_backend.prune!).to eq(0)
+    end
+
+    it 'prunes excess refs beyond count' do
+      backend = new_backend
+      5.times do |i|
+        write_local_cache(run_id: "run-#{i}")
+        backend.upload("sha-#{i}")
+        sleep 0.05
+      end
+
+      removed = backend.prune!(count: 2)
+
+      expect(removed).to eq(3)
+      remaining = Dir.children(File.join(@root, 'main'))
+      expect(remaining.size).to eq(2)
+    end
+
+    it 'prunes refs older than duration_seconds' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-old')
+      backend.upload('old-sha')
+      # Backdate the archive mtime to 30 days ago
+      old_path = File.join(@root, 'main', 'old-sha', 'cache.tar.gz')
+      old_time = Time.now - (30 * 86_400)
+      File.utime(old_time, old_time, old_path)
+
+      write_local_cache(run_id: 'run-new')
+      backend.upload('new-sha')
+
+      removed = backend.prune!(duration_seconds: 7 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(Dir.exist?(File.join(@root, 'main', 'old-sha'))).to be(false)
+      expect(Dir.exist?(File.join(@root, 'main', 'new-sha'))).to be(true)
+    end
+
+    it 'prunes dead PR branch when pr_branch_ttl exceeded' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      write_local_cache(run_id: 'run-dead')
+      pr.upload('dead-sha')
+      old_time = Time.now - (30 * 86_400)
+      File.utime(old_time, old_time, File.join(@root, 'pr', 'feat', 'dead-sha', 'cache.tar.gz'))
+
+      removed = pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(Dir.exist?(File.join(@root, 'pr', 'feat'))).to be(false)
+    end
+
+    it 'leaves live PR branch untouched when newest ref is within TTL' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      write_local_cache(run_id: 'run-live')
+      pr.upload('live-sha')
+
+      expect(pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)).to eq(0)
+      expect(Dir.exist?(File.join(@root, 'pr', 'feat'))).to be(true)
+    end
+
+    it 'returns 0 and logs when whole-branch delete fails' do
+      logger = instance_double(RSpecTracer::Logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:warn)
+      pr = described_class.new(root: @root, branch: 'feat', default_branch: 'main',
+                               cache_path: @cache_path, logger: logger)
+      write_local_cache(run_id: 'run-dead')
+      pr.upload('dead-sha')
+      old_time = Time.now - (30 * 86_400)
+      File.utime(old_time, old_time, File.join(@root, 'pr', 'feat', 'dead-sha', 'cache.tar.gz'))
+      # Stub rm_rf on the branch dir to raise.
+      allow(FileUtils).to receive(:rm_rf).and_call_original
+      allow(FileUtils).to receive(:rm_rf).with(File.join(@root, 'pr', 'feat')).and_raise(Errno::EACCES)
+
+      expect(pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)).to eq(0)
+      expect(logger).to have_received(:warn).with(/failed to prune dead PR branch/)
+    end
+
+    it 'pr_branch_ttl is a no-op on main tier' do
+      backend = new_backend(branch: 'main', default_branch: 'main')
+      write_local_cache(run_id: 'run-main')
+      backend.upload('sha1')
+
+      expect(backend.prune!(pr_branch_ttl_seconds: 1)).to eq(0)
+    end
+
+    it 'continues on per-ref delete failures and logs' do
+      logger = instance_double(RSpecTracer::Logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:warn)
+      backend = described_class.new(root: @root, branch: 'main', default_branch: 'main',
+                                    cache_path: @cache_path, logger: logger)
+      # Upload 2 refs so count: 1 triggers a prune of 1.
+      write_local_cache(run_id: 'run-x')
+      backend.upload('sha1')
+      sleep 0.05
+      write_local_cache(run_id: 'run-y')
+      backend.upload('sha2')
+      # Stub ONLY the ref-dir rm_rf path to raise; let staging cleanup rm_f pass.
+      allow(FileUtils).to receive(:rm_rf).and_raise(Errno::EACCES)
+
+      expect { backend.prune!(count: 1) }.not_to raise_error
+      expect(logger).to have_received(:warn).at_least(:once)
+    end
+  end
+
+  describe '#prune_all!' do
+    it 'returns 0 when ttl is nil' do
+      expect(new_backend.prune_all!).to eq(0)
+    end
+
+    it 'returns 0 when pr/ root does not exist' do
+      expect(new_backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'deletes dead PR branches but keeps live ones' do
+      live = new_backend(branch: 'live', default_branch: 'main')
+      write_local_cache(run_id: 'run-live')
+      live.upload('live-sha')
+
+      dead = new_backend(branch: 'dead', default_branch: 'main')
+      write_local_cache(run_id: 'run-dead')
+      dead.upload('dead-sha')
+      old_time = Time.now - (30 * 86_400)
+      File.utime(old_time, old_time, File.join(@root, 'pr', 'dead', 'dead-sha', 'cache.tar.gz'))
+
+      admin = new_backend # branch/default don't matter for prune_all
+      removed = admin.prune_all!(pr_branch_ttl_seconds: 14 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(Dir.exist?(File.join(@root, 'pr', 'live'))).to be(true)
+      expect(Dir.exist?(File.join(@root, 'pr', 'dead'))).to be(false)
+    end
+
+    it 'skips empty branch dirs (no archive files)' do
+      FileUtils.mkdir_p(File.join(@root, 'pr', 'empty'))
+      admin = new_backend
+
+      expect(admin.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+      expect(Dir.exist?(File.join(@root, 'pr', 'empty'))).to be(true)
+    end
+  end
+
+  describe '#unbounded_warning' do
+    it 'returns nil when ref count at or below threshold' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-1')
+      backend.upload('sha1')
+
+      expect(backend.unbounded_warning(warn_threshold: 10)).to be_nil
+    end
+
+    it 'returns a warning when ref count exceeds threshold' do
+      backend = new_backend
+      3.times do |i|
+        write_local_cache(run_id: "run-#{i}")
+        backend.upload("sha-#{i}")
+      end
+
+      expect(backend.unbounded_warning(warn_threshold: 2)).to match(/3 refs/)
+    end
+  end
+
+  describe 'concurrent upload (AC: no corruption)' do
+    # Two processes uploading the same ref simultaneously produce an
+    # archive that is still valid on download. Last-write-wins via
+    # atomic rename. Skipped on non-MRI interpreters where fork() is
+    # either unavailable or unreliable.
+    it 'survives two concurrent writers to the same ref' do
+      skip 'fork unavailable' unless RUBY_ENGINE == 'ruby'
+
+      write_local_cache(run_id: 'run-concurrent')
+      # Snapshot the cache path contents to a reference tmp so each
+      # forked writer has a consistent view even if another writer is
+      # mid-write. The fork semantics copy-on-write the parent's view.
+      readers = Array.new(2) do
+        fork do
+          # exit! bypasses at_exit hooks - keeps the child out of
+          # SimpleCov's per-process result writer (which would otherwise
+          # record a child-local partial coverage snapshot and stomp on
+          # the parent's full coverage after merge). Same reason the
+          # parallel_tests spec uses Process._exit in its workers.
+
+          backend = new_backend
+          backend.upload('concurrent-sha')
+        ensure
+          Process.exit!(0)
+        end
+      end
+      readers.each { |pid| Process.wait(pid) }
+
+      # Verify: archive exists, is valid, downloads cleanly.
+      archive = File.join(@root, 'main', 'concurrent-sha', 'cache.tar.gz')
+      expect(File.file?(archive)).to be(true)
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      expect(new_backend.download('concurrent-sha')).to be(true)
+      expect(File.exist?(File.join(@cache_path, 'last_run.json'))).to be(true)
+    end
+  end
+end
+# rubocop:enable RSpec/InstanceVariable, RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/remote_cache/redis_backend_spec.rb
+++ b/spec/remote_cache/redis_backend_spec.rb
@@ -1,0 +1,558 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+require 'rspec_tracer/remote_cache/redis_backend'
+require 'rspec_tracer/storage/schema'
+require_relative '../contracts/remote_cache_backend'
+
+# Minimal in-memory Redis stand-in. Supports only the commands
+# RedisBackend uses; not a general-purpose fake. Keeps specs fast and
+# free of external dependencies; the real redis-rb wire path is
+# covered by the integration spec in spec/integration/remote_cache_spec.rb
+# against a localhost Redis service.
+class FakeRedisStore
+  attr_reader :calls
+
+  def initialize
+    @strings = {}
+    @hashes = {}
+    @calls = Hash.new { |h, k| h[k] = [] }
+  end
+
+  def get(key)
+    @calls[:get] << key
+    @strings[key]
+  end
+
+  def set(key, value)
+    @calls[:set] << [key, value]
+    @strings[key] = value
+    'OK'
+  end
+
+  def del(*keys)
+    @calls[:del] << keys
+    keys.flatten.sum do |k|
+      removed = 0
+      removed += 1 if @strings.delete(k)
+      removed += 1 if @hashes.delete(k)
+      removed
+    end
+  end
+
+  def hgetall(key)
+    @calls[:hgetall] << key
+    (@hashes[key] || {}).dup
+  end
+
+  def hset(key, *args)
+    @calls[:hset] << [key, args]
+    fields = args.first.is_a?(Hash) ? args.first : Hash[*args]
+    @hashes[key] ||= {}
+    @hashes[key].merge!(fields.transform_values(&:to_s))
+    fields.size
+  end
+
+  def hget(key, field)
+    @calls[:hget] << [key, field]
+    (@hashes[key] || {})[field]
+  end
+
+  # rubocop:disable Naming/PredicateMethod
+  def expire(key, seconds)
+    @calls[:expire] << [key, seconds]
+    true
+  end
+  # rubocop:enable Naming/PredicateMethod
+
+  def multi
+    @calls[:multi] << :enter
+    yield self
+    @calls[:multi] << :exit
+    []
+  end
+
+  def scan_each(match:, count: nil, &block)
+    @calls[:scan_each] << { match: match, count: count }
+    pattern = Regexp.new("\\A#{Regexp.escape(match).gsub('\\*', '.*')}\\z")
+    keys = (@strings.keys + @hashes.keys).uniq.grep(pattern)
+    return enum_for(:scan_each, match: match, count: count) unless block_given?
+
+    keys.each(&block)
+  end
+
+  def stored_hash(key)
+    @hashes[key]
+  end
+
+  def stored_string(key)
+    @strings[key]
+  end
+
+  def all_keys
+    (@strings.keys + @hashes.keys).uniq
+  end
+end
+
+# rubocop:disable RSpec/InstanceVariable, RSpec/ExampleLength, RSpec/MultipleExpectations
+RSpec.describe RSpecTracer::RemoteCache::RedisBackend do
+  around do |example|
+    Dir.mktmpdir('rspec-tracer-redis-cache-') do |cache|
+      @cache_path = cache
+      @fake = FakeRedisStore.new
+      example.run
+    end
+  end
+
+  let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
+
+  def new_backend(branch: 'main', default_branch: 'main', test_suite_id: nil, prefix: 'rspec-tracer')
+    described_class.new(
+      prefix: prefix,
+      branch: branch,
+      default_branch: default_branch,
+      test_suite_id: test_suite_id,
+      cache_path: @cache_path,
+      redis_client: @fake
+    )
+  end
+
+  def write_local_cache(run_id: 'abc123', schema: current_schema)
+    File.write(
+      File.join(@cache_path, 'last_run.json'),
+      JSON.pretty_generate('schema_version' => schema, 'run_id' => run_id)
+    )
+    FileUtils.mkdir_p(File.join(@cache_path, run_id))
+    File.write(File.join(@cache_path, run_id, 'all_examples.json'), '{"ex1":"passed"}')
+    File.write(File.join(@cache_path, run_id, 'dependency.json'), '{"ex1":["lib/foo.rb"]}')
+  end
+
+  it_behaves_like 'a RemoteCache::Backend' do
+    let(:backend) { new_backend }
+  end
+
+  describe '#initialize' do
+    it 'raises on missing prefix' do
+      expect do
+        described_class.new(prefix: nil, branch: 'main', default_branch: 'main',
+                            cache_path: @cache_path, redis_client: @fake)
+      end.to raise_error(described_class::RedisBackendError, /prefix/)
+    end
+
+    it 'raises on missing branch' do
+      expect do
+        described_class.new(prefix: 'p', branch: nil, default_branch: 'main',
+                            cache_path: @cache_path, redis_client: @fake)
+      end.to raise_error(described_class::RedisBackendError, /branch/)
+    end
+
+    it 'raises on missing default_branch' do
+      expect do
+        described_class.new(prefix: 'p', branch: 'main', default_branch: nil,
+                            cache_path: @cache_path, redis_client: @fake)
+      end.to raise_error(described_class::RedisBackendError, /default_branch/)
+    end
+
+    it 'raises when neither url nor redis_client is provided' do
+      expect do
+        described_class.new(prefix: 'p', branch: 'main', default_branch: 'main',
+                            cache_path: @cache_path)
+      end.to raise_error(described_class::RedisBackendError, /url or redis_client/)
+    end
+
+    it 'trims trailing colons from the prefix' do
+      backend = new_backend(prefix: 'rspec-tracer::')
+      expect(backend.instance_variable_get(:@prefix)).to eq('rspec-tracer')
+    end
+
+    it 'accepts a class-level redis_client kwarg without requiring url' do
+      expect { new_backend }.not_to raise_error
+    end
+
+    it 'calls ::Redis.new with the supplied url when no client is injected' do
+      # Warm up Redis constant so the stub has a target (the backend
+      # requires 'redis' lazily; without a prior require, ::Redis is
+      # not yet defined here).
+      require 'redis'
+      fake_client = FakeRedisStore.new
+      allow(Redis).to receive(:new).with(url: 'redis://localhost:6379/0').and_return(fake_client)
+
+      backend = described_class.new(
+        prefix: 'rspec-tracer', branch: 'main', default_branch: 'main',
+        cache_path: @cache_path, url: 'redis://localhost:6379/0'
+      )
+
+      expect(Redis).to have_received(:new).with(url: 'redis://localhost:6379/0')
+      expect(backend.instance_variable_get(:@redis)).to be(fake_client)
+    end
+
+    context 'when the redis gem is not available' do
+      # rubocop:disable RSpec/AnyInstance
+      it 'raises a clear error pointing at the Gemfile' do
+        # Stub Kernel#require to raise LoadError only for 'redis'.
+        # Other requires (JSON, fileutils, etc.) still succeed.
+        allow_any_instance_of(described_class).to receive(:require).and_call_original
+        allow_any_instance_of(described_class).to receive(:require)
+          .with('redis').and_raise(LoadError, 'cannot load redis')
+
+        expect do
+          described_class.new(prefix: 'p', branch: 'main', default_branch: 'main',
+                              cache_path: @cache_path, url: 'redis://localhost:6379/0')
+        end.to raise_error(described_class::RedisBackendError, /redis gem is not installed/)
+      end
+      # rubocop:enable RSpec/AnyInstance
+
+      it 'does not attempt to require redis when a client is DI-injected' do
+        allow_any_instance_of(described_class).to receive(:require).with('redis').and_raise(LoadError) # rubocop:disable RSpec/AnyInstance
+
+        # DI path skips build_client entirely - so the LoadError never fires.
+        expect { new_backend }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#download' do
+    it 'returns false for nil ref' do
+      expect(new_backend.download(nil)).to be(false)
+    end
+
+    it 'returns false when hash does not exist' do
+      expect(new_backend.download('missing')).to be(false)
+    end
+
+    it 'round-trips a valid upload on main tier' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-main')
+      backend.upload('sha1')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+
+      expect(backend.download('sha1')).to be(true)
+      expect(File.exist?(File.join(@cache_path, 'last_run.json'))).to be(true)
+      expect(File.exist?(File.join(@cache_path, 'run-main', 'all_examples.json'))).to be(true)
+    end
+
+    it 'falls back from pr tier to main tier on miss' do
+      main = new_backend(branch: 'main', default_branch: 'main')
+      write_local_cache(run_id: 'run-shared')
+      main.upload('shared-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+
+      expect(pr.download('shared-sha')).to be(true)
+    end
+
+    it 'rejects a mismatched schema_version and rolls back' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-bad', schema: current_schema + 99)
+      backend.upload('bad-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+
+      expect(backend.download('bad-sha')).to be(false)
+      expect(File.exist?(File.join(@cache_path, 'last_run.json'))).to be(false)
+      expect(Dir.exist?(File.join(@cache_path, 'run-bad'))).to be(false)
+    end
+
+    it 'rescues StandardError from the redis client and returns false' do
+      backend = new_backend
+      allow(@fake).to receive(:hgetall).and_raise(RuntimeError, 'connection refused')
+
+      expect(backend.download('any-sha')).to be(false)
+    end
+
+    it 'ignores unsafe hash field names (absolute paths and ..)' do
+      backend = new_backend
+      @fake.hset('rspec-tracer:main:safe-check', {
+                   '_timestamp' => '1',
+                   'last_run.json' => JSON.generate('schema_version' => current_schema, 'run_id' => 'r'),
+                   'r/ok.json' => '{}',
+                   '/etc/passwd' => 'evil',
+                   '../escape.json' => 'bad'
+                 })
+
+      backend.download('safe-check')
+
+      expect(File.exist?('/etc/passwd')).to be(true) # was never at risk, but confirms we didn't touch it
+      expect(Dir.children(@cache_path)).to match_array(%w[last_run.json r])
+    end
+
+    it 'does not write _timestamp as a file' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-ts')
+      backend.upload('ts-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      backend.download('ts-sha')
+
+      expect(File.exist?(File.join(@cache_path, '_timestamp'))).to be(false)
+    end
+  end
+
+  describe '#upload' do
+    it 'raises on empty ref' do
+      expect { new_backend.upload('') }.to raise_error(described_class::RedisBackendError, /ref is required/)
+    end
+
+    it 'raises when no local cache to upload' do
+      expect { new_backend.upload('sha1') }.to raise_error(described_class::RedisBackendError, /no local cache/)
+    end
+
+    it 'raises when last_run.json is malformed JSON (treats as missing cache)' do
+      File.write(File.join(@cache_path, 'last_run.json'), '{not json')
+
+      expect { new_backend.upload('sha1') }.to raise_error(described_class::RedisBackendError, /no local cache/)
+    end
+
+    it 'HSETs the expected fields for a 15-file cache' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-fields')
+      backend.upload('fields-sha')
+
+      stored = @fake.stored_hash('rspec-tracer:main:fields-sha')
+      expect(stored.keys).to include('_timestamp', 'last_run.json',
+                                     'run-fields/all_examples.json', 'run-fields/dependency.json')
+      expect(stored['_timestamp'].to_i).to be > 0
+    end
+
+    it 'scopes by test_suite_id when set' do
+      backend = new_backend(test_suite_id: '3')
+      write_local_cache(run_id: 'run-s')
+      backend.upload('suite-sha')
+
+      expect(@fake.stored_hash('rspec-tracer:main:suite-sha:3')).not_to be_nil
+    end
+
+    it 'writes under pr:<branch>:<sha> for a PR tier backend' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      write_local_cache(run_id: 'run-pr')
+      pr.upload('pr-sha')
+
+      expect(@fake.stored_hash('rspec-tracer:pr:feat:pr-sha')).not_to be_nil
+    end
+
+    it 'wraps the write in MULTI and DELs before HSET to flush stale fields' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-multi')
+      backend.upload('multi-sha')
+
+      expect(@fake.calls[:multi]).to eq(%i[enter exit])
+      expect(@fake.calls[:del].flatten).to include('rspec-tracer:main:multi-sha')
+    end
+  end
+
+  describe '#branch_refs' do
+    it 'returns {} for a missing key' do
+      expect(new_backend(branch: 'feat', default_branch: 'main').branch_refs('feat')).to eq({})
+    end
+
+    it 'round-trips a hash via the string key' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      refs = { 'sha1' => 1, 'sha2' => 2 }
+
+      backend.write_branch_refs('feat', refs)
+
+      expect(backend.branch_refs('feat')).to eq(refs)
+    end
+
+    it 'returns {} on non-hash JSON' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      @fake.set('rspec-tracer:pr:feat:branch_refs', '"just a string"')
+
+      expect(backend.branch_refs('feat')).to eq({})
+    end
+
+    it 'returns {} on malformed JSON' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      @fake.set('rspec-tracer:pr:feat:branch_refs', '{not json')
+
+      expect(backend.branch_refs('feat')).to eq({})
+    end
+
+    it 'rescues StandardError from the redis client and returns {}' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      allow(@fake).to receive(:get).and_raise(RuntimeError, 'refused')
+
+      expect(backend.branch_refs('feat')).to eq({})
+    end
+  end
+
+  describe '#write_branch_refs' do
+    it 'is a no-op for main branch' do
+      backend = new_backend(branch: 'main', default_branch: 'main')
+      backend.write_branch_refs('main', 'sha' => 1)
+
+      expect(@fake.stored_string('rspec-tracer:pr:main:branch_refs')).to be_nil
+    end
+
+    it 'is a no-op for empty refs' do
+      backend = new_backend(branch: 'feat', default_branch: 'main')
+      backend.write_branch_refs('feat', {})
+
+      expect(@fake.stored_string('rspec-tracer:pr:feat:branch_refs')).to be_nil
+    end
+  end
+
+  describe '#prune!' do
+    it 'no-ops when all knobs are nil or zero' do
+      expect(new_backend.prune!).to eq(0)
+    end
+
+    it 'prunes excess refs beyond count by _timestamp ordering' do
+      backend = new_backend
+      5.times do |i|
+        @fake.hset("rspec-tracer:main:sha-#{i}", {
+                     '_timestamp' => (Time.now.to_i - ((5 - i) * 3600)).to_s,
+                     'last_run.json' => '{}'
+                   })
+      end
+
+      removed = backend.prune!(count: 2)
+
+      expect(removed).to eq(3)
+      # Newest two (sha-3, sha-4) should survive
+      expect(@fake.all_keys).to include('rspec-tracer:main:sha-3', 'rspec-tracer:main:sha-4')
+    end
+
+    it 'prunes refs older than duration_seconds by _timestamp' do
+      backend = new_backend
+      now = Time.now.to_i
+      @fake.hset('rspec-tracer:main:recent', { '_timestamp' => (now - 60).to_s })
+      @fake.hset('rspec-tracer:main:old', { '_timestamp' => (now - (30 * 86_400)).to_s })
+
+      removed = backend.prune!(duration_seconds: 7 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(@fake.all_keys).not_to include('rspec-tracer:main:old')
+      expect(@fake.all_keys).to include('rspec-tracer:main:recent')
+    end
+
+    it 'prunes dead PR branch when pr_branch_ttl exceeded' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      now = Time.now.to_i
+      @fake.hset('rspec-tracer:pr:feat:old-sha', { '_timestamp' => (now - (30 * 86_400)).to_s })
+      @fake.set('rspec-tracer:pr:feat:branch_refs', '{}')
+
+      removed = pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(@fake.all_keys.grep(/rspec-tracer:pr:feat:/)).to be_empty
+    end
+
+    it 'leaves alive PR branch untouched when newest ref is within TTL' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      now = Time.now.to_i
+      @fake.hset('rspec-tracer:pr:feat:live-sha', { '_timestamp' => (now - 60).to_s })
+
+      expect(pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)).to eq(0)
+    end
+
+    it 'filters out branch_refs keys when enumerating refs' do
+      backend = new_backend
+      @fake.set('rspec-tracer:main:branch_refs', '{}') # shouldn't happen at main tier but guard exists
+
+      expect(backend.prune!(count: 10)).to eq(0)
+    end
+
+    it 'skips keys missing a _timestamp field' do
+      backend = new_backend
+      @fake.hset('rspec-tracer:main:no-ts', { 'last_run.json' => '{}' })
+
+      expect(backend.prune!(count: 0)).to eq(0) # no refs with timestamp to enumerate
+    end
+
+    it 'returns the partial count on a StandardError mid-prune' do
+      new_backend
+      logger = instance_double(RSpecTracer::Logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:warn)
+      backend_with_logger = described_class.new(
+        prefix: 'rspec-tracer', branch: 'main', default_branch: 'main',
+        cache_path: @cache_path, redis_client: @fake, logger: logger
+      )
+      allow(@fake).to receive(:scan_each).and_raise(RuntimeError, 'network')
+
+      expect(backend_with_logger.prune!(count: 5)).to eq(0)
+      expect(logger).to have_received(:warn).with(/prune! failed/)
+    end
+  end
+
+  describe '#prune_all!' do
+    it 'returns 0 when ttl is nil' do
+      expect(new_backend.prune_all!).to eq(0)
+    end
+
+    it 'discovers PR branches via branch_refs keys and prunes dead ones' do
+      admin = new_backend
+      now = Time.now.to_i
+      # live branch
+      @fake.hset('rspec-tracer:pr:live:sha1', { '_timestamp' => (now - 60).to_s })
+      @fake.set('rspec-tracer:pr:live:branch_refs', '{}')
+      # dead branch
+      @fake.hset('rspec-tracer:pr:dead:sha2', { '_timestamp' => (now - (30 * 86_400)).to_s })
+      @fake.set('rspec-tracer:pr:dead:branch_refs', '{}')
+
+      removed = admin.prune_all!(pr_branch_ttl_seconds: 14 * 86_400)
+
+      expect(removed).to eq(1)
+      expect(@fake.all_keys).to include('rspec-tracer:pr:live:sha1')
+      expect(@fake.all_keys.grep(/rspec-tracer:pr:dead:/)).to be_empty
+    end
+
+    it 'returns 0 when no PR branches exist' do
+      expect(new_backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'rescues StandardError and returns 0' do
+      backend = new_backend
+      allow(@fake).to receive(:scan_each).and_raise(RuntimeError, 'fire')
+
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'returns 0 and logs when DEL raises on a dead-branch prune' do
+      logger = instance_double(RSpecTracer::Logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:warn)
+      admin = described_class.new(prefix: 'rspec-tracer', branch: 'main', default_branch: 'main',
+                                  cache_path: @cache_path, redis_client: @fake, logger: logger)
+      now = Time.now.to_i
+      @fake.hset('rspec-tracer:pr:dead:sha1', { '_timestamp' => (now - (30 * 86_400)).to_s })
+      @fake.set('rspec-tracer:pr:dead:branch_refs', '{}')
+      # Let scan_each succeed; raise on the bulk DEL.
+      allow(@fake).to receive(:del).and_raise(RuntimeError, 'connection lost')
+
+      expect(admin.prune_all!(pr_branch_ttl_seconds: 14 * 86_400)).to eq(0)
+      expect(logger).to have_received(:warn).with(/failed to prune dead PR branch/)
+    end
+  end
+
+  describe '#unbounded_warning' do
+    it 'returns nil when ref count is at or below threshold' do
+      backend = new_backend
+      @fake.hset('rspec-tracer:main:sha1', { '_timestamp' => '1' })
+
+      expect(backend.unbounded_warning(warn_threshold: 10)).to be_nil
+    end
+
+    it 'returns a warning when main tier ref count exceeds threshold' do
+      backend = new_backend
+      5.times { |i| @fake.hset("rspec-tracer:main:sha-#{i}", { '_timestamp' => '1' }) }
+
+      expect(backend.unbounded_warning(warn_threshold: 3)).to match(/5 refs/)
+    end
+
+    it 'excludes branch_refs keys from the count' do
+      backend = new_backend
+      @fake.set('rspec-tracer:main:branch_refs', '{}') # not a real cache key
+
+      expect(backend.unbounded_warning(warn_threshold: 0)).to be_nil
+    end
+  end
+end
+# rubocop:enable RSpec/InstanceVariable, RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/remote_cache/s3_backend_spec.rb
+++ b/spec/remote_cache/s3_backend_spec.rb
@@ -509,6 +509,112 @@ RSpec.describe RSpecTracer::RemoteCache::S3Backend do
     end
   end
 
+  describe '#prune_all!' do
+    let(:backend) { new_backend(branch: 'main', default_branch: 'main') }
+
+    def common_prefixes_json(branches)
+      contents = branches.map { |b| { 'Prefix' => "rspec-tracer/pr/#{b}/" } }
+      JSON.generate('CommonPrefixes' => contents)
+    end
+
+    def list_json(keys_with_ts)
+      contents = keys_with_ts.map { |key, ts| { 'Key' => key, 'LastModified' => Time.at(ts).utc.iso8601 } }
+      JSON.generate('Contents' => contents)
+    end
+
+    it 'returns 0 when pr_branch_ttl_seconds is nil' do
+      expect(backend.prune_all!).to eq(0)
+    end
+
+    it 'returns 0 when pr_branch_ttl_seconds is zero or negative' do
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 0)).to eq(0)
+      expect(backend.prune_all!(pr_branch_ttl_seconds: -1)).to eq(0)
+    end
+
+    it 'discovers every PR branch via list-objects delimiter and prunes dead ones' do
+      now = Time.now.to_i
+      # Two branches: live (recent) and dead (ancient)
+      call_args = []
+      allow(Open3).to receive(:capture3) do |_cli, *args|
+        call_args << args
+        if args.include?('--delimiter')
+          [common_prefixes_json(%w[live dead]), '', status_ok]
+        elsif args.include?('list-objects-v2') && args.any? { |a| a.to_s.include?('pr/live') }
+          [list_json([['rspec-tracer/pr/live/sha1/cache.tar.gz', now - 60]]), '', status_ok]
+        elsif args.include?('list-objects-v2') && args.any? { |a| a.to_s.include?('pr/dead') }
+          [list_json([['rspec-tracer/pr/dead/sha2/cache.tar.gz', now - (30 * 86_400)]]), '', status_ok]
+        else
+          ['', '', status_ok]
+        end
+      end
+
+      removed = backend.prune_all!(pr_branch_ttl_seconds: 14 * 86_400)
+
+      expect(removed).to eq(1)
+      rm_calls = call_args.select { |a| a.first == 's3' && a[1] == 'rm' }
+      expect(rm_calls.any? { |a| a[2].include?('/pr/dead/') }).to be(true)
+      expect(rm_calls.none? { |a| a[2].include?('/pr/live/') }).to be(true)
+    end
+
+    it 'returns 0 when no PR branches exist' do
+      allow(Open3).to receive(:capture3) do |_cli, *args|
+        if args.include?('--delimiter')
+          [JSON.generate('CommonPrefixes' => []), '', status_ok]
+        else
+          ['', '', status_ok]
+        end
+      end
+
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'rescues StandardError from the outer prune_all walk and returns 0' do
+      # Inner Open3 calls have their own rescues; to hit prune_all!'s
+      # top-level rescue, force maybe_prune_branch itself to raise after
+      # discover_pr_branches returned a branch.
+      allow(backend).to receive(:discover_pr_branches).and_return(['feat'])
+      allow(backend).to receive(:maybe_prune_branch).and_raise(RuntimeError, 'network fire')
+
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'skips malformed CommonPrefixes entries' do
+      allow(Open3).to receive(:capture3) do |_cli, *args|
+        if args.include?('--delimiter')
+          [JSON.generate('CommonPrefixes' => [{ 'Prefix' => nil }, { 'Prefix' => 'outside/' }]), '', status_ok]
+        else
+          ['', '', status_ok]
+        end
+      end
+
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'returns 0 when list-common-prefixes stdout fails to parse' do
+      allow(Open3).to receive(:capture3) do |_cli, *args|
+        if args.include?('--delimiter')
+          ['{not json', '', status_ok]
+        else
+          ['', '', status_ok]
+        end
+      end
+
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+
+    it 'returns 0 when list-common-prefixes stderr signals failure' do
+      allow(Open3).to receive(:capture3) do |_cli, *args|
+        if args.include?('--delimiter')
+          ['', 'access denied', status_fail]
+        else
+          ['', '', status_ok]
+        end
+      end
+
+      expect(backend.prune_all!(pr_branch_ttl_seconds: 3600)).to eq(0)
+    end
+  end
+
   describe '#unbounded_warning' do
     it 'returns nil when ref count is at or below the threshold' do
       backend = new_backend

--- a/spec/remote_cache/user_tasks_spec.rb
+++ b/spec/remote_cache/user_tasks_spec.rb
@@ -75,6 +75,11 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
                              pr_branch_ttl_seconds: pr_branch_ttl_seconds }
         @prune_return
       end
+
+      def prune_all!(pr_branch_ttl_seconds: nil)
+        @calls[:prune_all!] << { pr_branch_ttl_seconds: pr_branch_ttl_seconds }
+        @prune_return
+      end
     end
   end
 
@@ -395,6 +400,86 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
 
       expect(result).to be(false)
       expect(captured_logs.any? { |_l, m| m.include?('invalid remote_cache_backend') }).to be(true)
+    end
+
+    it 'resolves :local_fs to LocalFsBackend' do
+      expect(described_class::BUILT_IN_BACKENDS[:local_fs]).to eq(RSpecTracer::RemoteCache::LocalFsBackend)
+    end
+
+    it 'resolves :redis to RedisBackend' do
+      expect(described_class::BUILT_IN_BACKENDS[:redis]).to eq(RSpecTracer::RemoteCache::RedisBackend)
+    end
+  end
+
+  describe '#prune_all!' do
+    let(:backend_entry) { [fake_backend_class, {}] }
+
+    it 'returns 0 when cache_retention_pr_branch_ttl_seconds is unset' do
+      config = build_config(remote_cache_backend_entry: backend_entry,
+                            cache_retention_pr_branch_ttl_seconds: nil)
+      stub_ancestry
+
+      result = described_class.new(configuration: config, env: build_env).prune_all!
+
+      expect(result).to eq(0)
+      expect(captured_logs.any? { |_l, m| m.include?('prune_all requires cache_retention_pr_branch_ttl') }).to be(true)
+    end
+
+    it 'dispatches to backend.prune_all! with the configured ttl when set' do
+      config = build_config(remote_cache_backend_entry: backend_entry,
+                            cache_retention_pr_branch_ttl_seconds: 7200)
+      stub_ancestry
+
+      tasks = described_class.new(configuration: config, env: build_env)
+      allow_any_instance_of(fake_backend_class).to receive(:prune_all!).and_return(5) # rubocop:disable RSpec/AnyInstance
+
+      expect(tasks.prune_all!).to eq(5)
+    end
+
+    it 'returns 0 and logs on StandardError from the backend' do
+      config = build_config(remote_cache_backend_entry: backend_entry,
+                            cache_retention_pr_branch_ttl_seconds: 3600)
+      stub_ancestry
+      allow_any_instance_of(fake_backend_class).to receive(:prune_all!).and_raise(RuntimeError, 'boom') # rubocop:disable RSpec/AnyInstance
+
+      result = described_class.new(configuration: config, env: build_env).prune_all!
+
+      expect(result).to eq(0)
+      expect(captured_logs.any? { |_l, m| m.include?('prune_all failed') }).to be(true)
+    end
+
+    it 'allows GIT_BRANCH to be unset and defaults it to GIT_DEFAULT_BRANCH' do
+      config = build_config(remote_cache_backend_entry: backend_entry,
+                            cache_retention_pr_branch_ttl_seconds: 3600)
+      stub_ancestry
+
+      env = { 'GIT_DEFAULT_BRANCH' => 'main' } # GIT_BRANCH intentionally omitted
+
+      expect { described_class.new(configuration: config, env: env).prune_all! }.not_to raise_error
+    end
+
+    it 'requires GIT_DEFAULT_BRANCH to be set (graceful failure logs)' do
+      config = build_config(remote_cache_backend_entry: backend_entry,
+                            cache_retention_pr_branch_ttl_seconds: 3600)
+
+      env = {} # both GIT_BRANCH and GIT_DEFAULT_BRANCH omitted
+
+      result = described_class.new(configuration: config, env: env).prune_all!
+
+      expect(result).to eq(0)
+      expect(captured_logs.any? do |_l, m|
+        m.include?('prune_all failed') && m.include?('GIT_DEFAULT_BRANCH')
+      end).to be(true)
+    end
+  end
+
+  describe '.prune_all!' do
+    it 'is a class-level convenience that dispatches to an instance' do
+      config = build_config(remote_cache_backend_entry: [fake_backend_class, {}],
+                            cache_retention_pr_branch_ttl_seconds: nil)
+      stub_ancestry
+
+      expect(described_class.prune_all!(configuration: config, env: build_env)).to eq(0)
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `LocalFsBackend` + `RedisBackend` alongside M7.1's `S3Backend`, completing Phase 7. All three implement the same `RemoteCache::Backend` protocol with the same two-tier layout, schema_version validator, and retention knobs. The shared-examples contract in `spec/contracts/remote_cache_backend.rb` gates every backend.
- Closes the M7.1 cross-tier prune deferral: new required `prune_all!` protocol method + `rake rspec_tracer:remote_cache:prune_all` maintenance task that walks every PR branch and drops those idle longer than `cache_retention_pr_branch_ttl`.
- `remote_cache_uri` learns `file://`, `redis://`, and `rediss://` schemes. `UserTasks::BUILT_IN_BACKENDS` gains `:local_fs` and `:redis`.

## Backend design

- **LocalFsBackend**: shared directory (NFS / dev cache / CI workspace). Reuses `Archive.pack`/`Archive.extract` so a LocalFs root rsyncs to/from S3 with no transform. Atomic uploads via `File.rename` on a same-filesystem staging path; no `flock` (unreliable over NFS; last-write-wins on same SHA is correct because archive bytes are deterministic).
- **RedisBackend**: each ref stored as a Redis HASH with `_timestamp` + `last_run.json` + one field per file in the 15-file layout. Native Redis inspection via `HGETALL` / `HKEYS` stays usable. The `redis` gem is an **optional** runtime dependency — users add `gem 'redis'` to their own Gemfile; a missing gem surfaces as a one-line warning and a cold run, never a crash. `_timestamp` uses `Time.now.to_f` (microsecond resolution) so multiple uploads within the same clock second have stable ordering for count-based prune.

## CI

- `lint-and-specs.yml` gains a `redis:7.4-alpine` services block alongside the M7.1 LocalStack container.
- `task ci:redis:ready` mirrors `ci:localstack:ready` with a health poll + operation smoke probe.
- `task test:integration:remote-cache:redis` runs the real-wire round-trip; the spec skips gracefully when Redis is unreachable so local dev without Redis still passes.

## Coverage + mutation

All new lib files land at 100% line + branch under the existing `remote_cache/` gate. Mutation smoke for `remote_cache/*` stays deferred to M8.3 per the M7.1 handoff.

## Test plan

- [x] `task lint:ruby` (152 files, 0 offenses — final pre-push re-run)
- [x] `task lint:actions` / `lint:yaml` / `lint:node`
- [x] `task check:bundle` / `reporters:html:check`
- [x] `task security:bundle-audit` / `security:trivy` / `npm audit` (all clean)
- [x] `task test:unit` (1354 examples, 0 failures)
- [x] `task test:property` (25 / 0)
- [x] `task test:mutation:smoke` (13 subjects, all >= 90%)
- [x] `task test:dogfood` (1 / 0)
- [x] `task test:integration` (19 / 0)
- [x] `task test:integration:parallel` (6 / 0 — M5.1 regression)
- [x] `task test:integration:per-example-dsl` (5 / 0 — M5.2 regression)
- [x] `task test:integration:remote-cache` (9 / 0 — M7.1 S3 regression)
- [x] `task test:integration:remote-cache:redis` (9 / 0 — new)
- [x] `task test:features:rails` (12 / 0 — M4.3 regression)
- [x] `task benchmark:smoke` (cold_ruby 1.08x / warm_noop 1.12x — no-enforce per M2.4)
- [ ] CI: full `lint-and-specs.yml` with Redis service container green