### PR TITLE
fix(source_file): handle absolute paths for shared examples from vendored gems

### DIFF
--- a/lib/rspec_tracer/source_file.rb
+++ b/lib/rspec_tracer/source_file.rb
@@ -25,7 +25,15 @@ module RSpecTracer
     end
 
     def file_path(file_name)
+      return file_name if absolute_external_file?(file_name)
+
       File.expand_path(file_name.sub(%r{^/}, ''), RSpecTracer.root)
+    end
+
+    def absolute_external_file?(file_name)
+      file_name.start_with?('/') &&
+        !file_name.start_with?(RSpecTracer.root) &&
+        File.file?(file_name)
     end
   end
 end

--- a/spec/lib/rspec_tracer/source_file_spec.rb
+++ b/spec/lib/rspec_tracer/source_file_spec.rb
@@ -4,6 +4,39 @@ require 'spec_helper'
 require 'tmpdir'
 
 RSpec.describe RSpecTracer::SourceFile do
+  describe '.file_path' do
+    # When a spec's metadata[:file_path] resolves to an absolute path
+    # outside RSpecTracer.root — common for shared examples from
+    # vendored gems (/opt/bundle/gems/rspec-rails-X/lib/shared_examples/...)
+    # or monorepo spec files adjacent to the project — the pre-fix
+    # method stripped the leading "/" and expanded against
+    # RSpecTracer.root, producing a non-existent <root>/opt/bundle/...
+    # path. File.file? returned false, from_path returned nil, and the
+    # tracer silently skipped dependency registration — a silent-
+    # correctness bug leaving stale caches whenever the external file
+    # changed. Closes the issue behind upstream PRs #37 and #67.
+    context 'when given an absolute path outside RSpecTracer.root' do
+      let(:tmp) { Dir.mktmpdir }
+
+      after { FileUtils.remove_entry(tmp) if File.directory?(tmp) }
+
+      it 'returns the absolute path unchanged when the file exists on disk' do
+        external = File.join(tmp, 'vendored_shared_example.rb')
+        File.write(external, "# shared example\n")
+
+        expect(described_class.file_path(external)).to eq(external)
+      end
+    end
+
+    context 'when given a project-relative path (leading / prefix stripped by file_name)' do
+      it 'expands the path against RSpecTracer.root' do
+        expanded = described_class.file_path('/spec/spec_helper.rb')
+
+        expect(expanded).to eq(File.expand_path('spec/spec_helper.rb', RSpecTracer.root))
+      end
+    end
+  end
+
   describe '.from_path' do
     let(:tmp) { Dir.mktmpdir }
 


### PR DESCRIPTION
## Summary
`SourceFile#file_path` previously mangled absolute input paths that weren't under `RSpecTracer.root` — stripping the leading `/` and expanding against the project root, producing non-existent paths like `<root>/opt/bundle/gems/...`. `File.file?` returned false downstream, `from_path` returned nil, and the tracer **silently skipped dependency registration** for those files. Cache-staleness silent-correctness bug: shared examples from vendored gems (typical `/opt/bundle/gems/rspec-rails-X/lib/shared_examples/...` paths) never appeared in the dependency graph, so a user upgrading `rspec-rails` mid-session wouldn't see the affected tests re-run on the next build.

The fix returns the input unchanged when three conjunctive conditions hold: starts with `/`, not under `RSpecTracer.root`, and references an existing file. Every other input form (relative paths, stripped-root forms, in-root absolute paths) continues through the existing expansion — `file_name` cache keys stay byte-identical to pre-fix. Zero cache invalidation.

Covers the issue behind upstream PRs [#37](https://github.com/avmnu-sng/rspec-tracer/pull/37) (2021-10-03, Alexey2257) and [#67](https://github.com/avmnu-sng/rspec-tracer/pull/67) (2024-08-15, tphoney — dependabot-core was the reporter). Both closed without merging because the design was contested (heuristic vs `File.file?` I/O). This PR ships the I/O variant with regression tests.

## Test plan
- [x] Regression spec at `spec/lib/rspec_tracer/source_file_spec.rb` verified to fail on pre-fix code (expected `/var/folders/.../vendored_shared_example.rb`, got mangled `<root>/var/folders/.../vendored_shared_example.rb`) and pass after.
- [x] `task lint:ruby` — 152 files, 0 offenses.
- [x] `task test:unit` — 1356 examples, 0 failures.
- [ ] Full CI matrix.

## Non-goals
- Not touching validator/aws — 1.x-only remote-cache work lives on the companion [1-x-stable PR #108](https://github.com/avmnu-sng/rspec-tracer/pull/108).
- Not bumping version or CHANGELOG — main has its own release cadence; C1 folds into the next major release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)