### PR TITLE
test(rspec): variance fixture + narrow-AR-schema spec + flake gate

### DIFF
--- a/.github/workflows/flake-gate.yml
+++ b/.github/workflows/flake-gate.yml
@@ -1,0 +1,109 @@
+---
+name: flake-gate
+
+# Post-fix gate workflow shipped with M8.2-B's Example.from /
+# parallel_tests determinism work. Drives `task test:integration:parallel`
+# 100 consecutive times on the historical-flake cell (ruby 3.1 +
+# RSPEC_VERSION='~> 3.12.0') and reports the first-fail log if any
+# iteration is red.
+#
+# Triggers:
+#   - workflow_dispatch (manual; configurable cell + iter count)
+#   - push to `m8.2-b/**` branches (auto during the M8.2-B dev window;
+#     once the branch lands, this auto-trigger can stay or be removed
+#     depending on whether the branch family is reused)
+#
+# This is a POST-FIX gate, not the primary investigation tool. Per
+# memory feedback_no_hit_and_trial_ci, reproduce + investigate + fix +
+# verify locally first; this workflow is for ongoing safety-net
+# verification on the full GHA shared-runner environment, which has
+# different scheduling characteristics than a local M-series Mac.
+
+on:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Consecutive runs to gate (default 100)"
+        required: false
+        default: "100"
+      ruby:
+        description: "Ruby version (setup-ruby resolution; default 3.1)"
+        required: false
+        default: "3.1"
+      rspec:
+        description: "Rspec gem pin via RSPEC_VERSION env (default '~> 3.12.0')"
+        required: false
+        default: "~> 3.12.0"
+  push:
+    branches:
+      - 'm8.2-b/**'
+
+permissions:
+  contents: read
+
+jobs:
+  flake-gate:
+    name: flake-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      RSPEC_VERSION: ${{ inputs.rspec || '~> 3.12.0' }}
+      ITERATIONS: ${{ inputs.iterations || '100' }}
+      TARGET_RUBY: ${{ inputs.ruby || '3.1' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ inputs.ruby || '3.1' }}
+          # Bundler 2.6.9 is the last 2.x line that supports Ruby 3.1;
+          # 3.2+ takes 4.0.10 (matches the rest of the matrix).
+          bundler: ${{ (inputs.ruby || '3.1') == '3.1' && '2.6.9' || '4.0.10' }}
+          bundler-cache: true
+
+      - name: Setup Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.45.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bundle — list resolved versions
+        run: bundle list
+
+      - name: Run flake gate
+        run: |
+          iters="${ITERATIONS:-100}"
+          pass=0
+          fail=0
+          first_fail_log=""
+
+          mkdir -p /tmp/flake-gate-runs
+
+          for i in $(seq 1 "$iters"); do
+            log="/tmp/flake-gate-runs/iter-$i.log"
+            if task test:integration:parallel >"$log" 2>&1; then
+              pass=$((pass + 1))
+              rm -f "$log"
+            else
+              fail=$((fail + 1))
+              echo "::warning::iter $i FAILED (target ruby=${TARGET_RUBY}, rspec=${RSPEC_VERSION})"
+              if [ -z "$first_fail_log" ]; then
+                first_fail_log="$log"
+              fi
+            fi
+          done
+
+          echo
+          echo "===== flake-gate summary ====="
+          echo "target: ruby=${TARGET_RUBY}, rspec=${RSPEC_VERSION}, iters=${iters}"
+          echo "pass:   $pass / $iters"
+          echo "fail:   $fail / $iters"
+
+          if [ "$fail" -gt 0 ]; then
+            echo
+            echo "===== first-fail log (${first_fail_log}) ====="
+            cat "$first_fail_log"
+            exit 1
+          fi

--- a/.github/workflows/full-matrix.yml
+++ b/.github/workflows/full-matrix.yml
@@ -268,6 +268,13 @@ jobs:
           SQLITE3_VERSION: "~> ${{ matrix.sqlite3 }}"
         run: task test:features:rails
 
+      - name: Test — Features (Rails, narrow AR schema)
+        env:
+          RAILS_VERSION: "~> ${{ matrix.rails }}.0"
+          RSPEC_RAILS_VERSION: "~> ${{ matrix.rspec_rails }}.0"
+          SQLITE3_VERSION: "~> ${{ matrix.sqlite3 }}"
+        run: task test:features:rails:narrow-schema
+
   jruby:
     name: jruby
     needs: matrix-config

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -391,6 +391,21 @@ tasks:
     cmds:
       - bundle exec rspec --no-color spec/integration/rails_app_spec.rb
 
+  test:features:rails:narrow-schema:
+    desc: >-
+      M8.2-B narrow-AR-schema integration test. Drives the rails fixture
+      with use_transactional_fixtures = false
+      (RSPEC_TRACER_RAILS_TRANSACTIONAL=false) and asserts the per-example
+      schema-subscriber attribution path
+      (lib/rspec_tracer/rails/notifications.rb #record_ar_schema) only
+      attributes db/schema.rb to the AR-touching example - so a schema
+      mutation re-runs only that example, not the entire suite.
+      DatabaseCleaner :truncation in the fixture rails_helper handles the
+      per-example commit cleanup automatically when the env toggle is on.
+      Excluded from the default rspec sweep (subprocess + Rails fixture).
+    cmds:
+      - bundle exec rspec --no-color spec/integration/narrow_ar_schema_spec.rb
+
   test:integration:per-example-dsl:
     desc: >-
       M5.2 per-example tracks DSL integration test. Drives the Rails fixture

--- a/benchmark/fixtures/ruby_app/Gemfile
+++ b/benchmark/fixtures/ruby_app/Gemfile
@@ -3,7 +3,8 @@
 source 'https://rubygems.org'
 
 parallel_tests_version = ENV.fetch('PARALLEL_TESTS_VERSION', '~> 4.7')
+rspec_version = ENV.fetch('RSPEC_VERSION', '~> 3.13')
 
 gem 'parallel_tests', parallel_tests_version
-gem 'rspec', '~> 3.13'
+gem 'rspec', rspec_version
 gem 'rspec-tracer', path: '../../..', require: false

--- a/benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb
+++ b/benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+# M8.2-B variance fixture. The original 3 spec files (calculator,
+# discount, inventory) only exercise top-level `it { }` patterns under
+# a single describe. Real users hit the same Example.from identity-hash
+# surface via shared examples (re-included from multiple hosts), shared
+# contexts, custom matchers, deeply nested describes, redefined-subject
+# contexts, and one-liner `is_expected` chains. This file broadens the
+# variance surface so the parallel_tests integration spec
+# (spec/integration/parallel_tests_spec.rb) gates cold/warm parity on
+# every shape that actually fires in the wild — not just top-level
+# anonymous it.
+#
+# Six patterns covered + one unicode-description regression case
+# (per M8.2-B kickoff decision (g-yes); construct unicode at runtime
+# so the source stays ASCII-only per feedback_mutant_non_ascii_source
+# discipline, even though spec files aren't in mutant's parser scope).
+
+RSpec::Matchers.define :be_a_finite_numeric do
+  match { |actual| actual.is_a?(Numeric) && actual.finite? }
+end
+
+RSpec.shared_examples 'a numeric op result' do
+  it { is_expected.to be_a_finite_numeric }
+  it { is_expected.to be >= 0 }
+end
+
+RSpec.shared_context 'with prepared inventory' do
+  let(:inv) do
+    Inventory.new.tap do |i|
+      i.add(:apple, 5)
+      i.add(:banana, 3)
+    end
+  end
+
+  it { expect(inv.count(:apple)).to eq(5) }
+  it { expect(inv.count(:banana)).to eq(3) }
+  it { expect(inv).not_to be_empty }
+end
+
+RSpec.describe 'M8.2-B anonymous-block variance fixture' do
+  # Pattern 1 — shared examples re-included from host A.
+  describe Calculator do
+    describe '.add (sum of positive ints)' do
+      subject { described_class.new.add(2, 3) }
+
+      it_behaves_like 'a numeric op result'
+    end
+  end
+
+  # Pattern 1 (cont.) — same shared block, different host. The Example.from
+  # identity hash must distinguish (host, included_block, position) cleanly
+  # across cold + warm so warm_skipped == cold_examples holds.
+  describe Discount do
+    describe '#apply (positive price)' do
+      subject { described_class.new(20).apply(100) }
+
+      it_behaves_like 'a numeric op result'
+    end
+  end
+
+  # Pattern 2 — shared context with let + anonymous it.
+  describe Inventory do
+    include_context 'with prepared inventory'
+  end
+
+  # Pattern 3 — custom matcher + anonymous one-liner is_expected.
+  describe 'custom matcher coverage' do
+    subject { Calculator.new.divide(10, 4) }
+
+    it { is_expected.to be_a_finite_numeric }
+  end
+
+  # Pattern 4 — deeply nested describes with anonymous it.
+  describe Calculator do
+    describe '.subtract' do
+      describe 'with same operands' do
+        it { expect(described_class.new.subtract(7, 7)).to eq(0) }
+      end
+
+      describe 'with positive then negative operand' do
+        it { expect(described_class.new.subtract(5, -3)).to eq(8) }
+      end
+    end
+  end
+
+  # Pattern 5 — redefined subject inside a nested context.
+  describe Discount do
+    subject(:discount) { described_class.new(50) }
+
+    it { expect(discount.apply(100)).to eq(50) }
+
+    context 'when reset to zero' do
+      subject(:discount) { described_class.new(0) }
+
+      it { expect(discount.apply(100)).to eq(100) }
+    end
+  end
+
+  # Pattern 6 — one-liner is_expected chain (multiple).
+  describe Calculator do
+    subject(:multiply_result) { described_class.new.multiply(4, 5) }
+
+    it { is_expected.to eq(20) }
+    it { is_expected.to be_a_finite_numeric }
+  end
+
+  # Decision (g-yes): unicode in description. Construct "café" at
+  # runtime via pack('U*') from integer codepoints so the source file
+  # stays ASCII-only. Example.from feeds the description through
+  # data.to_json -> Digest::MD5.hexdigest; cold + warm must encode the
+  # same bytes for the example_id to round-trip. If the identity hash
+  # holds for unicode descriptions this is a useful regression gate;
+  # if it breaks, that surfaces another flake source to fix in-session.
+  describe 'unicode description regression' do
+    description = "computes #{[0x63, 0x61, 0x66, 0xE9].pack('U*')} discount"
+    it description do
+      expect(Discount.new(25).apply(100)).to eq(75)
+    end
+  end
+end

--- a/benchmark/ratchet.json
+++ b/benchmark/ratchet.json
@@ -5,62 +5,62 @@
     "os": "darwin24",
     "cpu": "Apple M2 Max",
     "cores": 12,
-    "recorded_at": "2026-04-24T20:11:23Z"
+    "recorded_at": "2026-04-26T13:37:06Z"
   },
   "scenarios": {
     "cold_ruby": {
-      "p50": 0.2723,
-      "p95": 0.3426,
+      "p50": 0.2886,
+      "p95": 0.3225,
       "iterations": 10
     },
     "warm_noop": {
-      "p50": 0.2586,
-      "p95": 0.2784,
+      "p50": 0.2662,
+      "p95": 0.3089,
       "iterations": 10
     },
     "warm_env_mismatch": {
-      "p50": 0.2595,
-      "p95": 0.2983,
+      "p50": 0.2648,
+      "p95": 0.2795,
       "iterations": 10
     },
     "parallel_tests_2_workers": {
-      "p50": 0.9724,
-      "p95": 1.4901,
+      "p50": 1.5403,
+      "p95": 1.5628,
       "iterations": 10
     },
     "cold_rails": {
-      "p50": 3.0341,
-      "p95": 3.5797,
+      "p50": 2.9666,
+      "p95": 3.7172,
       "iterations": 10
     },
     "coverage_adapter": {
-      "p50": 2.5418,
-      "p95": 3.034,
+      "p50": 2.5007,
+      "p95": 2.5182,
       "iterations": 10
     },
     "cache_load": {
-      "p50": 0.4764,
-      "p95": 0.4826,
+      "p50": 0.4801,
+      "p95": 0.4865,
       "iterations": 10
     },
     "cache_load_msgpack": {
-      "p50": 0.4949,
-      "p95": 0.5027,
+      "p50": 0.5054,
+      "p95": 0.5215,
       "iterations": 10
     },
     "cache_load_sqlite": {
-      "p50": 0.6214,
-      "p95": 0.6578,
+      "p50": 0.6404,
+      "p95": 0.6487,
       "iterations": 10
     },
     "file_read_hook": {
-      "p50": 7.918,
-      "p95": 8.0877,
+      "p50": 7.2234,
+      "p95": 7.4909,
       "iterations": 10
     },
     "loaded_files_tracker": {
-      "p50": 1.8849,
-      "p95": 1.9877,
+      "p50": 1.8322,
+      "p95": 1.8834,
       "iterations": 10
     }
   }

--- a/spec/fixtures/rails_app/spec/narrow_schema_spec.rb
+++ b/spec/fixtures/rails_app/spec/narrow_schema_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# M8.2-B narrow-AR-schema fixture spec. Two examples:
+#   - one issues an AR query (User.create!) so the sql.active_record
+#     subscriber fires and rspec-tracer's record_ar_schema attributes
+#     `db/schema.rb` to this example_id;
+#   - one performs only a pure-Ruby computation, so the subscriber
+#     never fires and `db/schema.rb` is NOT in this example_id's
+#     dependency set.
+#
+# The OUTER `spec/integration/narrow_ar_schema_spec.rb` drives this
+# fixture with `RSPEC_TRACER_RAILS_TRANSACTIONAL=false`, asserts the
+# per-example attribution above, mutates `db/schema.rb`, and verifies
+# the warm filter re-runs only the AR-touching example.
+RSpec.describe "narrow AR schema attribution" do
+  it "creates a user (touches AR)" do
+    # Time-suffixed email so re-runs under non-transactional fixtures
+    # don't collide on the email uniqueness index even without
+    # DatabaseCleaner. (DatabaseCleaner was tried in M8.2-B and rejected:
+    # its TRUNCATE / DELETE queries fire inside the per-example bucket,
+    # which then attributes db/schema.rb to *every* example via the
+    # sql.active_record subscriber - completely defeating the test of
+    # narrow AR-schema attribution. Sequence-based uniqueness is the
+    # only setup that lets us assert the pure example genuinely does
+    # not depend on the schema.)
+    user = User.create!(
+      name: "Narrow AR test",
+      email: "narrow-#{Time.now.to_f}-#{Process.pid}@example.com"
+    )
+    expect(user).to be_persisted
+  end
+
+  it "computes a pure value (does not touch AR)" do
+    expect(2 + 2).to eq(4)
+  end
+end

--- a/spec/fixtures/rails_app/spec/rails_helper.rb
+++ b/spec/fixtures/rails_app/spec/rails_helper.rb
@@ -55,7 +55,7 @@ RSpec.configure do |config|
   end
 
   # Default: transactional fixtures on (matches Rails idiomatic test
-  # setup; covered by `task test:features:rails`). When the M8.2-absorbed
+  # setup; covered by `task test:features:rails`). When the M8.2-B
   # narrow-AR-schema scenario flips RSPEC_TRACER_RAILS_TRANSACTIONAL=false,
   # each example commits its writes to the test DB and the per-example
   # schema-subscriber attribution path (Tracker::Notifications) becomes

--- a/spec/integration/narrow_ar_schema_spec.rb
+++ b/spec/integration/narrow_ar_schema_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+# M8.2-B narrow-AR-schema integration spec. Drives the rails fixture
+# (spec/fixtures/rails_app/spec/narrow_schema_spec.rb) under
+# RSPEC_TRACER_RAILS_TRANSACTIONAL=false (M8.2-shipped env toggle in
+# the fixture rails_helper.rb). With transactional fixtures off,
+# rspec-tracer's per-example schema-subscriber attribution path
+# (lib/rspec_tracer/rails/notifications.rb #record_ar_schema) becomes
+# the only mechanism observing AR schema changes - the canonical use
+# case for users who run integration tests with each example
+# committing to the test DB.
+#
+# Two assertions:
+#
+#   1. (cold) Only the AR-touching example has db/schema.rb in its
+#      dependency set. The pure-compute example does NOT - the
+#      sql.active_record subscriber never fired for it.
+#
+#   2. (warm) After mutating db/schema.rb, the warm filter re-runs
+#      only the AR-touching example. The pure-compute example stays
+#      skipped, proving narrow attribution is load-bearing for the
+#      filter decision (and not just a cosmetic field on the cache).
+#
+# Per-example commit cleanup: sequence-based unique factories
+# (Time.now.to_f + pid suffix on User.email). DatabaseCleaner was
+# rejected in M8.2-B because its TRUNCATE / DELETE queries fire
+# sql.active_record events INSIDE the per-example bucket, which
+# would attribute db/schema.rb to every example via the subscriber -
+# defeating the very narrow-attribution behavior under test. Decision
+# revised from kickoff (d-i DatabaseCleaner) to (d-ii sequence
+# factories) once empirical evidence showed (d-i) was incompatible.
+
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'set'
+
+# Module-scoped constants + helpers (mirrors RailsAppSpecHelpers from
+# M4.3). Keeps `let` out of before(:all) where RSpec disallows
+# memoized accessors.
+module NarrowArSchemaSpecHelpers
+  FIXTURE_ROOT = File.expand_path('../fixtures/rails_app', __dir__)
+  CACHE_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_cache')
+  COVERAGE_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_coverage')
+  REPORT_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_report')
+  LOCAL_COVERAGE = File.join(FIXTURE_ROOT, 'coverage')
+  TRACER_ENV = {
+    'RSPEC_TRACER' => '1',
+    'RSPEC_TRACER_RAILS_TRANSACTIONAL' => 'false'
+  }.freeze
+  SCRUB_DIRS = [CACHE_DIR, COVERAGE_DIR, REPORT_DIR, LOCAL_COVERAGE].freeze
+  NARROW_SPEC = 'spec/narrow_schema_spec.rb'
+  SCHEMA_FILE_NAME = '/db/schema.rb'
+
+  MUTATION_MARKER = "\n# rspec-tracer M8.2-B narrow-schema mutation marker\n"
+
+  module_function
+
+  def run_rspec_in_fixture
+    Bundler.with_unbundled_env do
+      Open3.capture2e(TRACER_ENV, 'bundle', 'exec', 'rspec', '--no-color', NARROW_SPEC,
+                      chdir: FIXTURE_ROOT)
+    end
+  end
+
+  def ensure_bundle_and_db
+    Bundler.with_unbundled_env do
+      Dir.chdir(FIXTURE_ROOT) do
+        gemfile_env = { 'BUNDLE_GEMFILE' => File.join(FIXTURE_ROOT, 'Gemfile') }
+        unless system(gemfile_env, 'bundle', 'check', out: File::NULL, err: File::NULL)
+          system(gemfile_env, 'bundle', 'install', '--quiet') || raise('bundle install failed')
+        end
+
+        system('bundle', 'exec', 'rails', 'db:test:prepare',
+               out: File::NULL, err: File::NULL) || raise('db:test:prepare failed')
+      end
+    end
+  end
+
+  def clear_tracer_state
+    FileUtils.rm_rf(SCRUB_DIRS)
+  end
+
+  def load_cache_file(name)
+    manifest = JSON.parse(File.read(File.join(CACHE_DIR, 'last_run.json'), encoding: 'UTF-8'))
+    JSON.parse(File.read(File.join(CACHE_DIR, manifest.fetch('run_id'), name), encoding: 'UTF-8'))
+  end
+end
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/BeforeAfterAll, RSpec/InstanceVariable, RSpec/ExampleLength
+RSpec.describe 'narrow AR schema attribution' do
+  include NarrowArSchemaSpecHelpers
+
+  before(:all) do
+    NarrowArSchemaSpecHelpers.ensure_bundle_and_db
+  end
+
+  before do
+    NarrowArSchemaSpecHelpers.clear_tracer_state
+    out, status = NarrowArSchemaSpecHelpers.run_rspec_in_fixture
+    raise "cold rspec failed (status=#{status.exitstatus}):\n#{out}" unless status.success?
+
+    @all_examples = NarrowArSchemaSpecHelpers.load_cache_file('all_examples.json')
+    @reverse_dependency = NarrowArSchemaSpecHelpers.load_cache_file('reverse_dependency.json')
+  end
+
+  after(:all) do
+    NarrowArSchemaSpecHelpers.clear_tracer_state
+  end
+
+  def example_id_matching(description_substring)
+    pair = @all_examples.find { |_, meta| meta['description'].to_s.include?(description_substring) }
+    raise "no example matching #{description_substring.inspect} in cold cache" if pair.nil?
+
+    pair.first
+  end
+
+  describe 'cold attribution' do
+    it 'attributes db/schema.rb only to the AR-touching example' do
+      ar_id = example_id_matching('creates a user')
+      pure_id = example_id_matching('does not touch AR')
+      schema_dependents = @reverse_dependency.fetch(NarrowArSchemaSpecHelpers::SCHEMA_FILE_NAME, []).to_set
+
+      schema_file = NarrowArSchemaSpecHelpers::SCHEMA_FILE_NAME
+      expect(schema_dependents).to(include(ar_id),
+                                   "expected #{ar_id.inspect} to depend on #{schema_file}, " \
+                                   "got dependents: #{schema_dependents.to_a.inspect}")
+      expect(schema_dependents).not_to(include(pure_id),
+                                       "pure-compute example #{pure_id.inspect} should not depend on schema; " \
+                                       "got dependents: #{schema_dependents.to_a.inspect}")
+    end
+  end
+
+  describe 'warm filter after schema mutation' do
+    it 're-runs only the AR-touching example' do
+      ar_id = example_id_matching('creates a user')
+      pure_id = example_id_matching('does not touch AR')
+      schema_path = File.join(NarrowArSchemaSpecHelpers::FIXTURE_ROOT, 'db/schema.rb')
+      original = File.binread(schema_path)
+      File.open(schema_path, 'ab') { |f| f.write(NarrowArSchemaSpecHelpers::MUTATION_MARKER) }
+
+      begin
+        out, status = NarrowArSchemaSpecHelpers.run_rspec_in_fixture
+        raise "warm rspec failed (status=#{status.exitstatus}):\n#{out}" unless status.success?
+
+        skipped = NarrowArSchemaSpecHelpers.load_cache_file('skipped_examples.json').to_set
+        expect(skipped).to(include(pure_id),
+                           "pure-compute example #{pure_id.inspect} should be skipped on warm; " \
+                           "got skipped: #{skipped.to_a.inspect}")
+        expect(skipped).not_to(include(ar_id),
+                               "AR-touching example #{ar_id.inspect} should re-run on schema change; " \
+                               "got skipped: #{skipped.to_a.inspect}")
+      ensure
+        File.binwrite(schema_path, original)
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/BeforeAfterAll, RSpec/InstanceVariable, RSpec/ExampleLength

--- a/spec/integration/parallel_tests_spec.rb
+++ b/spec/integration/parallel_tests_spec.rb
@@ -57,12 +57,12 @@ module ParallelTestsSpecHelpers
   end
 
   def load_last_run
-    JSON.parse(File.read(File.join(CACHE_ROOT, 'last_run.json')))
+    JSON.parse(File.read(File.join(CACHE_ROOT, 'last_run.json'), encoding: 'UTF-8'))
   end
 
   def load_top_cache_file(name)
     run_id = load_last_run.fetch('run_id')
-    JSON.parse(File.read(File.join(CACHE_ROOT, run_id, name)))
+    JSON.parse(File.read(File.join(CACHE_ROOT, run_id, name), encoding: 'UTF-8'))
   end
 end
 

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -69,8 +69,8 @@ module RailsAppSpecHelpers
   end
 
   def load_cache_file(name)
-    manifest = JSON.parse(File.read(File.join(CACHE_DIR, 'last_run.json')))
-    JSON.parse(File.read(File.join(CACHE_DIR, manifest.fetch('run_id'), name)))
+    manifest = JSON.parse(File.read(File.join(CACHE_DIR, 'last_run.json'), encoding: 'UTF-8'))
+    JSON.parse(File.read(File.join(CACHE_DIR, manifest.fetch('run_id'), name), encoding: 'UTF-8'))
   end
 end
 

--- a/spec/integration/remote_cache_spec.rb
+++ b/spec/integration/remote_cache_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe 'RemoteCache::S3Backend against LocalStack', :integration, :local
     it 'preserves last_run.json and the run directory contents' do
       backend = build_backend(branch: 'main', default_branch: 'main')
       write_local_cache(run_id: 'run-main')
-      original_content = File.read(File.join(@cache_path, 'run-main', 'all_examples.json'))
+      original_content = File.read(File.join(@cache_path, 'run-main', 'all_examples.json'), encoding: 'UTF-8')
 
       backend.upload('main-sha-1')
 
@@ -106,7 +106,7 @@ RSpec.describe 'RemoteCache::S3Backend against LocalStack', :integration, :local
       result = backend.download('main-sha-1')
 
       expect(result).to be(true)
-      expect(File.read(File.join(@cache_path, 'run-main', 'all_examples.json'))).to eq(original_content)
+      expect(File.read(File.join(@cache_path, 'run-main', 'all_examples.json'), encoding: 'UTF-8')).to eq(original_content)
       manifest = JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))
       expect(manifest['schema_version']).to eq(current_schema)
     end

--- a/spec/integration/ruby_app_spec.rb
+++ b/spec/integration/ruby_app_spec.rb
@@ -37,12 +37,12 @@ RSpec.describe 'ruby_app v2 engine integration' do
   end
 
   def load_last_run_manifest
-    JSON.parse(File.read(File.join(cache_dir, 'last_run.json')))
+    JSON.parse(File.read(File.join(cache_dir, 'last_run.json'), encoding: 'UTF-8'))
   end
 
   def load_cache_file(name)
     run_id = load_last_run_manifest.fetch('run_id')
-    JSON.parse(File.read(File.join(cache_dir, run_id, name)))
+    JSON.parse(File.read(File.join(cache_dir, run_id, name), encoding: 'UTF-8'))
   end
 
   def ensure_bundle_installed!
@@ -106,15 +106,15 @@ RSpec.describe 'ruby_app v2 engine integration' do
 
     it 'embeds the payload run_id matching report.json' do
       run_rspec
-      report_json_run_id = JSON.parse(File.read(File.join(report_dir, 'report.json')))['run_id']
-      html = File.read(File.join(report_dir, 'index.html'))
+      report_json_run_id = JSON.parse(File.read(File.join(report_dir, 'report.json'), encoding: 'UTF-8'))['run_id']
+      html = File.read(File.join(report_dir, 'index.html'), encoding: 'UTF-8')
 
       expect(html).to include(%("run_id":"#{report_json_run_id}"))
     end
 
     it 'renders server-side fallback tables so JavaScript-disabled readers see data' do
       run_rspec
-      html = File.read(File.join(report_dir, 'index.html'))
+      html = File.read(File.join(report_dir, 'index.html'), encoding: 'UTF-8')
 
       expect(html).to include('id="fallback-all-examples"')
       expect(html).not_to include('<!-- RSPEC_TRACER_FALLBACK -->')


### PR DESCRIPTION
## Summary

- **Broader anonymous-block variance fixture** at `benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb` covering 6 patterns (shared examples re-included from two host describes, shared context with `let`, custom matcher, deeply nested describes, redefined-subject context, one-liner `is_expected`) plus a **unicode-description regression case** constructed at runtime via `pack('U*')`.
- **UTF-8 encoding fix** on 4 integration spec `File.read` calls (`parallel_tests_spec.rb`, `rails_app_spec.rb`, `ruby_app_spec.rb`, `remote_cache_spec.rb`). Latent bug surfaced by the unicode case under default-external US-ASCII locales; `lib/` was already encoding-correct (uses `encoding: 'UTF-8'` consistently), only the test helpers were unencoded.
- **Narrow-AR-schema integration spec** (`spec/integration/narrow_ar_schema_spec.rb` + fixture spec at `spec/fixtures/rails_app/spec/narrow_schema_spec.rb`) covers the per-example schema-subscriber attribution path under `RSPEC_TRACER_RAILS_TRANSACTIONAL=false`. Asserts that only AR-touching examples depend on `db/schema.rb` and that warm filter after schema mutation re-runs only those examples. Sequence-suffix unique factories; DatabaseCleaner was tried and rejected because its `TRUNCATE`/`DELETE` queries fire `sql.active_record` inside the per-example bucket and contaminate the very attribution behavior under test.
- **`task test:features:rails:narrow-schema`** wired into `full-matrix.yml`'s `rails` job alongside the existing `Test - Features (Rails)` step.
- **Fixture Gemfile `RSPEC_VERSION` hook** at `benchmark/fixtures/ruby_app/Gemfile` — was hardcoded `gem 'rspec', '~> 3.13'`, which made the `(*, rspec-3.12)` matrix-axis ineffective inside the fixture subprocess; now reads `ENV.fetch('RSPEC_VERSION', '~> 3.13')` matching the existing `PARALLEL_TESTS_VERSION` pattern.
- **`flake-gate.yml` workflow** drives `task test:integration:parallel` 100x on a configurable cell (defaults: ruby `3.1` + `RSPEC_VERSION='~> 3.12.0'`); `workflow_dispatch` + auto-fires on `m8.2-b/**` push. Reports pass/fail count and first-fail log.
- **`benchmark/ratchet.json` regenerated** after the variance fixture addition shifted example IDs (committed in-branch).

## Note on the historical `warm_skipped != cold_examples` flake

The historical intermittent flake on the `ruby-parallel (ruby-3.1, rspec-3.12)` cell **did not reproduce locally** across 125 consecutive runs on rbenv 3.1.7 + bundler 2.6.9:

- **100/100 PASS** with the new fixture-Gemfile `RSPEC_VERSION` hook (symmetric outer rspec 3.12 + fixture rspec 3.12)
- **25/25 PASS** with the original asymmetric configuration (outer rspec 3.12 + fixture rspec 3.13, by unsetting `RSPEC_VERSION` before the subprocess)

Static analysis of the three remaining run-in-CI hypotheses (parallel_rspec spec-distribution variance under runtime-weighted grouping, `NewFileDetector` declared-globs walk-order false-positive, last-worker-merge race vs `wait_for_other_processes_to_finish` in `parallel_tests` 4.10.1) yielded no clear culprit on M2 Max. Likely GHA-shared-runner-scheduling-specific (much slower CPU + different scheduler than M2 Max widens the timing race window). `flake-gate.yml` provides ongoing CI verification on real GHA runners — its first auto-fire on this branch push should give a real signal.

## Test plan

- [x] `task lint:ruby` (176 files, 0 offenses)
- [x] `task lint:yaml` / `lint:actions` / `lint:node` — clean
- [x] `task check:bundle` / `task reporters:html:check` — clean
- [x] `task security:bundle-audit` (no vulnerabilities) / `task security:trivy` (clean) / `npm audit --audit-level=high` (0 vulnerabilities)
- [x] `task test:unit` (1507 examples, 0 failures)
- [x] `task test:property` — clean
- [x] `task test:edge-cases` (103/103)
- [x] `task test:dogfood` (1/1)
- [x] `task test:integration` (19/19)
- [x] `task test:integration:parallel` (6/6 default Ruby)
- [x] `task test:integration:per-example-dsl` (5/5)
- [x] `task test:features:rails` (12/12 — encoding fix didn't regress the existing 12-scenario behavior matrix)
- [x] `task test:features:rails:narrow-schema` (2/2 NEW)
- [x] `task test:mutation:smoke` (13/13 subjects ≥ 90%)
- [x] `task test:fuzz:full` (10k iter × 3 harnesses, no crashes)
- [x] `task benchmark:smoke` (cold_ruby + warm_noop within thresholds)
- [x] `task benchmark:ratchet:update` — committed in-branch
- [x] **Local 125/125 flake repro** on rbenv 3.1.7 + bundler 2.6.9 + `RSPEC_VERSION='~> 3.12.0'` (100 with new Gemfile hook + 25 with original asymmetric config) — flake non-repro locally
- [ ] `task test:integration:remote-cache` (S3 LocalStack) — not run locally; only encoding fix touches `remote_cache_spec.rb`, mechanical change. CI will exercise.
- [ ] `task test:integration:remote-cache:redis` — not run locally for the same reason. CI will exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)