### PR TITLE
ci(workflows): bump test-mutation-top-level timeout to 30 min

### DIFF
--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -141,7 +141,18 @@ jobs:
   test-mutation-top-level:
     name: test-mutation-top-level
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Bumped 15 -> 30 after PR #122's merge-to-main run cancelled at
+    # 15:02 wall clock (PR #122 itself ran at 14:52, 8s under the cap).
+    # The mutation pass succeeds (Coverage 99.71% >= 85%) but pegs
+    # runtime at ~14:30 because most RSpecTracer.* methods are called
+    # during spec-helper setup; mutations cause the spec process to
+    # hang and get killed via mutant's per-mutation 5s timeout (674
+    # of 707 mutations land as Timeouts). Post-job cache cleanup adds
+    # the last few seconds, and any CI jitter pushes the job over the
+    # 15 min cap. 30 min matches test-mutation-tracker / -rspec and
+    # gives headroom without changing behavior - jobs end when work
+    # ends, the timeout is a hard cap.
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Bump `test-mutation-top-level` job timeout from 15 → 30 min in `.github/workflows/lint-and-specs.yml` (matches `test-mutation-tracker` / `test-mutation-rspec`).
- Fixes the merge-to-main CI run that cancelled at 15:02 wall clock when the prior job (PR #122) ran at 14:52 — same workload, ~10 s of CI jitter pushed the job over the 15-min cap.

## Context

The mutation pass itself **succeeded** on the cancelled run — `Coverage 99.71% ≥ 85%` gate, 705 of 707 mutations killed. This is not a coverage regression; it's a wall-clock-at-the-timeout-boundary issue.

Why the runtime sits so close to the cap: top-level `RSpecTracer.*` methods (`start`, `at_exit_behavior`, `run_finalize`, etc.) are called during spec-helper setup. Mutations on those bodies make the spec process hang, and mutant kills each via the per-mutation 5 s timeout — **674 of 707 mutations land as `Timeouts`** (counted as kills, since hanging tests don't pass). With 4 worker jobs, that pegs runtime at ~14:30, leaving only ~30 s of post-job cache cleanup before the 15-min cap.

Evidence:
- PR #122's last CI run on `test-mutation-top-level`: 14:52 → success (8 s under).
- Merge-to-main run on `07a5ea7`: 15:02 → cancelled. Logs show `Failed to save: Unable to reserve cache with key tools-Linux-...` during post-job cleanup — the kind of transient that takes a healthy run over the line.

The cap is a hard ceiling, not a budget — jobs still end when work ends, so this does not slow CI on the typical run. It just removes the boundary risk.

## Test plan

- [x] `task lint:actions` — clean
- [x] `task lint:yaml` — clean
- [ ] CI on this PR completes within the new 30-min cap (expected ~15 min wall)
- [ ] Post-merge: re-run / next push to main lands cleanly without re-tripping the boundary