### PR TITLE
ci: demote periphery mutation gates from per-PR to weekly

### DIFF
--- a/.github/workflows/combinations.yml
+++ b/.github/workflows/combinations.yml
@@ -1,16 +1,30 @@
 ---
 name: combinations
 
-# Exhaustive cross-product of every supported runtime-dep major-line
-# combination on every supported Ruby. Per-PR + per-main runs use
-# Option-A relaxed pins (root Gemfile uses `>= floor` for each
-# multi-line dep, so Bundler resolves latest-of-everything-installable
-# per cell - matching what an end user gets). This workflow flips that:
-# every dep is explicitly pinned per cell so the matrix actually probes
-# every (redis x conn_pool x msgpack x parallel x parallel_tests x
-# rspec x sqlite3) corner the user could land on.
+# Weekly off-PR signal split into two concerns sharing one Sun 02:00 UTC
+# cron:
 #
-# Cell count (~496):
+# (1) Exhaustive cross-product of every supported runtime-dep major-line
+#     combination on every supported Ruby (`combo-3.x` / `combo-4.0-*` /
+#     `combo-jruby` / `combo-redis-service`). Per-PR + per-main runs use
+#     Option-A relaxed pins (root Gemfile uses `>= floor` for each
+#     multi-line dep, so Bundler resolves latest-of-everything-installable
+#     per cell - matching what an end user gets). This workflow flips
+#     that: every dep is explicitly pinned per cell so the matrix actually
+#     probes every (redis x conn_pool x msgpack x parallel x
+#     parallel_tests x rspec x sqlite3) corner the user could land on.
+#
+# (2) Periphery mutation gates (`combo-mutation-rails` /
+#     `combo-mutation-reporters` / `combo-mutation-remote-cache`).
+#     Demoted from per-PR `lint-and-specs.yml` because the periphery
+#     subdirs ship with carve-out gates below 100% to accommodate
+#     structural ceilings (mutant first-token describe-label mapping;
+#     `Module#prepend` idempotency in shared-process spec suites). Below-
+#     100% gates are close to rubber-stamps; weekly cadence is sufficient
+#     signal at the periphery while per-PR mutation surface stays focused
+#     on the core engine (smoke + tracker + storage + rspec + top-level).
+#
+# Cell count for (1) (~496):
 #   - combinations-3.1:        16  (no conn_pool 3.x; no parallel 2.x; sqlite3 1.7 only)
 #   - combinations-3.2:        64  (no parallel 2.x)
 #   - combinations-3.3:       128
@@ -21,8 +35,12 @@ name: combinations
 #   - combinations-jruby:      16  (no sqlite3 specs; no conn_pool 3.x; no parallel 2.x)
 #   - combinations-redis-service: 16  (real-wire Redis 7.4 server x redis-gem 4.8/5.4)
 #
-# See docs/revamp/sessions/M3.8-part-c-runtime-dep-matrix.md (local) for
-# the full design rationale.
+# Plus 3 single-shot mutation jobs from (2) (no matrix axes; one cell
+# each on Ruby 3.3.10).
+#
+# See docs/revamp/sessions/M3.8-part-c-runtime-dep-matrix.md +
+# docs/revamp/sessions/M8.5-mutation-demote.md (local) for the full
+# design rationale.
 
 on:
   schedule:
@@ -464,3 +482,112 @@ jobs:
 
       - name: Test — Integration (remote cache + Redis)
         run: task test:integration:remote-cache:redis
+
+  # ---------------------------------------------------------------------
+  # Periphery mutation gates (demoted from per-PR `lint-and-specs.yml`).
+  # Per-subject carve-out thresholds documented inline in the matching
+  # `task test:mutation:<name>` Taskfile entry. Single-shot jobs (no
+  # matrix axes) on Ruby 3.3.10. Local Taskfile entries unchanged so
+  # developers can still run any of these on demand before opening a
+  # periphery-touching PR.
+  # ---------------------------------------------------------------------
+
+  combo_mutation_rails:
+    name: combo-mutation-rails
+    # Mutation pass on lib/rspec_tracer/rails/ (3 net-new subjects:
+    # Notifications, I18nTracking, Railtie; Preset stays in per-PR
+    # smoke). Smaller surface than remote-cache / reporters; 30 min
+    # cap matches the original lint-and-specs cell. Carve-outs sized
+    # for combined-describe + Module#prepend ceilings — see Taskfile
+    # inline rationale.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '.ruby-version'
+          bundler: '4.0.10'
+          bundler-cache: true
+
+      - name: Setup Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.45.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bundle — list resolved versions
+        run: bundle list
+
+      - name: Test — Mutation (rails)
+        run: task test:mutation:rails
+
+  combo_mutation_reporters:
+    name: combo-mutation-reporters
+    # Mutation pass on lib/rspec_tracer/reporters/ (6 subjects: Base,
+    # JsonReporter, TerminalReporter, HtmlReporter, PayloadBuilder,
+    # Registry). HtmlReporter (218 LOC) + PayloadBuilder (203 LOC) carry
+    # the bulk; 60 min cap matches the original lint-and-specs cell.
+    # Carve-outs sized for prose-form integration describe ceilings —
+    # see Taskfile inline rationale.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '.ruby-version'
+          bundler: '4.0.10'
+          bundler-cache: true
+
+      - name: Setup Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.45.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bundle — list resolved versions
+        run: bundle list
+
+      - name: Test — Mutation (reporters)
+        run: task test:mutation:reporters
+
+  combo_mutation_remote_cache:
+    name: combo-mutation-remote-cache
+    # Mutation pass on lib/rspec_tracer/remote_cache/ (8 subjects:
+    # Backend, Validator, Archive, GitAncestry, UserTasks, LocalFsBackend,
+    # RedisBackend, S3Backend). S3Backend (~567 LOC) is the bulk; sized
+    # comparable to per-PR test-mutation-storage's SqliteBackend (581
+    # LOC). 60 min cap matches the original lint-and-specs cell.
+    # Per-subject gates carve out the structural describe-label ceiling
+    # — see Taskfile inline rationale.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '.ruby-version'
+          bundler: '4.0.10'
+          bundler-cache: true
+
+      - name: Setup Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.45.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bundle — list resolved versions
+        run: bundle list
+
+      - name: Test — Mutation (remote-cache)
+        run: task test:mutation:remote-cache

--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -161,59 +161,6 @@ jobs:
       - name: Test — Mutation (top-level)
         run: task test:mutation:top-level
 
-  test-mutation-remote-cache:
-    name: test-mutation-remote-cache
-    # Mutation pass on lib/rspec_tracer/remote_cache/ (8 subjects).
-    # S3Backend at ~567 LOC + 47 mutant subjects is the bulk; sized
-    # comparable to test-mutation-storage's SqliteBackend (581 LOC).
-    # Per-subject gates carve out the structural describe-label
-    # ceiling (see Taskfile inline rationale). 60 min headroom matches
-    # storage's bottleneck.
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Test — Mutation (remote-cache)
-        run: task test:mutation:remote-cache
-
-  test-mutation-rails:
-    name: test-mutation-rails
-    # Mutation pass on lib/rspec_tracer/rails/ (3 net-new subjects:
-    # Notifications, I18nTracking, Railtie; Preset already in smoke).
-    # Smaller surface than storage / remote-cache; 30 min cap matches
-    # tracker / rspec / top-level. Carve-outs documented inline in the
-    # Taskfile gate for combined-describe + Module#prepend ceilings.
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Test — Mutation (rails)
-        run: task test:mutation:rails
-
-  test-mutation-reporters:
-    name: test-mutation-reporters
-    # Mutation pass on lib/rspec_tracer/reporters/ (6 subjects: Base,
-    # JsonReporter, TerminalReporter, HtmlReporter, PayloadBuilder,
-    # Registry). HtmlReporter at 218 LOC + PayloadBuilder at 203 LOC
-    # carry the bulk; 60 min headroom matches storage / remote-cache
-    # bottlenecks. Carve-outs sized for prose-form integration describe
-    # ceilings - see Taskfile inline rationale.
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Test — Mutation (reporters)
-        run: task test:mutation:reporters
-
   test-integration-remote:
     name: test-integration-remote
     runs-on: ubuntu-latest
@@ -294,9 +241,6 @@ jobs:
       - test-mutation-storage
       - test-mutation-rspec
       - test-mutation-top-level
-      - test-mutation-remote-cache
-      - test-mutation-rails
-      - test-mutation-reporters
       - test-integration-remote
     steps:
       - name: Consolidate


### PR DESCRIPTION
## Summary

Move `test-mutation-{rails,reporters,remote-cache}` from per-PR
[`lint-and-specs.yml`](.github/workflows/lint-and-specs.yml) to
weekly [`combinations.yml`](.github/workflows/combinations.yml).
Per-PR mutation surface narrows to the core engine
(`smoke + tracker + storage + rspec + top-level` — 5 gates instead
of 8); periphery jobs migrate to the existing Sun 02:00 UTC cron
alongside the runtime-dep matrix expansion.

Pure CI policy. No `lib/` / `spec/` / `Taskfile.yml` / fixture changes.

## Why

The periphery mutation gates (rails / reporters / remote_cache) ship
with carve-out thresholds below 100% (rails 62-90% / reporters 80-93%
/ remote-cache 65-95%) to accommodate structural ceilings in the
test suite — not weak tests:

- **Mutant first-token describe-label mapping**: mutant maps tests
  to subjects via the first space-separated token of
  `full_description`. Tests for `#initialize` / private helpers
  exercised through sibling-method describes are credited to the
  wrong subject (e.g. `Tracker::NewFileDetector#initialize` is
  exercised by every `describe '#new_files'` block but mutant
  credits the public method, not the constructor). Restructuring
  describes to satisfy mutant's mapping is the test-organization-
  for-coverage anti-pattern.
- **`Module#prepend` idempotency**: prepend-line mutations are
  structurally un-killable in shared-process spec suites. Ruby
  has no `unprepend` API — once any prior test triggers `prepend`,
  the singleton-class ancestor chain is set for the rest of the
  process. Subsequent installs (mutated or not) leave the chain
  unchanged. Applies to `Tracker::IOHooks.install`,
  `Rails::I18nTracking.install`, and `Rails::Notifications.install`.

Below-100% gates with these structural carve-outs are close to
rubber stamps at the periphery. Weekly cadence is sufficient signal
for the periphery's value-vs-cost shape; per-PR cadence stays
focused on the core engine where silent regressions in
filter / dependency_graph / change_set computation would break user
trust (running more or fewer specs than promised).

## Net effect

**Per-PR (`lint-and-specs.yml`)**:

- 14 + 1 → 11 + 1 jobs (consolidator job name `lint-and-specs`
  preserved).
- 3 fewer parallel runners per PR (~75 min reclaimed compute).
- Cleaner per-PR mutation signal focused on the core engine.
- `test-mutation-storage` remains the wall-clock bottleneck at the
  60-min cap; its wall clock is unchanged. The framing isn't "50%
  wall-clock cut" — storage doesn't shrink — but resource
  consumption per PR drops materially.

**Weekly (`combinations.yml`)**:

- 9 → 12 jobs (3 new single-shot `combo-mutation-{rails,reporters,
  remote-cache}` appended; +0 matrix-axis cells since the new jobs
  have no `strategy.matrix`).
- File header comment refreshed to document the two concerns
  (runtime-dep matrix expansion + periphery mutation cadence)
  sharing one Sun 02:00 UTC cron.
- Timeout-minutes preserved verbatim from the lint-and-specs caps:
  rails 30; reporters 60; remote-cache 60.
- Inline setup pattern (setup-ruby + setup-task + bundler-cache),
  matching combinations.yml's existing 9 jobs rather than the
  `.github/actions/setup` composite — composite carries HTML
  reporter npm install + out-of-bundle tools the mutation jobs
  don't need (verified: the demoted Taskfile entries only invoke
  `bundle exec mutant ...`).

**Local**:

- `task test:mutation:{rails,reporters,remote-cache}` Taskfile
  entries unchanged — developers still run them on demand before
  a periphery-touching PR opens. `task test:mutation:full`
  aggregator covers all 8 (including the demoted 3) for local
  manual verification.

## Branch protection note

`gh api repos/avmnu-sng/rspec-tracer/branches/main/protection`
currently returns `contexts: []`, `checks: []` — no required
status checks are configured. The consolidator job name
`lint-and-specs` is preserved defensively for any future re-add of
a required check; this PR does not change that name.

## Followup (deferred to docs rewrite)

A user-facing CHANGELOG entry capturing the mutation-policy change
("Per-PR mutation gates narrowed to core engine; rails / reporters
/ remote_cache mutation runs weekly via combinations.yml") is
deferred to the forthcoming docs rewrite — there is no
`CHANGELOG.md` yet. The intent is captured in this PR body for the
docs pass to absorb.

## Test plan

Local pre-PR parity (full lint-and-specs.yml mirror):

- [x] `task lint:ruby` — 177 files, 0 offenses.
- [x] `task lint:actions` — clean.
- [x] `task lint:yaml` — clean (strict).
- [x] `task lint:node` — ESLint + Prettier clean.
- [x] `task check:bundle` — Gemfile.lock satisfied.
- [x] `task security:bundle-audit` — 0 vulns.
- [x] `task security:trivy` — exit 0.
- [x] `task test:unit` — 1520 / 0 failures.
- [x] `task test:property` — 25 / 0.
- [x] `task test:dogfood` — 1 / 0.
- [x] `task test:edge-cases` — 103 / 0.
- [x] `task test:integration` — 19 / 0.
- [x] `task test:fuzz:full` — 30k iter × 3 harnesses, clean.
- [x] `task test:mutation:smoke` — 13 subjects, all ≥ 90%.
- [x] `task benchmark:smoke` — cold_ruby + warm_noop under threshold.
- [ ] `task test:mutation:full` — sanity check that local Taskfile
      entries for all 8 gates (including the 3 demoted) still work
      after the YAML move. Running locally as belt-and-suspenders
      since this is a YAML-only PR; CI on this branch exercises the
      kept gates against unchanged `lib/` + `spec/`.

CI structural verification:

- [ ] `lint-and-specs` workflow run on this branch shows 11 parallel
      jobs + 1 consolidator (down from 14 + 1).
- [ ] `combinations` workflow validates structurally (workflow_dispatch
      probe before merge OR first weekly run after merge).

Post-merge verification:

- [ ] First weekly `combinations` run after merge: 3 new
      `combo-mutation-*` jobs green (next Sun 02:00 UTC).
- [ ] First per-PR run on a periphery-touching change: lint-and-specs
      structural shape (11 parallel + 1 consolidator) holds; resource
      consumption drops as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)