### PR TITLE
fix(coverage): dup Coverage.peek_result frozen arrays before mutating

### DIFF
--- a/lib/rspec_tracer/reporters/coverage_json_reporter.rb
+++ b/lib/rspec_tracer/reporters/coverage_json_reporter.rb
@@ -114,10 +114,17 @@ module RSpecTracer
 
         engine.merge_skipped_coverage(skipped_ids).each do |file_path, line_map|
           existing = coverage[file_path]
+          # `Coverage.peek_result` returns frozen line-count arrays on
+          # Ruby 3.2+. Mutating those raises `FrozenError`. dup-on-write
+          # so we own a mutable copy before the merge loop, but only on
+          # the first hit per file_path (subsequent hits write into our
+          # already-mutable copy).
           if existing.nil?
-            stub = line_stub(file_path)
-            coverage[file_path] = stub
-            existing = stub
+            existing = line_stub(file_path)
+            coverage[file_path] = existing
+          elsif existing.frozen?
+            existing = existing.dup
+            coverage[file_path] = existing
           end
           line_map.each do |line_number, strength|
             idx = line_number.to_i

--- a/spec/reporters/coverage_json_reporter_spec.rb
+++ b/spec/reporters/coverage_json_reporter_spec.rb
@@ -185,6 +185,26 @@ RSpec.describe RSpecTracer::Reporters::CoverageJsonReporter do
       expect(payload['RSpecTracer']['coverage'][tracked_file]).to eq([3, 4])
     end
 
+    it 'tolerates frozen line arrays from Coverage.peek_result (Ruby 3.2+)' do
+      # `::Coverage.peek_result` returns frozen line-count arrays on
+      # Ruby 3.2+. Surfaced via Solidus warm-cache run with skipped
+      # examples, where every cumulative-coverage file in the peek
+      # output is frozen. accumulate_skipped must dup-on-write.
+      frozen_line_array = [1, nil].freeze
+      allow(adapter).to receive(:peek_unfiltered).and_return(tracked_file => frozen_line_array)
+      allow(registry).to receive(:ids_with_status).with(:skipped).and_return(['ex_skipped'])
+      allow(engine).to receive(:merge_skipped_coverage).with(['ex_skipped']).and_return(
+        tracked_file => { '0' => 2, '1' => 4 }
+      )
+
+      expect { build_reporter.generate }.not_to raise_error
+
+      payload = JSON.parse(File.read(File.join(coverage_dir, 'coverage.json'), encoding: 'UTF-8'))
+      expect(payload['RSpecTracer']['coverage'][tracked_file]).to eq([3, 4])
+      # Original frozen array must NOT be mutated (dup-on-write contract).
+      expect(frozen_line_array).to eq([1, nil])
+    end
+
     it 'creates a stub line array when a skipped-only file is missing from peek output' do
       allow(adapter).to receive(:peek_unfiltered).and_return({})
       allow(registry).to receive(:ids_with_status).with(:skipped).and_return(['ex_skipped'])


### PR DESCRIPTION
## Summary

`::Coverage.peek_result` returns frozen line-count arrays on Ruby 3.2+.
`Reporters::CoverageJsonReporter#accumulate_skipped` mutates those
arrays in place via `existing[idx] = (existing[idx] || 0) + strength`
to fold skipped-example coverage deltas into the cumulative coverage
hash. On warm runs with any skipped examples, this raises:

```
FrozenError: can't modify frozen Array: [...coverage line counts...]
```

The error is caught by `RSpecTracer.emit_coverage_json`'s outer
rescue (logged to STDERR, run continues), so it doesn't break tests
— but `coverage.json` silently fails to write, breaking SimpleCov
interop assumptions and any consumer expecting a fresh
`coverage.json` per run.

### Surfaced via realworld pre-flight

Bug found while pre-flighting [Solidus](https://github.com/solidusio/solidus)
@ HEAD against rspec-tracer for an upcoming follow-up PR that
swaps the synthetic spec-tree-clone soak fixture for real
open-source Rails projects. Solidus warm-run with 100% cached
examples (94/94 skipped) triggers the mutation path on every file
in the cumulative coverage:

```
$ RSPEC_TRACER=1 bundle exec rspec spec/models/spree/{calculator,country,zone,address,adjustment}_spec.rb
# Cold run: writes coverage.json (109 KB), 94 examples / 0 skipped — green.
$ RSPEC_TRACER=1 bundle exec rspec spec/models/spree/{calculator,country,zone,address,adjustment}_spec.rb
# Warm run: 94/94 skipped (100% cached)
# rspec-tracer: coverage.json emit failed (FrozenError: can't modify frozen Array: [...])
```

`spec/fixtures/rails_app/` and `spec/fixtures/rails_app_big/` don't
surface this because their warm-run patterns don't accumulate
skipped-coverage deltas onto un-loaded files. Real-world projects
like Solidus do — every cumulative-coverage file gets a delta merge
from the skipped pool.

### Fix

dup-on-write in `accumulate_skipped`. When `existing` is frozen
(canonical `peek_unfiltered` shape on Ruby 3.2+), dup it once before
the merge loop and stash the mutable copy back in the coverage hash.
Subsequent line-map writes go to the mutable copy. The original
frozen array is preserved (asserted by the new spec).

Pre-M8.0 (legacy `CoverageReporter`) didn't hit this because it
maintained its own merge buffer separate from `peek_result`. M8.0's
single-owner emitter routed `accumulate_skipped` to read directly
from `peek_unfiltered`'s hash, which holds frozen
`Coverage.peek_result` arrays verbatim.

## Test plan

- [x] New spec `tolerates frozen line arrays from Coverage.peek_result (Ruby 3.2+)`
      reproduces the bug pre-fix (FrozenError) and asserts post-fix:
      (a) no raise, (b) coverage.json contains the merged line array,
      (c) the original frozen input array is unmutated (dup-on-write
      contract).
- [x] `task lint:ruby` clean (186 files, 0 offenses)
- [x] `task test:unit` green (1561 examples, 0 failures, coverage gate green)
- [x] `bundle exec rspec spec/reporters/coverage_json_reporter_spec.rb`
      green (20 examples, 0 failures - existing 19 + 1 new)
- [x] Manual pre-flight against Solidus@HEAD: warm-run 94/94 skipped
      now writes coverage 3058/4522 LOC (67.62%) successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)