### PR TITLE
ci(benchmark): drop wall-clock gate on parallel_tests_2_workers (informational)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,14 @@ group :development do
   # rspec: 3.12 (LTS-ish) and 3.13 (current). Default resolves to 3.13.
   gem 'rspec', ENV.fetch('RSPEC_VERSION', '>= 3.12')
 
+  # Ruby 4.0 extracted `benchmark` from the stdlib into a bundled gem.
+  # benchmark/harness.rb uses Benchmark.realtime + spec/benchmark/
+  # harness_spec.rb requires the harness, both of which need the gem
+  # in the bundle on 4.0+. On Ruby <= 3.4 it's still in stdlib so
+  # `gem 'benchmark'` is harmless. Floor of 0.4 is the first 4.0-
+  # extracted release.
+  gem 'benchmark', ENV.fetch('RSPEC_TRACER_BENCHMARK_VERSION', '>= 0.4')
+
   # parallel + parallel_tests: 1.x / 2.x and 4.x / 5.x respectively.
   # parallel 2.x requires Ruby >= 3.3; on lower Rubies Bundler picks 1.x.
   gem 'parallel', ENV.fetch('RSPEC_TRACER_PARALLEL_VERSION', '>= 1.26')

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -50,6 +50,44 @@ ratchet's P50:
 - `≤ 1.10×` threshold — silent pass.
 - `1.10× – 1.30×` — warning (CI posts a PR comment; build passes).
 - `> 1.30×` — build fails.
+- **`INFO` (informational, not gated)** — scenarios listed in
+  `INFORMATIONAL_SCENARIOS` (currently: `parallel_tests_2_workers`)
+  print their ratio for trend-watching but never fail the build.
+  See "Informational scenarios" below for why.
+
+### Informational scenarios
+
+Some scenarios have inherent wall-clock variance that exceeds the
+gate threshold by structural property — they exercise code shapes
+where CI-environment factors dominate timing. These scenarios are
+reported (timing emitted to stderr + summary markdown) but their
+ratio never contributes to the exit code.
+
+The canonical case is `parallel_tests_2_workers`. Its baseline
+itself records `p50=0.866 / p95=1.868` — `p95/p50 = 2.16×` within
+its own 10-iter sample. Any threshold below 2.16× will fail on
+noise alone. Two structural causes compound:
+
+1. **Process contention**: `parallel_rspec` spawns driver + 2 workers
+   = 3 Ruby processes on GHA's 2-vCPU runners. Worst-case wall ≈
+   `max(worker_wall) + merge`, and per-worker wall is ~2× of dedicated
+   on contended CPU.
+2. **Worker-startup variance amplified by max-of-N**: each worker
+   independently boots Ruby + Bundler + the gem set. The driver
+   waits for the slowest. Per-worker startup variance amplifies
+   into total wall.
+
+A real regression-detection signal for these scenarios would be a
+behavior assertion (cache-merge correctness, no worker crash)
+rather than a wall-clock comparison. Wall-clock stays as
+informational summary output for trend-watching across runs.
+
+**For gem users**: if you adopt similar wall-clock gates against
+your own benchmark of rspec-tracer + parallel_tests, expect
+2-3× run-to-run variance on shared CI runners. That's not a
+regression — it's an inherent property of `N workers on M vCPUs`
+where `N > M` plus shared-runner co-tenancy. Use a wider tolerance
+(or no wall-clock gate) for parallel-worker scenarios.
 
 ### When to update the ratchet
 

--- a/benchmark/harness.rb
+++ b/benchmark/harness.rb
@@ -49,10 +49,37 @@ module BenchmarkHarness
   # scenario threshold; tracked as a 2.1 followup.
   REGRESSION_FAIL_RATIO = 1.30
 
+  # Scenarios whose wall-clock variance exceeds the gate threshold
+  # by structural property (worker-subprocess CPU contention on
+  # shared runners) get reported but NOT gated. Their ratio is
+  # printed as `INFO` and never contributes to exit-non-zero.
+  #
+  # Currently only `parallel_tests_2_workers` qualifies: the GHA-
+  # baseline regen recorded p50=0.8665 / p95=1.8682 (p95/p50 = 2.16x)
+  # within its own 10-iter sample - the baseline itself acknowledges
+  # >2x variance, so any threshold below 2.16x will fail on noise
+  # alone. Two structural causes compound:
+  #
+  #   1. Process contention: `parallel_rspec` spawns driver + 2
+  #      workers = 3 Ruby processes on GHA's 2-vCPU runners. Worst-
+  #      case wall = max(worker_wall) + merge overhead; on contended
+  #      CPU each worker can be 2x of dedicated wall.
+  #   2. Worker startup variance amplified by max-of-N: each worker
+  #      boots Ruby + Bundler + gem set independently; the driver
+  #      waits for the slowest to finish.
+  #
+  # The right regression signal for these scenarios would be a
+  # behavior assertion (cache-merge correctness, no worker crash)
+  # rather than wall-clock comparison. Wall-clock stays as
+  # informational summary output for trend-watching but doesn't
+  # gate. See benchmark/README.md "Informational scenarios" for
+  # the user-facing rationale.
+  INFORMATIONAL_SCENARIOS = %w[parallel_tests_2_workers].freeze
+
   DEFAULT_ITERATIONS_FULL = 5
   DEFAULT_ITERATIONS_SMOKE = 3
 
-  STATUS_ICONS = { ok: '✓', warn: '⚠', fail: '✗' }.freeze
+  STATUS_ICONS = { ok: '✓', warn: '⚠', fail: '✗', informational: 'ℹ' }.freeze
 
   # Per-interpreter ratchet multipliers. The committed ratchet.json is a
   # canonical MRI baseline (Apple M2 Max + Ruby 3.3.10). Non-MRI
@@ -343,7 +370,9 @@ module BenchmarkHarness
       threshold = base * multiplier
       ratio = result['p50'] / threshold
       statuses[name] =
-        if ratio > REGRESSION_FAIL_RATIO then { status: :fail, ratio: ratio, threshold: threshold }
+        if INFORMATIONAL_SCENARIOS.include?(name)
+          { status: :informational, ratio: ratio, threshold: threshold }
+        elsif ratio > REGRESSION_FAIL_RATIO then { status: :fail, ratio: ratio, threshold: threshold }
         elsif ratio > REGRESSION_WARN_RATIO then { status: :warn, ratio: ratio, threshold: threshold }
         else { status: :ok, ratio: ratio, threshold: threshold }
         end
@@ -364,9 +393,10 @@ module BenchmarkHarness
       line = format('  %<name>-14s p50=%<p50>.3fs p95=%<p95>.3fs',
                     name: name, p50: result['p50'], p95: result['p95'])
       if status.is_a?(Hash)
+        label = status[:status] == :informational ? 'INFO (not gated)' : status[:status].upcase
         line += format('  [%<ratio>.2fx threshold %<threshold>.3fs] %<status>s',
                        ratio: status[:ratio], threshold: status[:threshold],
-                       status: status[:status].upcase)
+                       status: label)
       end
       warn line
     end
@@ -427,7 +457,8 @@ module BenchmarkHarness
       '|---|---|---|---|---|',
       *rows,
       '',
-      'Thresholds: ≤ 1.10× silent pass · 1.10–1.30× warning · > 1.30× fail.'
+      'Thresholds: ≤ 1.10× silent pass · 1.10–1.30× warning · > 1.30× fail. ' \
+      "Scenarios marked INFO are reported but not gated (see #{INFORMATIONAL_SCENARIOS.join(', ')})."
     ]
     body << '' << 'No ratchet loaded — comparison skipped.' if ratchet.nil?
     FileUtils.mkdir_p(File.dirname(path))

--- a/spec/benchmark/harness_spec.rb
+++ b/spec/benchmark/harness_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Loads the benchmark harness module without auto-running
+# (`if $PROGRAM_NAME == __FILE__` guard at the bottom of harness.rb
+# keeps `BenchmarkHarness.main` from firing on require).
+require_relative '../../benchmark/harness'
+
+# Verifies that `INFORMATIONAL_SCENARIOS` correctly removes
+# wall-clock gating for variance-prone parallel-worker scenarios
+# while leaving other scenarios under the canonical
+# REGRESSION_FAIL_RATIO / REGRESSION_WARN_RATIO gates.
+#
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'BenchmarkHarness.compare_to_ratchet' do
+  let(:harness) do
+    Module.new do
+      extend BenchmarkHarness
+
+      module_function
+
+      def compare(results, ratchet)
+        compare_to_ratchet(results, ratchet)
+      end
+    end
+  end
+
+  let(:ratchet) do
+    {
+      'scenarios' => {
+        'cold_ruby' => { 'p50' => 0.40 },
+        'parallel_tests_2_workers' => { 'p50' => 0.866 }
+      }
+    }
+  end
+
+  context 'when scenario is in INFORMATIONAL_SCENARIOS' do
+    it 'returns :informational status regardless of ratio magnitude' do
+      results = [
+        { 'scenario' => 'parallel_tests_2_workers', 'p50' => 1.976 } # 2.28x baseline
+      ]
+      statuses = harness.compare(results, ratchet)
+
+      expect(statuses['parallel_tests_2_workers'][:status]).to eq(:informational)
+      expect(statuses['parallel_tests_2_workers'][:ratio]).to be_within(0.01).of(2.28)
+    end
+
+    it 'returns :informational even when ratio is well below WARN threshold' do
+      results = [
+        { 'scenario' => 'parallel_tests_2_workers', 'p50' => 0.50 } # 0.58x baseline (would be OK normally)
+      ]
+      statuses = harness.compare(results, ratchet)
+
+      expect(statuses['parallel_tests_2_workers'][:status]).to eq(:informational)
+    end
+  end
+
+  context 'when scenario is not informational' do
+    it 'returns :fail when ratio exceeds REGRESSION_FAIL_RATIO' do
+      results = [{ 'scenario' => 'cold_ruby', 'p50' => 0.55 }] # 1.375x of 0.40 baseline > 1.30
+      statuses = harness.compare(results, ratchet)
+
+      expect(statuses['cold_ruby'][:status]).to eq(:fail)
+    end
+
+    it 'returns :warn when ratio is between WARN and FAIL' do
+      results = [{ 'scenario' => 'cold_ruby', 'p50' => 0.48 }] # 1.20x of 0.40 baseline
+      statuses = harness.compare(results, ratchet)
+
+      expect(statuses['cold_ruby'][:status]).to eq(:warn)
+    end
+
+    it 'returns :ok when ratio is below WARN threshold' do
+      results = [{ 'scenario' => 'cold_ruby', 'p50' => 0.42 }] # 1.05x of 0.40 baseline
+      statuses = harness.compare(results, ratchet)
+
+      expect(statuses['cold_ruby'][:status]).to eq(:ok)
+    end
+  end
+
+  it 'INFORMATIONAL_SCENARIOS contains parallel_tests_2_workers' do
+    expect(BenchmarkHarness::INFORMATIONAL_SCENARIOS).to include('parallel_tests_2_workers')
+  end
+
+  describe 'gate enforcement (any_fail filter)' do
+    it 'an :informational status with high ratio does NOT trigger any_fail' do
+      results = [
+        { 'scenario' => 'cold_ruby', 'p50' => 0.41 }, # OK
+        { 'scenario' => 'parallel_tests_2_workers', 'p50' => 5.0 } # 5.77x INFO
+      ]
+      statuses = harness.compare(results, ratchet)
+      any_fail = statuses.values.any? { |s| s.is_a?(Hash) && s[:status] == :fail }
+
+      expect(any_fail).to be(false)
+    end
+
+    it 'a :fail status on a gated scenario DOES trigger any_fail' do
+      results = [{ 'scenario' => 'cold_ruby', 'p50' => 0.55 }] # 1.375x FAIL
+      statuses = harness.compare(results, ratchet)
+      any_fail = statuses.values.any? { |s| s.is_a?(Hash) && s[:status] == :fail }
+
+      expect(any_fail).to be(true)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength


### PR DESCRIPTION
## Summary

`parallel_tests_2_workers`'s wall-clock variance structurally
exceeds the gate threshold (1.30×). The GHA-baseline regen itself
recorded `p50=0.8665, p95=1.8682` — `p95/p50 = 2.16×` within its
own 10-iter sample. Any threshold below 2.16× will fail on noise
alone.

Empirical evidence — same code (`a0ce9e2`), two consecutive runs:

```
PR #134 run        : p50=0.986  p95=2.083  [1.14x WARN]
main post-merge    : p50=1.976  p95=2.004  [2.28x FAIL]
```

Same SHA, same workflow, different runner-load lottery. The variance
is a structural property of `parallel_rspec` (driver + 2 workers
= 3 Ruby processes on GHA's 2-vCPU runners) plus shared-runner
co-tenancy. Real users running parallel_tests with rspec-tracer
in shared CI will see this same variance — it's not an rspec-tracer
regression.

## Why not bump fail-ratio?

Calibrating a fail-ratio against observed CI noise is hit-and-trial
calibration. The honest fix: acknowledge that wall-clock gating
doesn't work for variance-prone scenarios and remove them from
the gate.

A real regression-detection signal for these scenarios would be
a behavior assertion (cache-merge correctness, no worker crash)
rather than wall-clock comparison. That's a separate follow-up.
For now, wall-clock stays as informational output for trend-watching.

## Implementation

- `INFORMATIONAL_SCENARIOS = %w[parallel_tests_2_workers].freeze`
  in `benchmark/harness.rb`.
- `compare_to_ratchet` returns `:informational` status for matching
  scenarios; ratio is computed and reported but the threshold
  comparison is skipped.
- Summary output labels these as `INFO (not gated)` instead of
  `OK`/`WARN`/`FAIL`.
- `any_fail` filter ignores `:informational` — exit code unaffected.
- If more parallel-worker scenarios get added later, they
  automatically fall into the same bucket via the constant.

## User-facing

`benchmark/README.md` gains an "Informational scenarios" section
explaining the rationale + warning gem users to expect 2-3×
wall-clock variance on parallel-worker scenarios in shared CI.
Recommends wider tolerance (or no gate) for similar scenarios in
their own benchmark suites.

## Test plan

- [x] `spec/benchmark/harness_spec.rb` — 8 examples, 0 failures:
  - `:informational` status returned regardless of ratio magnitude
  - non-informational scenarios still gate OK / WARN / FAIL correctly
  - `:informational` + extreme ratio does NOT trigger `any_fail`
  - `:fail` on a gated scenario DOES trigger `any_fail`
  - `INFORMATIONAL_SCENARIOS` constant contains
    `parallel_tests_2_workers`
- [x] `task lint:ruby` clean (187 files, 0 offenses)
- [x] `task benchmark:smoke` runs clean on M2 Max (sub-1.0× ratios
  on cold_ruby + warm_noop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)