### PR TITLE
fix(ci): keep merge-fire runs on the cache demo from being cancelled by later dispatches

### DIFF
--- a/.github/workflows/example-tracer-cache.yml
+++ b/.github/workflows/example-tracer-cache.yml
@@ -38,8 +38,16 @@ permissions:
   contents: read
 
 concurrency:
+  # Group runs together for visibility in the GHA UI but never cancel
+  # an in-flight run. The merge-to-main push fire is the cold-cycle
+  # cache-populating run; if a manual workflow_dispatch comes in
+  # while it's still going, cancelling the merge run would lose its
+  # post-step cache save (per feedback_actions_cache_post_hook_timeout)
+  # and trap the next dispatch in cold-run hell. Mirrors ci.yml's
+  # rule: main / merge runs must run to completion, never cancelled
+  # because a later trigger arrived.
   group: example-tracer-cache
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   demo:


### PR DESCRIPTION
## Summary

Switches the `example-tracer-cache.yml` workflow's concurrency policy from `cancel-in-progress: true` → `cancel-in-progress: false`, with a comment explaining the rule.

## Why

The cache demo's merge-to-main push fire is the cold-cycle cache-populating run. With the previous setting, a manual `workflow_dispatch` shortly after the merge cancelled the merge-push run. That lost its post-step cache save (per the `feedback_actions_cache_post_hook_timeout` trap shape — same outcome, different cause) and trapped the dispatch in another cold run.

Caught immediately after PR #138 merged: the merge-fire run was cancelled with `Canceling since a higher priority waiting request for example-tracer-cache exists` when I dispatched the warm-cycle validation. Both runs ended up cold; cache never persisted.

## What changed

```yaml
concurrency:
  group: example-tracer-cache
  cancel-in-progress: false  # was: true
```

Plus a comment explaining the rule, mirroring [ci.yml's](.github/workflows/ci.yml) precedent: runs on main never get cancelled because a later trigger arrived. The group label is kept so runs cluster together in the GHA UI; only the cancel behavior changed.

## Test plan

- [ ] CI lint clean (yamllint, actionlint).
- [ ] After merge, fire the workflow twice (push or `gh workflow run --ref main`); confirm the second fire queues behind the first instead of cancelling it. Cache should populate on the first run; second run reads it (`% cached` non-zero).

🤖 Generated with [Claude Code](https://claude.com/claude-code)