### PR TITLE
fix(parallel_tests): glob worker dirs instead of trusting PARALLEL_TEST_GROUPS env

### DIFF
--- a/lib/rspec_tracer/rspec/parallel_tests.rb
+++ b/lib/rspec_tracer/rspec/parallel_tests.rb
@@ -150,14 +150,29 @@ module RSpecTracer
         ::FileUtils.rm_f(RSpecTracer.lock_file)
       end
 
-      def self.worker_group_count
-        ::ENV.fetch('PARALLEL_TEST_GROUPS', '0').to_i
-      end
-
+      # parallel_tests sets `PARALLEL_TEST_GROUPS = num_processes.to_s`
+      # for each child, where `num_processes` is the user-requested
+      # process count (Parallel.processor_count by default) - NOT the
+      # number of workers actually spawned. When `num_processes` and
+      # the spawned-worker count diverge (e.g. when the spec count caps
+      # the partition below the CPU count, or when shared-runner
+      # cgroup throttling shifts the visible CPU count between when
+      # the parent computed `num_processes` and the spec count is
+      # observed), iterating `1..ENV['PARALLEL_TEST_GROUPS']` either
+      # over-iterates (cheap; rm_rf on a non-existent path is a no-op)
+      # or UNDER-iterates (expensive; merge skips peers + purge leaves
+      # `parallel_tests_N` stragglers behind, breaking the integration
+      # spec at `spec/integration/parallel_tests_spec.rb:88`).
+      #
+      # Glob the actual filesystem state rather than reconstructing dir
+      # names from an env var with surprising semantics. The directory
+      # IS the source of truth for which workers ran. The wait at
+      # `finalize!` (`wait_for_other_processes_to_finish`) guarantees
+      # every other worker's at_exit has flushed its `parallel_tests_N`
+      # tree before this method runs, so the glob captures every peer.
       def self.peer_paths_for(base_dir)
-        (1..worker_group_count).filter_map do |n|
-          path = ::File.join(base_dir, "parallel_tests_#{n}")
-          path if ::File.directory?(path)
+        ::Dir.glob(::File.join(base_dir, 'parallel_tests_*')).select do |path|
+          ::File.directory?(path)
         end
       end
 
@@ -214,11 +229,16 @@ module RSpecTracer
         RSpecTracer.logger.debug("RSpec tracer merged parallel tests coverage (took #{elapsed})") if log_rollups?
       end
 
+      # Sweep every `parallel_tests_*` subdirectory under each managed
+      # base path. Globbing matches the same source-of-truth contract
+      # documented on `peer_paths_for`: the directories that actually
+      # exist are exactly the workers that ran, regardless of what
+      # PARALLEL_TEST_GROUPS reports.
       def self.purge_worker_dirs!
         [RSpecTracer.cache_path, RSpecTracer.coverage_path, RSpecTracer.report_path].each do |path|
           base_dir = ::File.dirname(path)
-          (1..worker_group_count).each do |n|
-            ::FileUtils.rm_rf(::File.join(base_dir, "parallel_tests_#{n}"))
+          ::Dir.glob(::File.join(base_dir, 'parallel_tests_*')).each do |worker_dir|
+            ::FileUtils.rm_rf(worker_dir)
           end
         end
       end

--- a/spec/rspec/parallel_tests_spec.rb
+++ b/spec/rspec/parallel_tests_spec.rb
@@ -212,19 +212,8 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
     end
   end
 
-  describe '.worker_group_count' do
-    it 'returns 0 when PARALLEL_TEST_GROUPS is unset' do
-      expect(described_class.worker_group_count).to eq(0)
-    end
-
-    it 'returns the integer value of PARALLEL_TEST_GROUPS' do
-      ENV['PARALLEL_TEST_GROUPS'] = '4'
-      expect(described_class.worker_group_count).to eq(4)
-    end
-  end
-
   describe '.peer_paths_for' do
-    it 'returns only the existing parallel_tests_N subdirs' do
+    it 'returns the existing parallel_tests_* subdirs in the base dir' do
       ENV['PARALLEL_TEST_GROUPS'] = '3'
       base = File.join(tmp_base, 'peers')
       FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
@@ -233,6 +222,52 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(described_class.peer_paths_for(base)).to contain_exactly(
         File.join(base, 'parallel_tests_1'),
         File.join(base, 'parallel_tests_3')
+      )
+    end
+
+    # Regression: parallel_tests sets PARALLEL_TEST_GROUPS to the
+    # user-requested num_processes (CPU count by default), not the
+    # actual worker count. When num_processes < spawned-worker count,
+    # iterating `1..ENV['PARALLEL_TEST_GROUPS']` would skip the trailing
+    # peer dirs and silently lose their snapshots in the merge.
+    it 'finds peer dirs whose index exceeds PARALLEL_TEST_GROUPS' do
+      ENV['PARALLEL_TEST_GROUPS'] = '2'
+      base = File.join(tmp_base, 'peers')
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_2'))
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_4'))
+
+      expect(described_class.peer_paths_for(base)).to contain_exactly(
+        File.join(base, 'parallel_tests_1'),
+        File.join(base, 'parallel_tests_2'),
+        File.join(base, 'parallel_tests_4')
+      )
+    end
+
+    it 'finds peer dirs even when PARALLEL_TEST_GROUPS is unset' do
+      base = File.join(tmp_base, 'peers')
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+
+      expect(described_class.peer_paths_for(base)).to contain_exactly(
+        File.join(base, 'parallel_tests_1')
+      )
+    end
+
+    it 'returns an empty array when no parallel_tests_* dirs exist' do
+      ENV['PARALLEL_TEST_GROUPS'] = '4'
+      base = File.join(tmp_base, 'peers')
+      FileUtils.mkdir_p(base)
+
+      expect(described_class.peer_paths_for(base)).to eq([])
+    end
+
+    it 'rejects file entries with parallel_tests_ prefix' do
+      base = File.join(tmp_base, 'peers')
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+      File.write(File.join(base, 'parallel_tests_2.json'), 'not a dir')
+
+      expect(described_class.peer_paths_for(base)).to contain_exactly(
+        File.join(base, 'parallel_tests_1')
       )
     end
   end
@@ -386,6 +421,40 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
           expect(File.directory?(File.join(File.dirname(path), "parallel_tests_#{n}"))).to be(false)
         end
       end
+    end
+
+    # Regression for spec/integration/parallel_tests_spec.rb:88 flake
+    # on ruby-parallel CI cells: parallel_tests sets
+    # PARALLEL_TEST_GROUPS = num_processes (the user-requested process
+    # count), not the actual worker count. When the spawned worker
+    # count exceeds num_processes (e.g. via spec-count partitioning
+    # interactions or shared-runner CPU detection drift), iterating
+    # `1..ENV['PARALLEL_TEST_GROUPS']` left worker dirs above that
+    # bound behind. Globbing the actual filesystem state is robust.
+    it 'sweeps worker dirs whose index exceeds PARALLEL_TEST_GROUPS' do
+      ENV['PARALLEL_TEST_GROUPS'] = '2'
+      base = File.dirname(cache_path)
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_4'))
+
+      described_class.purge_worker_dirs!
+
+      expect(Dir.glob(File.join(base, 'parallel_tests_*'))).to be_empty
+    end
+
+    it 'sweeps worker dirs even when PARALLEL_TEST_GROUPS is unset' do
+      base = File.dirname(cache_path)
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_2'))
+
+      described_class.purge_worker_dirs!
+
+      expect(Dir.glob(File.join(base, 'parallel_tests_*'))).to be_empty
+    end
+
+    it 'is a no-op when no worker dirs exist' do
+      ENV['PARALLEL_TEST_GROUPS'] = '4'
+      expect { described_class.purge_worker_dirs! }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
## Summary

Fixes a real bug in `lib/rspec_tracer/rspec/parallel_tests.rb` that was silently corrupting peer-cache merges and intermittently leaving worker dirs behind. Surfaced as a flake on `full-matrix / ruby-parallel (ruby-3.4, rspec-3.12)` against `spec/integration/parallel_tests_spec.rb:88` (`purges per-worker parallel_tests_N directories on the last worker`).

## Root cause

`purge_worker_dirs!` and `peer_paths_for` iterated `1..worker_group_count` where `worker_group_count = ENV['PARALLEL_TEST_GROUPS'].to_i`. But the parallel_tests gem sets `PARALLEL_TEST_GROUPS = num_processes.to_s` for each child (in `parallel_tests/test/runner.rb#execute_command`), where `num_processes` is the user-requested process count (`Parallel.processor_count` by default) — **not** the actual number of workers spawned.

The existing `last_process?` comment block already documents this:

> `::ParallelTests.last_process?` compares TEST_ENV_NUMBER against PARALLEL_TEST_GROUPS. parallel_rspec's CLI sets PARALLEL_TEST_GROUPS to the CPU-based *intended* process count, NOT the actual worker count [...]

We used that gem behavior to motivate using `first_process?` over `last_process?`, then made the matching mistake in our own helpers.

## Failure profile

- `num_processes >= spawned_worker_count` (the common case): over-iteration is harmless. `rm_rf` on a non-existent path is a no-op. Tests pass.
- `num_processes < spawned_worker_count` (the failure case): peer dirs above the bound are silently skipped. `peer_paths_for` loses their snapshots in the merge (data corruption — silent); `purge_worker_dirs!` leaves them as stragglers (the visible failure on the integration spec).

The inequality flips when the spec-count partition produces more non-empty groups than `num_processes`, or when shared-runner CPU detection drifts mid-run via cgroup throttling. The CI flake hit this on a single ruby-parallel cell while 11 sibling cells passed on the same SHA.

## Reproduction

Local 12-vCPU box, fixture has 4 specs, `PARALLEL_TEST_GROUPS=2` at parent:

```
4 processes for 4 specs, ~ 1 spec per process
TEST_ENV_NUMBER= PARALLEL_TEST_GROUPS=12 bundle exec rspec spec/shared_examples_spec.rb
TEST_ENV_NUMBER=2 PARALLEL_TEST_GROUPS=12 bundle exec rspec spec/calculator_spec.rb
TEST_ENV_NUMBER=3 PARALLEL_TEST_GROUPS=12 bundle exec rspec spec/discount_spec.rb
TEST_ENV_NUMBER=4 PARALLEL_TEST_GROUPS=12 bundle exec rspec spec/inventory_spec.rb
```

`PARALLEL_TEST_GROUPS=12` (the CPU count) shows up in children even though only 4 workers spawned. Locally this works by accident (12 >= 4). On a runner where the gem-derived num_processes < 4, the under-iteration produces the failure.

## Fix

Glob `parallel_tests_*` directly under each managed base path. The filesystem state IS the source of truth for which workers ran, and `wait_for_other_processes_to_finish` in `finalize!` guarantees every other worker's at_exit has flushed its tree before this code runs.

Drops the now-unused `worker_group_count` helper. Adds regression specs covering:
- Peer dirs whose index exceeds `PARALLEL_TEST_GROUPS` (the failure shape).
- Missing env var (defensive).
- Non-directory siblings with the `parallel_tests_` prefix (defensive).

## Test plan

- [x] `task lint:ruby` clean (188 files, 0 offenses)
- [x] `task test:unit` green (1574 examples, 0 failures)
- [x] `bundle exec rspec spec/rspec/parallel_tests_spec.rb` green (45 examples, 0 failures, including the 4 new regression specs)
- [x] `bundle exec rspec spec/integration/parallel_tests_spec.rb` green (6 examples, 0 failures, including the previously-failing line 88)
- [ ] CI green across the full ruby-parallel matrix (Ruby 3.1 / 3.2 / 3.3 / 3.4 / 4.0 × rspec 3.12 / 3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)