### PR TITLE
fix(parallel_tests): glob worker dirs in merge + purge (v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## [1.2.1] - 2026-05-01
+
+### Fixed
+
+- **Parallel-tests merge silently dropped peer caches and left worker
+  directories behind** when the spawned-worker count exceeded
+  `ENV['PARALLEL_TEST_GROUPS']`. The merge + purge call-sites in
+  `lib/rspec_tracer.rb` (`merge_parallel_tests_reports`,
+  `merge_parallel_tests_coverage_reports`,
+  `purge_parallel_tests_reports`) iterated `1..ENV['PARALLEL_TEST_GROUPS']`
+  to construct per-worker directory names. But parallel_tests sets
+  `PARALLEL_TEST_GROUPS = num_processes.to_s` for each child, where
+  `num_processes` is the user-requested process count
+  (`Parallel.processor_count` by default) — not the actual worker
+  count. When `num_processes < spawned_worker_count` (e.g. when the
+  spec-count partition produces more non-empty groups than
+  `num_processes`, or shared-runner CPU detection drifts mid-run),
+  peer caches with `TEST_ENV_NUMBER` above the env bound were silently
+  dropped from the merge (warm-run skip decisions get made against
+  an under-sampled merged manifest) and left behind by the purge
+  (visible as straggler `parallel_tests_<N>/` directories under
+  `rspec_tracer_cache/`). The same gem behaviour was documented on
+  v1.1.1's `last_process?` fix
+  ([PR #101](https://github.com/avmnu-sng/rspec-tracer/pull/101)) but
+  the iteration call-sites kept the buggy bound. Each method now globs
+  the actual `parallel_tests_*` subdirectories under its base path,
+  making the merge + purge robust to whatever count parallel_tests
+  spawned. No cache format change.
+
 ## [1.2.0] - 2026-04-24
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-tracer (1.2.0)
+    rspec-tracer (1.2.1)
       docile (~> 1.4)
       rspec-core (~> 3.12)
 

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -330,12 +330,7 @@ module RSpecTracer
       starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       reports_dir = []
 
-      1.upto(ENV['PARALLEL_TEST_GROUPS'].to_i) do |test_num|
-        cache_path = File.dirname(RSpecTracer.cache_path)
-        cache_dir = File.join(cache_path, "parallel_tests_#{test_num}")
-
-        next unless File.directory?(cache_dir)
-
+      parallel_tests_peer_dirs(File.dirname(RSpecTracer.cache_path)).each do |cache_dir|
         run_id = JSON.parse(File.read(File.join(cache_dir, 'last_run.json'), encoding: 'UTF-8'))['run_id']
 
         reports_dir << File.join(cache_dir, run_id)
@@ -365,14 +360,8 @@ module RSpecTracer
       return unless parallel_tests_executed? && !simplecov?
 
       starting = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      reports_dir = []
 
-      1.upto(ENV['PARALLEL_TEST_GROUPS'].to_i) do |test_num|
-        coverage_path = File.dirname(RSpecTracer.coverage_path)
-        coverage_dir = File.join(coverage_path, "parallel_tests_#{test_num}")
-
-        reports_dir << coverage_dir if File.directory?(coverage_dir)
-      end
+      reports_dir = parallel_tests_peer_dirs(File.dirname(RSpecTracer.coverage_path))
 
       coverage_merger.merge(reports_dir)
 
@@ -401,10 +390,31 @@ module RSpecTracer
     def purge_parallel_tests_reports
       return unless parallel_tests_executed?
 
-      1.upto(ENV['PARALLEL_TEST_GROUPS'].to_i) do |test_num|
-        [RSpecTracer.cache_path, RSpecTracer.coverage_path, RSpecTracer.report_path].each do |path|
-          FileUtils.rm_rf(File.join(File.dirname(path), "parallel_tests_#{test_num}"))
+      [RSpecTracer.cache_path, RSpecTracer.coverage_path, RSpecTracer.report_path].each do |path|
+        parallel_tests_peer_dirs(File.dirname(path)).each do |worker_dir|
+          FileUtils.rm_rf(worker_dir)
         end
+      end
+    end
+
+    # Returns every `parallel_tests_*` subdirectory directly under
+    # `base_path`. Used by the parallel_tests merge + purge paths.
+    #
+    # Earlier patches iterated `1..ENV['PARALLEL_TEST_GROUPS'].to_i`
+    # to construct dir names, but parallel_tests's own runner sets
+    # PARALLEL_TEST_GROUPS to the user-requested process count
+    # (`Parallel.processor_count` by default), NOT the actual worker
+    # count. When num_processes < spawned_worker_count, the upper
+    # bound was too small: peer caches with TEST_ENV_NUMBER above the
+    # bound were silently dropped from the merge AND left behind by
+    # the purge. PR #101's commit message documented this gem
+    # behaviour for `last_process?` detection but did not extend the
+    # fix to the iteration call-sites; this method closes that gap.
+    # Globbing the actual filesystem state is robust to the env
+    # discrepancy regardless of how the gem partitions specs.
+    def parallel_tests_peer_dirs(base_path)
+      Dir.glob(File.join(base_path, 'parallel_tests_*')).select do |path|
+        File.directory?(path)
       end
     end
 

--- a/lib/rspec_tracer/version.rb
+++ b/lib/rspec_tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RSpecTracer
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end

--- a/spec/parallel_tests_spec.rb
+++ b/spec/parallel_tests_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'tmpdir'
+
+# Regression coverage for v1.2.1's fix to the parallel_tests merge +
+# purge paths in lib/rspec_tracer.rb. parallel_tests sets
+# PARALLEL_TEST_GROUPS to the user-requested process count (the
+# CPU-derived num_processes), not the actual worker count - so the
+# 1.upto(ENV['PARALLEL_TEST_GROUPS']) iteration earlier patches used
+# silently dropped peer caches and left straggler dirs whenever the
+# spawned-worker count exceeded num_processes. Globbing
+# `parallel_tests_*` subdirectories is robust regardless.
+#
+# These tests target the private singleton helpers via `.send` because
+# they were extracted purely to make the iteration testable; they
+# remain implementation detail of the at_exit pipeline.
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe RSpecTracer do
+  describe '.parallel_tests_peer_dirs' do
+    subject(:peer_dirs) { described_class.send(:parallel_tests_peer_dirs, base_dir) }
+
+    let(:base_dir) { Dir.mktmpdir }
+
+    after { FileUtils.rm_rf(base_dir) }
+
+    it 'returns every parallel_tests_* subdirectory under base_dir' do
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_1'))
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_2'))
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_4'))
+
+      expect(peer_dirs).to contain_exactly(
+        File.join(base_dir, 'parallel_tests_1'),
+        File.join(base_dir, 'parallel_tests_2'),
+        File.join(base_dir, 'parallel_tests_4')
+      )
+    end
+
+    it 'finds peer dirs whose index exceeds PARALLEL_TEST_GROUPS' do
+      ENV['PARALLEL_TEST_GROUPS'] = '2'
+
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_1'))
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_2'))
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_4'))
+
+      expect(peer_dirs).to include(File.join(base_dir, 'parallel_tests_4'))
+    ensure
+      ENV.delete('PARALLEL_TEST_GROUPS')
+    end
+
+    it 'finds peer dirs even when PARALLEL_TEST_GROUPS is unset' do
+      ENV.delete('PARALLEL_TEST_GROUPS')
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_1'))
+
+      expect(peer_dirs).to contain_exactly(File.join(base_dir, 'parallel_tests_1'))
+    end
+
+    it 'returns an empty array when no parallel_tests_* dirs exist' do
+      expect(peer_dirs).to eq([])
+    end
+
+    it 'rejects file entries with the parallel_tests_ prefix' do
+      FileUtils.mkdir_p(File.join(base_dir, 'parallel_tests_1'))
+      File.write(File.join(base_dir, 'parallel_tests_2.json'), 'not a dir')
+
+      expect(peer_dirs).to contain_exactly(File.join(base_dir, 'parallel_tests_1'))
+    end
+  end
+
+  describe '.purge_parallel_tests_reports' do
+    let(:tmp_root)      { Dir.mktmpdir }
+    let(:cache_path)    { File.join(tmp_root, 'rspec_tracer_cache', 'parallel_tests_1') }
+    let(:coverage_path) { File.join(tmp_root, 'rspec_tracer_coverage', 'parallel_tests_1') }
+    let(:report_path)   { File.join(tmp_root, 'rspec_tracer_report', 'parallel_tests_1') }
+
+    before do
+      allow(described_class).to receive_messages(
+        cache_path: cache_path, coverage_path: coverage_path, report_path: report_path
+      )
+      allow(described_class).to receive(:parallel_tests_executed?).and_return(true)
+      [cache_path, coverage_path, report_path].each { |p| FileUtils.mkdir_p(File.dirname(p)) }
+    end
+
+    after { FileUtils.rm_rf(tmp_root) }
+
+    it 'sweeps every parallel_tests_* subdir under each tracked base dir' do
+      [cache_path, coverage_path, report_path].each do |path|
+        base = File.dirname(path)
+        FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+        FileUtils.mkdir_p(File.join(base, 'parallel_tests_2'))
+      end
+
+      described_class.send(:purge_parallel_tests_reports)
+
+      [cache_path, coverage_path, report_path].each do |path|
+        expect(Dir.glob(File.join(File.dirname(path), 'parallel_tests_*'))).to be_empty
+      end
+    end
+
+    # Regression: the bug we're fixing. Worker dirs whose index >
+    # PARALLEL_TEST_GROUPS used to be left behind because the iteration
+    # bound was env-derived, not filesystem-derived.
+    it 'sweeps worker dirs whose index exceeds PARALLEL_TEST_GROUPS' do
+      ENV['PARALLEL_TEST_GROUPS'] = '2'
+      base = File.dirname(cache_path)
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_4'))
+
+      described_class.send(:purge_parallel_tests_reports)
+
+      expect(Dir.glob(File.join(base, 'parallel_tests_*'))).to be_empty
+    ensure
+      ENV.delete('PARALLEL_TEST_GROUPS')
+    end
+
+    it 'is a no-op when parallel_tests has not executed' do
+      allow(described_class).to receive(:parallel_tests_executed?).and_return(false)
+      base = File.dirname(cache_path)
+      FileUtils.mkdir_p(File.join(base, 'parallel_tests_1'))
+
+      described_class.send(:purge_parallel_tests_reports)
+
+      expect(File.directory?(File.join(base, 'parallel_tests_1'))).to be(true)
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
Back-ports the parallel_tests merge + purge fix to the 1.x line and bumps to v1.2.1. Companion to [main PR #140](https://github.com/avmnu-sng/rspec-tracer/pull/140).

## Root cause

`merge_parallel_tests_reports`, `merge_parallel_tests_coverage_reports`, and `purge_parallel_tests_reports` in `lib/rspec_tracer.rb` each iterated `1..ENV['PARALLEL_TEST_GROUPS'].to_i` to construct per-worker directory names. But parallel_tests sets `PARALLEL_TEST_GROUPS = num_processes.to_s` for each child, where `num_processes` is the user-requested process count (`Parallel.processor_count` by default) — **not** the actual number of workers spawned.

The same gem behaviour was documented on [v1.1.1's `last_process?` fix](https://github.com/avmnu-sng/rspec-tracer/pull/101):

> parallel_tests' own `last_process?` compares `TEST_ENV_NUMBER` to `PARALLEL_TEST_GROUPS`, which parallel_rspec sets to the CPU-based intended process count — not the actual worker count. When spec files < CPU count, no `TEST_ENV_NUMBER` matches and the merge is silently skipped.

That PR fixed the election logic but left the iteration call-sites with the same buggy bound.

## Failure profile

- `num_processes >= spawned_worker_count` (the common case): over-iteration is harmless; checks for non-existent dirs are skipped via `next unless File.directory?`.
- `num_processes < spawned_worker_count` (the failure case): peer dirs above the bound are silently skipped. The merge loses their snapshots (data corruption — silent, can produce warm-run skip decisions against an under-sampled manifest); the purge leaves them as stragglers under `rspec_tracer_cache/parallel_tests_<N>/`.

The inequality flips when the spec-count partition produces more non-empty groups than `num_processes`, or when shared-runner CPU detection drifts mid-run via cgroup throttling. On the 2.x line this surfaced as an intermittent flake on `spec/integration/parallel_tests_spec.rb:88` against the `ruby-parallel (ruby-3.4, rspec-3.12)` cell.

## What's in this PR

- `lib/rspec_tracer.rb` — extracts a private `parallel_tests_peer_dirs(base_path)` helper that globs `parallel_tests_*` directly under the base path. The three call-sites use it. Drops the `1..ENV['PARALLEL_TEST_GROUPS']` iteration shape.
- `lib/rspec_tracer/version.rb` — bumps to `1.2.1`.
- `Gemfile.lock` — picks up the version bump.
- `CHANGELOG.md` — new `[1.2.1]` entry.
- `spec/parallel_tests_spec.rb` — new regression spec covering the helper + the purge: peer dirs above `PARALLEL_TEST_GROUPS`, missing env var, non-directory siblings, and the purge no-op when parallel_tests didn't execute.

No cache format change.

## Test plan

- [x] `bundle exec rspec spec/parallel_tests_spec.rb` — 8/8 pass locally
- [x] `bundle exec rspec spec/configuration_spec.rb spec/time_formatter_spec.rb spec/parallel_tests_spec.rb spec/lib/rspec_tracer/` — 78/78 pass locally
- [x] `bundle exec rubocop lib/rspec_tracer.rb lib/rspec_tracer/version.rb spec/parallel_tests_spec.rb` — clean
- [ ] CI matrix on this PR
- [ ] After merge: tag `v1.2.1` on the merge commit → release workflow publishes to rubygems

🤖 Generated with [Claude Code](https://claude.com/claude-code)