### PR TITLE
ci(benchmark): multi-run p95 baseline for GHA runner-CPU heterogeneity

### DIFF
--- a/.github/workflows/multi-run-ratchet.yml
+++ b/.github/workflows/multi-run-ratchet.yml
@@ -1,0 +1,210 @@
+---
+name: multi-run-ratchet
+
+# Multi-run ratchet baseline for GHA `ubuntu-latest` runner-CPU
+# heterogeneity. Replaces the single-run `regen-ratchet.yml` workflow
+# for periodic re-baselining. Strategy:
+#
+#   1. Fan N parallel jobs (default 30, configurable via
+#      workflow_dispatch input). Each job mirrors `regen-ratchet.yml`'s
+#      setup + runs `task benchmark:ratchet:update` to produce its
+#      own per-run `ratchet.json`.
+#   2. Each job uploads its `ratchet.json` as an artifact named
+#      `multi-run-ratchet-N` so the aggregator can find them.
+#   3. The aggregate job downloads all N artifacts + invokes
+#      `scripts/aggregate_ratchet.rb` to compute min/p50/p75/p90/p95
+#      /p99/max across runs of within-run-p50 per scenario.
+#   4. The candidate `benchmark/ratchet.json` is uploaded as an
+#      artifact + a per-scenario distribution table is written to
+#      `GITHUB_STEP_SUMMARY`.
+#   5. Maintainer reviews the summary, then commits the candidate
+#      ratchet on a small follow-up PR.
+#
+# Why N=30: GHA `ubuntu-latest` mixes ~2-3 distinct CPU SKUs (EPYC
+# 9V74 / EPYC 7763 / occasional Intel Xeon). 30 runs samples each
+# SKU ~10 times - enough to land a stable p95-of-p50 baseline.
+# Beyond N=30, ROI plateaus because the p95 estimate is dominated by
+# which SKUs exist, not how many times each is sampled. Configurable
+# via the `runs` input for higher-confidence re-baselines.
+#
+# Why p95-of-p50: 95% of runs land at-or-below this threshold (silent
+# OK); the slowest 5% (slowest SKU on a noisy day) WARN/FAIL but
+# don't define the threshold. p50-of-p50 would WARN half the runs
+# (defeats the gate); max-of-p50 would let one outlier define the
+# threshold (gating becomes useless).
+#
+# Trigger via:
+#   gh workflow run multi-run-ratchet.yml --ref <branch> [--field runs=30]
+#
+# Then download the candidate:
+#   gh run download <run-id> -n multi-run-ratchet-candidate
+#
+# And review the summary in the workflow run page before committing
+# the candidate `benchmark/ratchet.json` on a small PR.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Number of parallel benchmark runs to aggregate (default 30)
+        required: false
+        default: '30'
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      indices: ${{ steps.compute.outputs.indices }}
+    steps:
+      - name: Compute matrix indices
+        id: compute
+        env:
+          RUNS: ${{ inputs.runs }}
+        run: |
+          # Emit JSON array [1, 2, ..., N]. Validates N is a positive
+          # integer in the 1..200 range to prevent runaway matrices.
+          if ! [[ "$RUNS" =~ ^[1-9][0-9]?$|^1[0-9][0-9]$|^200$ ]]; then
+            echo "::error::runs input '$RUNS' must be a positive integer 1-200"
+            exit 1
+          fi
+          indices=$(seq 1 "$RUNS" | jq -nR '[inputs | tonumber]')
+          echo "indices=$(echo "$indices" | jq -c .)" >> "$GITHUB_OUTPUT"
+          echo "Will fan $RUNS parallel benchmark runs"
+
+  regen-run:
+    name: regen-run-${{ matrix.idx }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      # Fan all N runs in parallel; one slow VM doesn't block the
+      # rest. fail-fast disabled so a single-run flake doesn't
+      # cancel the aggregation.
+      fail-fast: false
+      matrix:
+        idx: ${{ fromJSON(needs.prepare.outputs.indices) }}
+    # Mirror the canonical benchmark cell's env pins (full-matrix.yml's
+    # `benchmark:` job) so resolution converges on the same Rails /
+    # rspec-rails / sqlite3 majors. Apples-to-apples across the N
+    # parallel runs.
+    env:
+      RAILS_VERSION: "~> 7.1.0"
+      RSPEC_RAILS_VERSION: "~> 6.1.0"
+      SQLITE3_VERSION: "~> 1.4"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '.ruby-version'
+          bundler: '4.0.10'
+          bundler-cache: true
+
+      - name: Setup Task
+        uses: go-task/setup-task@v2
+        with:
+          version: 3.45.4
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Same fixture-bundle caches as the canonical `benchmark:` job
+      # in full-matrix.yml + regen-ratchet.yml; share keys so each
+      # matrix job runs warm on existing caches without re-downloading
+      # the fixture gem set.
+      - name: Cache benchmark ruby_app fixture bundle
+        uses: actions/cache@v5
+        with:
+          path: benchmark/fixtures/ruby_app/vendor/bundle
+          key: fixture-bundle-ruby-app-${{ runner.os }}-${{ hashFiles('.ruby-version') }}-${{ hashFiles('benchmark/fixtures/ruby_app/Gemfile') }}
+          restore-keys: |
+            fixture-bundle-ruby-app-${{ runner.os }}-${{ hashFiles('.ruby-version') }}-
+
+      - name: Cache rails_app fixture bundle
+        uses: actions/cache@v5
+        with:
+          path: spec/fixtures/rails_app/vendor/bundle
+          key: >-
+            fixture-bundle-rails-app-${{ runner.os
+            }}-${{ hashFiles('.ruby-version')
+            }}-${{ hashFiles('spec/fixtures/rails_app/Gemfile')
+            }}-${{ env.RAILS_VERSION
+            }}-${{ env.RSPEC_RAILS_VERSION
+            }}-${{ env.SQLITE3_VERSION }}
+          restore-keys: |
+            fixture-bundle-rails-app-${{ runner.os }}-${{ hashFiles('.ruby-version') }}-${{ hashFiles('spec/fixtures/rails_app/Gemfile') }}-
+            fixture-bundle-rails-app-${{ runner.os }}-${{ hashFiles('.ruby-version') }}-
+
+      - name: Point fixture bundler at vendor/bundle
+        run: |
+          (cd benchmark/fixtures/ruby_app && bundle config set --local path vendor/bundle)
+          (cd spec/fixtures/rails_app && bundle config set --local path vendor/bundle)
+
+      - name: Install fixture bundles
+        run: task benchmark:bundle
+
+      - name: Prepare Rails fixture database
+        run: bundle exec rails db:test:prepare
+        working-directory: spec/fixtures/rails_app
+
+      - name: Run benchmark (10 iters per scenario)
+        run: task benchmark:ratchet:update
+
+      # Capture the per-run ratchet.json with the matrix index in the
+      # artifact name so the aggregator can find each one. The CPU
+      # model is preserved inside the ratchet's environment block so
+      # the aggregator can tally distinct SKUs seen.
+      - name: Upload per-run ratchet
+        uses: actions/upload-artifact@v7
+        with:
+          name: multi-run-ratchet-${{ matrix.idx }}
+          path: benchmark/ratchet.json
+          if-no-files-found: error
+
+  aggregate:
+    name: aggregate
+    needs: regen-run
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '.ruby-version'
+          bundler-cache: false
+
+      # Download every per-run artifact under tmp/multi-run-ratchet/.
+      # actions/download-artifact@v6 with `pattern:` and
+      # `merge-multiple: false` preserves the per-run subdirs (e.g.
+      # tmp/multi-run-ratchet/multi-run-ratchet-7/ratchet.json) so
+      # the aggregator can iterate them.
+      - name: Download all per-run artifacts
+        uses: actions/download-artifact@v6
+        with:
+          path: tmp/multi-run-ratchet
+          pattern: multi-run-ratchet-*
+          merge-multiple: false
+
+      - name: Aggregate per-run ratchets
+        run: |
+          ruby scripts/aggregate_ratchet.rb \
+            --runs-dir tmp/multi-run-ratchet \
+            --out tmp/candidate-ratchet.json \
+            --summary "$GITHUB_STEP_SUMMARY" \
+            --baseline-percentile 95
+
+      - name: Upload candidate ratchet
+        uses: actions/upload-artifact@v7
+        with:
+          name: multi-run-ratchet-candidate
+          path: tmp/candidate-ratchet.json
+          if-no-files-found: error

--- a/benchmark/ratchet.json
+++ b/benchmark/ratchet.json
@@ -3,74 +3,81 @@
     "ruby": "3.3.10",
     "ruby_platform": "x86_64-linux",
     "os": "linux",
-    "cpu": "AMD EPYC 9V74 80-Core Processor",
-    "cores": 4,
-    "recorded_at": "2026-04-29T20:33:02Z"
+    "recorded_at": "2026-05-01T21:18:31Z",
+    "baseline_methodology": {
+      "across_runs": 30,
+      "baseline_percentile": 95,
+      "cpus_seen": {
+        "AMD EPYC 9V74 80-Core Processor": 11,
+        "AMD EPYC 7763 64-Core Processor": 16,
+        "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz": 3
+      }
+    }
   },
   "scenarios": {
-    "cold_ruby": {
-      "p50": 0.4033,
-      "p95": 0.4366,
-      "iterations": 10
-    },
-    "warm_noop": {
-      "p50": 0.3346,
-      "p95": 0.3753,
-      "iterations": 10
-    },
-    "warm_env_mismatch": {
-      "p50": 0.3318,
-      "p95": 0.4807,
-      "iterations": 10
-    },
-    "track_env_warm_mismatch": {
-      "p50": 0.3086,
-      "p95": 0.3409,
-      "iterations": 10
-    },
-    "parallel_tests_2_workers": {
-      "p50": 0.8665,
-      "p95": 1.8682,
-      "iterations": 10
-    },
-    "cold_rails": {
-      "p50": 7.0289,
-      "p95": 7.3304,
-      "iterations": 10
-    },
-    "cold_rails_v2": {
-      "p50": 16.4719,
-      "p95": 17.2098,
-      "iterations": 10
-    },
-    "coverage_adapter": {
-      "p50": 0.9474,
-      "p95": 0.9886,
-      "iterations": 10
-    },
     "cache_load": {
-      "p50": 0.6352,
-      "p95": 0.6557,
+      "p50": 0.7729,
+      "p95": 0.7961,
       "iterations": 10
     },
     "cache_load_msgpack": {
-      "p50": 0.6623,
-      "p95": 0.6794,
+      "p50": 0.8261,
+      "p95": 0.8364,
       "iterations": 10
     },
     "cache_load_sqlite": {
-      "p50": 1.1576,
-      "p95": 1.808,
+      "p50": 1.0321,
+      "p95": 1.0568,
+      "iterations": 10
+    },
+    "cold_rails": {
+      "p50": 8.4521,
+      "p95": 8.6651,
+      "iterations": 10
+    },
+    "cold_rails_v2": {
+      "p50": 19.8368,
+      "p95": 20.396,
+      "iterations": 10
+    },
+    "cold_ruby": {
+      "p50": 0.4507,
+      "p95": 0.4763,
+      "iterations": 10
+    },
+    "coverage_adapter": {
+      "p50": 1.1969,
+      "p95": 1.2228,
       "iterations": 10
     },
     "file_read_hook": {
-      "p50": 3.9904,
-      "p95": 4.0616,
+      "p50": 5.0953,
+      "p95": 5.1474,
       "iterations": 10
     },
     "loaded_files_tracker": {
-      "p50": 1.1102,
-      "p95": 1.1553,
+      "p50": 1.4107,
+      "p95": 1.4407,
+      "iterations": 10
+    },
+    "parallel_tests_2_workers": {
+      "p50": 1.0626,
+      "p95": 2.0554,
+      "iterations": 10
+    },
+    "track_env_warm_mismatch": {
+      "p50": 0.402,
+      "p95": 0.445,
+      "iterations": 10
+    },
+    "warm_env_mismatch": {
+      "p50": 0.4099,
+      "p95": 0.4247,
+      "iterations": 10
+    },
+    "warm_noop": {
+      "p50": 0.4044,
+      "p95": 0.4439,
       "iterations": 10
     }
   }

--- a/scripts/aggregate_ratchet.rb
+++ b/scripts/aggregate_ratchet.rb
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Aggregate N per-run ratchet.json captures into a single
+# representative-baseline ratchet.json + a summary markdown.
+#
+# Usage:
+#   ruby scripts/aggregate_ratchet.rb \
+#     --runs-dir tmp/multi-run-ratchet \
+#     --out benchmark/ratchet.json \
+#     --summary $GITHUB_STEP_SUMMARY \
+#     [--baseline-percentile 95]
+#
+# Why N runs: GHA `ubuntu-latest` mixes EPYC 9V74 (Zen 4) + EPYC 7763
+# (Zen 3) + occasional Intel Xeon - CPU-microbench scenarios shift
+# 15-25% across SKUs. Single-run baseline seeding bakes in whichever
+# silicon GHA happened to allocate. N runs sample the SKU mix; an
+# across-runs percentile threshold absorbs runner-pool heterogeneity.
+#
+# Why p95-of-p50: 95% of runs land at-or-below this baseline, going
+# silent OK; the 5% tail (slowest SKU on a noisy day) goes WARN/FAIL
+# but doesn't define the threshold. p50-of-p50 would WARN half the
+# runs (defeats the gate); max-of-p50 would let one slow outlier
+# define the threshold (gating becomes useless).
+#
+# What the summary captures: full distribution per scenario
+# (min/p50/p75/p90/p95/p99/max) so the maintainer can sanity-check
+# the spread + drift over time, plus the distinct CPU models seen +
+# their per-scenario p50-of-p50.
+
+require 'json'
+require 'optparse'
+require 'time'
+
+DEFAULT_BASELINE_PERCENTILE = 95
+DEFAULT_PERCENTILES = [50, 75, 90, 95, 99].freeze
+
+def percentile(sorted, pct)
+  return nil if sorted.empty?
+  return sorted.first if sorted.size == 1
+
+  idx_f = (pct / 100.0) * (sorted.size - 1)
+  lower = idx_f.floor
+  upper = idx_f.ceil
+  return sorted[lower] if lower == upper
+
+  weight = idx_f - lower
+  ((sorted[lower] * (1.0 - weight)) + (sorted[upper] * weight)).round(4)
+end
+
+def parse_options(argv)
+  options = { baseline_percentile: DEFAULT_BASELINE_PERCENTILE }
+  OptionParser.new do |o|
+    o.on('--runs-dir DIR', 'Directory containing per-run subdirs each with ratchet.json') do |v|
+      options[:runs_dir] = v
+    end
+    o.on('--out PATH', 'Output candidate ratchet.json path') { |v| options[:out] = v }
+    o.on('--summary PATH', 'Markdown summary output path (e.g. $GITHUB_STEP_SUMMARY)') do |v|
+      options[:summary] = v
+    end
+    o.on('--baseline-percentile N', Integer, 'Across-runs percentile for threshold (default 95)') do |v|
+      options[:baseline_percentile] = v
+    end
+  end.parse!(argv)
+  options
+end
+
+def load_runs(runs_dir)
+  Dir[File.join(runs_dir, '*', 'ratchet.json')].map do |path|
+    JSON.parse(File.read(path)).merge('source_path' => path)
+  end
+end
+
+def aggregate(runs, baseline_percentile)
+  scenario_names = runs.flat_map { |r| r.fetch('scenarios').keys }.uniq.sort
+  cpus = runs.map { |r| r.dig('environment', 'cpu') }.tally
+  scenarios = scenario_names.to_h do |name|
+    p50_samples = runs.filter_map { |r| r.dig('scenarios', name, 'p50') }.sort
+    p95_samples = runs.filter_map { |r| r.dig('scenarios', name, 'p95') }.sort
+    [name, summarize(name, p50_samples, p95_samples, baseline_percentile, runs.size)]
+  end
+  { 'scenarios' => scenarios, 'cpus' => cpus, 'run_count' => runs.size }
+end
+
+def summarize(name, p50_samples, p95_samples, baseline_percentile, run_count)
+  baseline_p50 = percentile(p50_samples, baseline_percentile)
+  baseline_p95 = percentile(p95_samples, baseline_percentile)
+  {
+    'name' => name,
+    'observed_runs' => p50_samples.size,
+    'missing_runs' => run_count - p50_samples.size,
+    'baseline_p50' => baseline_p50,
+    'baseline_p95' => baseline_p95,
+    'p50_distribution' => DEFAULT_PERCENTILES.to_h { |p| ["p#{p}", percentile(p50_samples, p)] }
+      .merge('min' => p50_samples.first, 'max' => p50_samples.last),
+    'p95_distribution' => DEFAULT_PERCENTILES.to_h { |p| ["p#{p}", percentile(p95_samples, p)] }
+      .merge('min' => p95_samples.first, 'max' => p95_samples.last)
+  }
+end
+
+def write_candidate_ratchet(out_path, agg, baseline_percentile, sample_environment)
+  payload = {
+    'environment' => sample_environment.merge(
+      'recorded_at' => Time.now.utc.iso8601,
+      'baseline_methodology' => {
+        'across_runs' => agg.fetch('run_count'),
+        'baseline_percentile' => baseline_percentile,
+        'cpus_seen' => agg.fetch('cpus')
+      }
+    ),
+    'scenarios' => agg.fetch('scenarios').to_h do |name, summary|
+                     [name, {
+                       'p50' => summary.fetch('baseline_p50'),
+                       'p95' => summary.fetch('baseline_p95'),
+                       'iterations' => 10
+                     }]
+                   end
+  }
+  File.write(out_path, "#{JSON.pretty_generate(payload)}\n")
+end
+
+def summary_header(agg, baseline_percentile)
+  buf = +''
+  buf << "## Multi-run ratchet aggregation\n\n"
+  buf << "- **Runs:** #{agg.fetch('run_count')}\n"
+  buf << "- **Baseline percentile:** p#{baseline_percentile} across runs of within-run-p50\n"
+  buf << "- **CPU models seen:**\n"
+  agg.fetch('cpus').each { |cpu, count| buf << "  - `#{cpu}` (#{count} runs)\n" }
+  buf
+end
+
+def summary_row(name, summary)
+  dist = summary.fetch('p50_distribution')
+  obs = "#{summary.fetch('observed_runs')}/#{summary.fetch('observed_runs') + summary.fetch('missing_runs')}"
+  "| `#{name}` | #{format('%.4f', dist['min'])} | #{format('%.4f', dist['p50'])} " \
+    "| #{format('%.4f', dist['p75'])} | #{format('%.4f', dist['p90'])} " \
+    "| **#{format('%.4f', summary.fetch('baseline_p50'))}** " \
+    "| #{format('%.4f', dist['p99'])} | #{format('%.4f', dist['max'])} | #{obs} |\n"
+end
+
+def write_summary(summary_path, agg, baseline_percentile)
+  out = +''
+  out << summary_header(agg, baseline_percentile)
+  out << "\n### Per-scenario p50 distribution across runs\n\n"
+  out << "| Scenario | min | p50 | p75 | p90 | p95 (baseline) | p99 | max | observed |\n"
+  out << "|---|---|---|---|---|---|---|---|---|\n"
+  agg.fetch('scenarios').each { |name, summary| out << summary_row(name, summary) }
+  out << "\n_Threshold = p#{baseline_percentile}-of-p50 across runs. " \
+         "Per scenario, #{baseline_percentile}% of runs land at or below this value._\n"
+  File.write(summary_path, out)
+end
+
+options = parse_options(ARGV)
+%i[runs_dir out summary].each do |k|
+  abort("missing --#{k.to_s.tr('_', '-')}") if options[k].nil?
+end
+
+runs = load_runs(options[:runs_dir])
+abort("no ratchet.json files found under #{options[:runs_dir]}") if runs.empty?
+
+agg = aggregate(runs, options[:baseline_percentile])
+sample_env = runs.first.fetch('environment').except('cpu', 'cores', 'recorded_at')
+write_candidate_ratchet(options[:out], agg, options[:baseline_percentile], sample_env)
+write_summary(options[:summary], agg, options[:baseline_percentile])
+
+warn "candidate ratchet written to #{options[:out]} (p#{options[:baseline_percentile]} across #{runs.size} runs)"
+agg.fetch('cpus').each { |cpu, n| warn "  cpu: #{cpu} (#{n} runs)" }

--- a/scripts/mine_ratchet_history.rb
+++ b/scripts/mine_ratchet_history.rb
@@ -1,0 +1,211 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Mine historical benchmark runs from GitHub Actions to populate a
+# multi-run sample without re-running benchmarks. Per-run benchmark
+# stdout already emits one JSON-line per scenario (see
+# benchmark/harness.rb#run_scenario); this script:
+#
+#   1. Lists recent CI runs via `gh run list` (main + closed PRs).
+#   2. For each run, finds the `full-matrix / benchmark` job and
+#      pulls the log via `gh run view --job <id> --log`.
+#   3. Greps the per-scenario JSON lines from the log.
+#   4. Synthesizes a per-run ratchet.json under a temp dir keyed by
+#      run id, containing an `environment` block (CPU model, OS) +
+#      a `scenarios` block (p50 + p95 per scenario).
+#   5. Hands the temp dir to scripts/aggregate_ratchet.rb to compute
+#      the multi-run baseline.
+#
+# Cutoff: only mine runs with head_sha at or after the perf-stable
+# cutoff (default: e574f6f, M8.4-A merge 2026-04-29). Earlier runs
+# represent different lib perf shape and would mis-calibrate.
+#
+# Usage:
+#   ruby scripts/mine_ratchet_history.rb \
+#     --cutoff-sha e574f6f \
+#     --target-runs 30 \
+#     --tmp-dir tmp/mined-ratchet
+#
+# Then invoke the aggregator on the tmp dir:
+#   ruby scripts/aggregate_ratchet.rb \
+#     --runs-dir tmp/mined-ratchet \
+#     --out tmp/candidate-ratchet.json \
+#     --summary tmp/candidate-summary.md \
+#     --baseline-percentile 95
+
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'optparse'
+require 'time'
+require 'tmpdir'
+
+DEFAULT_CUTOFF_SHA = 'e574f6f' # M8.4-A merge — perf-stable baseline
+DEFAULT_TARGET_RUNS = 30
+WORKFLOW_FILE = 'ci.yml'
+BENCHMARK_JOB_NAME = 'full-matrix / benchmark'
+SCENARIO_LINE_RX = /\{"scenario":[^}]+"env":\{[^}]+\}\}/
+
+RETRY_BACKOFFS = [1, 3, 8].freeze
+
+def gh_capture(args)
+  attempt = 0
+  loop do
+    out, err, status = Open3.capture3('gh', *args)
+    return out.force_encoding('UTF-8').scrub if status.success?
+
+    attempt += 1
+    backoff = RETRY_BACKOFFS[attempt - 1]
+    if backoff && (err.include?('502') || err.include?('503') || err.include?('timeout'))
+      warn "  gh transient failure (attempt #{attempt}); sleeping #{backoff}s"
+      sleep backoff
+      next
+    end
+    raise "gh failed: #{args.inspect}\nstderr: #{err}"
+  end
+end
+
+def gh_json(args)
+  JSON.parse(gh_capture(args))
+end
+
+def gh_text(args)
+  gh_capture(args)
+end
+
+def commit_committed_at_or_after(sha, cutoff_committer_date)
+  out, status = Open3.capture2('git', 'show', '-s', '--format=%cI', sha)
+  return false unless status.success?
+
+  Time.parse(out.strip) >= cutoff_committer_date
+rescue StandardError
+  false
+end
+
+def list_candidate_runs(cutoff_sha:, target:, repo:)
+  cutoff_date = Time.parse(gh_text(['api', "repos/#{repo}/commits/#{cutoff_sha}", '--jq',
+                                    '.commit.committer.date']).strip)
+  warn "Cutoff: #{cutoff_sha} committed at #{cutoff_date}"
+
+  page_size = [target * 4, 100].min
+  runs = gh_json([
+    'run', 'list',
+    '--repo', repo,
+    '--workflow', WORKFLOW_FILE,
+    '--status', 'completed',
+    '--limit', page_size.to_s,
+    '--json', 'databaseId,headSha,createdAt,event,conclusion'
+  ])
+
+  runs.select { |r| commit_committed_at_or_after(r['headSha'], cutoff_date) }
+end
+
+def find_benchmark_job(run_id, repo)
+  jobs = gh_json([
+    'run', 'view', run_id.to_s,
+    '--repo', repo,
+    '--json', 'jobs'
+  ]).fetch('jobs', [])
+  jobs.find { |j| j['name'] == BENCHMARK_JOB_NAME }
+end
+
+def fetch_log(job_id, repo)
+  gh_text(['run', 'view', '--repo', repo, '--job', job_id.to_s, '--log'])
+rescue StandardError => e
+  warn "  log fetch failed (job=#{job_id}): #{e.message}"
+  nil
+end
+
+def parse_scenario_lines(log)
+  log.scan(SCENARIO_LINE_RX).filter_map do |raw|
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    nil
+  end
+end
+
+def write_synthesized_ratchet(scenarios, out_path)
+  return if scenarios.empty?
+
+  env = scenarios.first.fetch('env')
+  payload = {
+    'environment' => env,
+    'scenarios' => scenarios.to_h do |s|
+      [
+        s.fetch('scenario'),
+        { 'p50' => s.fetch('p50'), 'p95' => s.fetch('p95'), 'iterations' => s.fetch('iterations') }
+      ]
+    end
+  }
+  FileUtils.mkdir_p(File.dirname(out_path))
+  File.write(out_path, "#{JSON.pretty_generate(payload)}\n")
+end
+
+def parse_options(argv)
+  options = {
+    cutoff_sha: DEFAULT_CUTOFF_SHA,
+    target_runs: DEFAULT_TARGET_RUNS,
+    tmp_dir: 'tmp/mined-ratchet',
+    repo: 'avmnu-sng/rspec-tracer'
+  }
+  OptionParser.new do |o|
+    o.on('--cutoff-sha SHA', 'Mine only runs at or after this commit (perf-stable cutoff)') do |v|
+      options[:cutoff_sha] = v
+    end
+    o.on('--target-runs N', Integer, "Target N usable runs (default #{DEFAULT_TARGET_RUNS})") do |v|
+      options[:target_runs] = v
+    end
+    o.on('--tmp-dir DIR', 'Where to write per-run ratchet.json files') { |v| options[:tmp_dir] = v }
+    o.on('--repo REPO', 'GitHub repo (owner/name)') { |v| options[:repo] = v }
+  end.parse!(argv)
+  options
+end
+
+options = parse_options(ARGV)
+FileUtils.mkdir_p(options[:tmp_dir])
+
+candidate_runs = list_candidate_runs(
+  cutoff_sha: options[:cutoff_sha],
+  target: options[:target_runs],
+  repo: options[:repo]
+)
+warn "Found #{candidate_runs.size} candidate runs at or after cutoff #{options[:cutoff_sha]}"
+
+mined = 0
+candidate_runs.each do |run|
+  break if mined >= options[:target_runs]
+
+  warn "[#{mined + 1}] run=#{run['databaseId']} sha=#{run['headSha'][0, 7]} event=#{run['event']}"
+  job = find_benchmark_job(run['databaseId'], options[:repo])
+  unless job
+    warn '  no benchmark job; skip'
+    next
+  end
+  if job['conclusion'] != 'success' && job['conclusion'] != 'failure'
+    # 'failure' is OK — the run still produced JSON lines before
+    # the ratchet check failed. Cancelled/skipped have no usable data.
+    warn "  benchmark job inconclusive (#{job['conclusion']}); skip"
+    next
+  end
+
+  log = fetch_log(job['databaseId'], options[:repo])
+  next if log.nil?
+
+  scenarios = parse_scenario_lines(log)
+  if scenarios.empty?
+    warn '  no scenario JSON lines parsed; skip'
+    next
+  end
+
+  out_path = File.join(options[:tmp_dir], "run-#{run['databaseId']}", 'ratchet.json')
+  write_synthesized_ratchet(scenarios, out_path)
+  warn "  -> wrote #{scenarios.size} scenarios from cpu=#{scenarios.first.dig('env', 'cpu')}"
+  mined += 1
+end
+
+warn "\nMined #{mined} usable runs into #{options[:tmp_dir]}/"
+warn 'Next: ruby scripts/aggregate_ratchet.rb ' \
+     "--runs-dir #{options[:tmp_dir]} " \
+     '--out tmp/candidate-ratchet.json ' \
+     '--summary tmp/candidate-summary.md ' \
+     '--baseline-percentile 95'


### PR DESCRIPTION
## Summary

GHA `ubuntu-latest` mixes 3 distinct CPU SKUs — AMD EPYC 9V74 (Zen 4), AMD EPYC 7763 (Zen 3), Intel Xeon Platinum 8370C (Ice Lake) — with 15–25% per-core IPC differences on CPU-microbench workloads. The committed `benchmark/ratchet.json` was set by M8.4-B's `regen-ratchet.yml` single run on a 9V74 runner; later runs on 7763 or 8370C have produced false-positive WARN/FAIL on identical code. Most recently: M9.0's post-merge main run hit `track_env_warm_mismatch` 1.32x **FAIL** on 7763.

Fix: re-baseline against a multi-run sample with **p95-of-p50** thresholds. 95% of runs go silent OK; the slowest 5% (slowest SKU on a noisy day) still WARN/FAIL but don't define the threshold. A real code regression on a typical SKU still pushes p50 ~10-20% → 1.10-1.30x WARN; on the slowest SKU → 1.30+ FAIL. Gating signal preserved.

## What ships

- `scripts/mine_ratchet_history.rb` — pulls per-scenario JSON lines from the last N `full-matrix / benchmark` job logs (post-M8.4-A perf-stable cutoff, default `e574f6f`) via `gh run view --log`. Synthesizes per-run `ratchet.json` files into a temp dir keyed by run id. Free, fast, no CI minutes.
- `scripts/aggregate_ratchet.rb` — consumes a directory of per-run captures, computes min/p50/p75/p90/p95/p99/max per scenario across runs, emits candidate `benchmark/ratchet.json` with p95-of-p50 + a markdown summary table.
- `.github/workflows/multi-run-ratchet.yml` — fans N=30 parallel benchmark jobs (configurable via `runs:` input), aggregator job downloads + invokes `aggregate_ratchet.rb`. The principled re-baseline mechanism for FUTURE periodic regens after material lib perf changes (where historical data would mix old + new code shape).
- `benchmark/ratchet.json` — replaced with the candidate derived from 30 mined runs (16 EPYC 7763, 11 EPYC 9V74, 3 Intel Xeon 8370C).

## Mined-run distribution

| Scenario | min | p50 | p95 (new baseline) | max | observed |
|---|---|---|---|---|---|
| `cache_load` | 0.5770 | 0.7427 | **0.7729** | 0.7831 | 30/30 |
| `cache_load_msgpack` | 0.6110 | 0.7937 | **0.8261** | 0.8287 | 30/30 |
| `cache_load_sqlite` | 0.7620 | 0.9953 | **1.0321** | 1.0359 | 30/30 |
| `cold_rails` | 5.8401 | 7.2877 | **8.4521** | 8.8201 | 30/30 |
| `cold_rails_v2` | 13.7734 | 17.0916 | **19.8368** | 21.4875 | 30/30 |
| `cold_ruby` | 0.3289 | 0.4195 | **0.4507** | 0.4688 | 30/30 |
| `coverage_adapter` | 0.9160 | 1.1594 | **1.1969** | 1.2043 | 30/30 |
| `file_read_hook` | 2.7774 | 4.5884 | **5.0953** | 5.1173 | 30/30 |
| `loaded_files_tracker` | 1.0554 | 1.3700 | **1.4107** | 1.4233 | 30/30 |
| `parallel_tests_2_workers` | 0.7758 | 0.9820 | **1.0626** | 1.8119 | 30/30 |
| `track_env_warm_mismatch` | 0.3568 | 0.3727 | **0.4020** | 0.4087 | 6/30 |
| `warm_env_mismatch` | 0.2957 | 0.3760 | **0.4099** | 0.4191 | 30/30 |
| `warm_noop` | 0.2962 | 0.3727 | **0.4044** | 0.4204 | 30/30 |

`track_env_warm_mismatch` only has 6 observations because it was added in PR #143 (2026-05-01); the rest of the mined window predates M5.3. As more runs accumulate, periodic re-baselining tightens that estimate.

## Verdict change against M9.0 main run measurements

| Scenario | M9.0 main p50 | Old verdict (9V74-baseline) | New verdict (multi-run p95) |
|---|---|---|---|
| `track_env_warm_mismatch` | 0.357 | 1.16x WARN (or 1.32x FAIL on a 7763 day) | **0.89x OK** |
| `coverage_adapter` | 1.145 | 1.21x WARN | **0.96x OK** |
| `cache_load` | 0.734 | 1.16x WARN | **0.95x OK** |
| `cache_load_msgpack` | 0.783 | 1.18x WARN | **0.95x OK** |
| `file_read_hook` | 4.477 | 1.12x WARN | **0.88x OK** |
| `loaded_files_tracker` | 1.360 | 1.23x WARN | **0.96x OK** |

## Test plan

- [x] `task benchmark:smoke` passes against the new ratchet on M2 Max (cold_ruby + warm_noop both ~0.55-0.61x of new threshold; expected since M2 Max is faster than every GHA SKU).
- [x] `task lint:ruby` + `lint:actions` + `lint:yaml` clean on the new scripts + workflow.
- [ ] CI `full-matrix / benchmark` lands silent OK on this PR's run (verifies the new baseline holds for a typical run).
- [ ] (Future, optional) `gh workflow run multi-run-ratchet.yml --ref main --field runs=30` after the next material lib perf change, to regen against fresh measurements.

## Notes

- Methodology codified in `feedback_gha_runner_cpu_heterogeneity_ratchet_seeding` memory.
- Supersedes `feedback_gha_benchmark_runner_variance` for the SKU-heterogeneity case (which is repeatable, not pure runner noise). Both forces compose.
- Container-seeded scenarios (`feedback_targeted_ratchet_seeding_via_container` shape) like `track_env_warm_mismatch` will be off-true initially because the M2-Max-arm64 container measurement doesn't predict GHA x86_64; treat them as provisional + plan to re-baseline after 10-20 historical runs accumulate. This PR makes that re-baselining a one-line script invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)