### PR TITLE
feat: pre-2.0.0.pre.1 polish (round 2) — parallel-aware reporters + integration coverage + CI recipes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,13 +107,18 @@ group :development do
   # gem is only required there, never by lib/ code.
   gem 'stackprof', '~> 0.2' if RUBY_ENGINE == 'ruby'
 
-  # Coexistence smoke specs (M9.0). Used only by spec/regressions/
-  # rspec_retry_coexistence_spec.rb + rspec_rerun_coexistence_spec.rb
-  # to verify that popular RSpec extensions compose with rspec-tracer's
-  # Module#prepend chain on RSpec::Core::Runner / Reporter. Installed
-  # by default but never required by lib/ or unit specs - the
-  # regression specs explicitly require them in subprocess shape, so
-  # the outer rspec process is unaffected.
+  # Coexistence smoke specs (M9.0 + M8.10). Used only by
+  # spec/regressions/*_coexistence_spec.rb to verify that popular
+  # RSpec extensions compose with rspec-tracer's Module#prepend chain
+  # on RSpec::Core::Runner / Reporter. Installed by default but never
+  # required by lib/ or unit specs - the regression specs explicitly
+  # require them in subprocess shape, so the outer rspec process is
+  # unaffected. M8.10 adds knapsack (free, local-only test-splitter)
+  # to round out the M9.0 retry+rerun coverage; knapsack_pro shares
+  # the same RSpec hook surface but requires an API key and a
+  # network-bound service, so the smoke uses `knapsack` as the
+  # composition fingerprint.
+  gem 'knapsack', '~> 4.0'
   gem 'rspec-rerun', '~> 1.1'
   gem 'rspec-retry', '~> 0.6'
 end

--- a/docs/CI_RECIPES.md
+++ b/docs/CI_RECIPES.md
@@ -1,0 +1,256 @@
+# CI recipes for rspec-tracer
+
+The canonical GitHub Actions pattern lives at
+[`.github/workflows/example-tracer-cache.yml`](../.github/workflows/example-tracer-cache.yml)
+(M8.4-D). This doc translates the same cache-key shape to four other
+popular CI providers — **CircleCI**, **GitLab CI**, **Buildkite**,
+and **Heroku CI**. The cache contract is the same on every platform:
+
+> Persist `rspec_tracer_cache/` across runs, keyed on the inputs that
+> change the cache layout: OS + Ruby version + rspec-tracer gem
+> version + project Gemfile.
+
+If any of those four inputs differs, the cache is invalidated and
+the next run is cold. If all four match, the next run restores the
+prior cache and rspec-tracer skips unchanged examples per its
+dependency-tracking contract.
+
+## Cache key shape
+
+The 4-component canonical key (per
+[ARCHITECTURE.md](../ARCHITECTURE.md) + the `feedback_actions_cache_traps`
+memory) is:
+
+```
+<os>-<ruby-version>-<tracer-version>-<gemfile-hash>
+```
+
+- **`<os>`** — runner platform (`linux` / `macos`). Native gem
+  binaries (sqlite3, nokogiri) are not portable across OS.
+- **`<ruby-version>`** — language ABI gate. A Ruby 3.3 → 3.4 bump
+  flips native ext compat for many gems.
+- **`<tracer-version>`** — the rspec-tracer gem version itself.
+  Cache schemas can change across tool versions; restoring an
+  old-shape cache after an upgrade is a wasted restore.
+- **`<gemfile-hash>`** — content hash of the project's Gemfile (or
+  Gemfile.lock if committed). Manifest edits are the most common
+  reason a previously-populated cache is out of date.
+
+Pair the exact key with a `restore-keys`-style ladder where
+supported (manifest hash drops first, then tool-version, then
+lang-version) so a Gemfile bump still warm-starts from the closest
+prior shape rather than going fully cold.
+
+---
+
+## CircleCI
+
+```yaml
+# .circleci/config.yml
+version: 2.1
+
+jobs:
+  rspec:
+    docker:
+      - image: cimg/ruby:3.3.10
+    steps:
+      - checkout
+
+      - run:
+          name: bundle install
+          command: bundle install --path vendor/bundle
+
+      # Restore rspec_tracer_cache/ from a prior run. CircleCI's
+      # `restore_cache` walks the keys in order, restoring the first
+      # match. The exact key carries every invalidation input; the
+      # fallback prefixes progressively widen the match.
+      - restore_cache:
+          keys:
+            - rspec-tracer-v1-{{ arch }}-ruby-3.3.10-tracer-2.0.0-{{ checksum "Gemfile.lock" }}
+            - rspec-tracer-v1-{{ arch }}-ruby-3.3.10-tracer-2.0.0-
+            - rspec-tracer-v1-{{ arch }}-ruby-3.3.10-
+
+      - run:
+          name: rspec
+          command: bundle exec rspec
+
+      # Save freshly-updated rspec_tracer_cache/ back under the same
+      # exact key. If the same key already has an entry, CircleCI
+      # writes the new content (last-write-wins).
+      - save_cache:
+          key: rspec-tracer-v1-{{ arch }}-ruby-3.3.10-tracer-2.0.0-{{ checksum "Gemfile.lock" }}
+          paths:
+            - rspec_tracer_cache
+```
+
+**Notes:**
+
+- `{{ arch }}` covers the OS axis on CircleCI's machine executors.
+- Bump the prefix (`rspec-tracer-v1-...`) when the rspec-tracer schema
+  bumps; CircleCI keys are immutable so a manual prefix bump is the
+  invalidation lever.
+- For matrix builds across Ruby versions, parameterize the key:
+  `ruby-{{ matrix.ruby }}` instead of the literal `3.3.10`.
+
+---
+
+## GitLab CI
+
+```yaml
+# .gitlab-ci.yml
+image: ruby:3.3.10
+
+cache:
+  # GitLab cache keys support a `files:` array + a per-file fallback
+  # ladder via `key:files:`. Pair that with a literal prefix so the
+  # tracer-version bump is a single string edit.
+  key:
+    prefix: rspec-tracer-v1-ruby-3.3.10-tracer-2.0.0
+    files:
+      - Gemfile.lock
+  paths:
+    - rspec_tracer_cache/
+
+rspec:
+  script:
+    - bundle install --path vendor/bundle
+    - bundle exec rspec
+```
+
+**Notes:**
+
+- GitLab's cache is per-job by default. To share across job
+  branches, set `cache:policy: pull-push` (default) and ensure the
+  `key:` shape matches across the jobs that should hit the same
+  cache.
+- The `files:` array hashes the listed files into the key; if
+  Gemfile.lock isn't committed, swap to `Gemfile` (less precise but
+  stable enough for the warm-cache common case).
+- For multi-Ruby matrix:
+  ```yaml
+  parallel:
+    matrix:
+      - RUBY_VERSION: ['3.1.6', '3.2.5', '3.3.10', '3.4.1']
+  cache:
+    key:
+      prefix: rspec-tracer-v1-ruby-${RUBY_VERSION}-tracer-2.0.0
+      files: [Gemfile.lock]
+    paths: [rspec_tracer_cache/]
+  ```
+
+---
+
+## Buildkite
+
+```yaml
+# .buildkite/pipeline.yml
+steps:
+  - label: ":rspec: rspec"
+    command: |
+      bundle install --path vendor/bundle
+      bundle exec rspec
+    plugins:
+      - cache#v1.7.1:
+          # Cache key composes the four invalidation inputs; the
+          # fallback list is a manual restore-keys ladder.
+          manifest:
+            - Gemfile.lock
+          path: rspec_tracer_cache
+          restore: pipeline
+          save: pipeline
+          key: |
+            v1-rspec-tracer-{{ os }}-ruby-3.3.10-tracer-2.0.0-{{ hash "Gemfile.lock" }}
+          fallback_keys:
+            - v1-rspec-tracer-{{ os }}-ruby-3.3.10-tracer-2.0.0-
+            - v1-rspec-tracer-{{ os }}-ruby-3.3.10-
+```
+
+**Notes:**
+
+- The `cache#v1.x` plugin (Buildkite's official plugin) provides
+  S3-backed cache out of the box; configure the bucket via the
+  plugin's `s3_bucket` option or the agent's `BUILDKITE_PLUGIN_CACHE_S3_BUCKET`
+  env var.
+- `{{ os }}` substitutes the runner OS via the plugin's template
+  language; `{{ hash "Gemfile.lock" }}` produces a deterministic
+  short hash.
+- For matrix builds across Ruby versions, factor the version into a
+  pipeline-level env var and substitute via `{{ env "RUBY_VERSION" }}`.
+
+---
+
+## Heroku CI
+
+Heroku CI's `app.json` doesn't expose a built-in cache primitive
+the way the other providers do, so the canonical pattern uses an S3
+bucket via rspec-tracer's own remote-cache backend (the rake-task
+flow rspec-tracer's README documents). The cache invalidation
+inputs are the same four; the storage substrate is S3 instead of
+the CI provider's built-in cache.
+
+```json
+{
+  "name": "myapp",
+  "environments": {
+    "test": {
+      "scripts": {
+        "test-setup": "bundle exec rake rspec_tracer:remote_cache:download",
+        "test": "bundle exec rspec",
+        "test-teardown": "bundle exec rake rspec_tracer:remote_cache:upload"
+      },
+      "env": {
+        "GIT_DEFAULT_BRANCH": "main",
+        "GIT_BRANCH": "$HEROKU_TEST_RUN_BRANCH",
+        "RSPEC_TRACER_REMOTE_CACHE_URI": "s3://my-bucket/rspec-tracer"
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+
+- The S3 bucket is the storage substrate; rspec-tracer's two-tier
+  layout (`main/<sha>/`, `pr/<branch>/<sha>/`) provides the same
+  cold/warm cycle as the platform-built-in caches above.
+- `HEROKU_TEST_RUN_BRANCH` is Heroku CI's own env var; map it to
+  `GIT_BRANCH` so rspec-tracer's PR-tier resolution works.
+- AWS creds (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`) belong
+  in Heroku CI's encrypted env, not in `app.json`.
+- The same pattern works on any CI provider that does NOT have a
+  native cache primitive — the rspec-tracer remote-cache backend
+  abstracts the substrate.
+
+---
+
+## Validating the cache works end-to-end
+
+After landing one of the recipes above, verify on the next two
+runs:
+
+1. **Cold first run** — no prior cache; rspec-tracer runs every
+   example; on success the cache writes back at job-end.
+2. **Warm second run** — cache restores; rspec-tracer reads
+   `last_run.json`, finds matching dependencies for unchanged
+   examples, and emits a "skipped" terminal line for them. Look
+   for the `rspec-tracer: N examples tracked · M re-run · K
+   skipped (X% cached)` line in the run output.
+
+If the warm run shows `0% cached` despite the cache restoring, one
+of the invalidation inputs differs run-to-run (typically a
+timestamp baked into the Gemfile hash or a runner-OS mismatch).
+Run `bundle exec rspec-tracer doctor` locally with the same cache
+to diagnose; the doctor's `schema:` + `cache_path:` + `git:` lines
+surface the typical culprits.
+
+---
+
+## See also
+
+- [`ARCHITECTURE.md`](../ARCHITECTURE.md) — the input-taxonomy +
+  schema-versioning model that drives cache invalidation.
+- [`.github/workflows/example-tracer-cache.yml`](../.github/workflows/example-tracer-cache.yml)
+  — the GHA reference workflow these recipes translate.
+- README "Configuring CI" section — the rake-task flow for projects
+  that prefer rspec-tracer's own remote-cache backend over the CI
+  provider's built-in cache.

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -166,7 +166,16 @@ module RSpecTracer
         RSpecTracer.logger.info 'Skipped reports generation since all examples were filtered out'
       else
         snapshot = run_finalize
-        emit_reporters(snapshot) if snapshot
+        # M8.10: under parallel_tests, defer reporter emission until
+        # last-process finalize merges per-worker snapshots into the
+        # top-level cache. Each worker still persists its per-worker
+        # snapshot for the merge to consume. Pre-M8.10 every worker
+        # emitted reporters into rspec_tracer_report/parallel_tests_N/
+        # and purge_worker_dirs! removed those dirs - leaving the user
+        # with no usable terminal/JSON/HTML output. Now reporters fire
+        # ONCE at the merged top-level location (3x v1 orphan: M6.2 +
+        # M7.1 + M7.2).
+        emit_reporters(snapshot) if snapshot && !parallel_tests?
       end
 
       emit_coverage_json

--- a/lib/rspec_tracer/rspec/parallel_tests.rb
+++ b/lib/rspec_tracer/rspec/parallel_tests.rb
@@ -87,6 +87,14 @@ module RSpecTracer
 
         merge_snapshot!
         merge_coverage! unless RSpecTracer.simplecov?
+        # M8.10: emit terminal/JSON/HTML reporters ONCE at the merged
+        # top-level location BEFORE purge_worker_dirs! removes the
+        # per-worker `parallel_tests_N` dirs. Pre-M8.10 each worker
+        # emitted reports into its `rspec_tracer_report/parallel_tests_N`
+        # dir and the purge then deleted them, leaving the user with
+        # zero usable output. Now reporters consume the just-merged
+        # top-level snapshot.
+        emit_merged_reporters!
         purge_worker_dirs!
         remove_lock_file!
         true
@@ -95,6 +103,54 @@ module RSpecTracer
           "RSpec tracer: parallel_tests finalize failed (#{e.class}: #{e.message})"
         )
         false
+      end
+
+      # M8.10: Emit reporters against the merged top-level snapshot
+      # so the user gets one terminal summary + one JSON report + one
+      # HTML report at the canonical (non-`parallel_tests_N`) path.
+      # Wrapped in its own rescue so a failed reporter never blocks
+      # purge / lock cleanup downstream.
+      def self.emit_merged_reporters!
+        return unless RSpecTracer.storage_backend == :json
+
+        base_dir = ::File.dirname(RSpecTracer.cache_path)
+        merged_snapshot = load_merged_snapshot(base_dir)
+        return if merged_snapshot.nil?
+
+        top_report_dir = ::File.dirname(RSpecTracer.report_path)
+        ::FileUtils.mkdir_p(top_report_dir)
+
+        RSpecTracer::Reporters::Registry.emit_all(
+          configuration: RSpecTracer,
+          snapshot: merged_snapshot,
+          report_dir: top_report_dir,
+          run_metadata: build_merged_run_metadata(base_dir)
+        )
+      rescue StandardError => e
+        RSpecTracer.logger.warn(
+          "RSpec tracer: merged reporter emission failed (#{e.class}: #{e.message})"
+        )
+      end
+
+      def self.load_merged_snapshot(base_dir)
+        backend = RSpecTracer::Storage::JsonBackend.new(
+          cache_path: base_dir,
+          logger: RSpecTracer.logger,
+          retention_local_count: RSpecTracer.cache_retention_local_count,
+          serializer: RSpecTracer.storage_backend_opts[:serializer] || :json
+        )
+        backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      end
+
+      def self.build_merged_run_metadata(base_dir)
+        {
+          pid: Process.pid,
+          run_time: nil,
+          started_at: nil,
+          cache_path: base_dir,
+          parallel_tests: true,
+          rails: RSpecTracer.rails?
+        }
       end
 
       def self.track_test_env_number!

--- a/spec/integration/non_git_repo_spec.rb
+++ b/spec/integration/non_git_repo_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+# M8.10: rspec-tracer in a non-git directory (graceful degradation).
+#
+# Real-world scenarios where this happens:
+#   - User runs rspec in a tarball-extracted source dir.
+#   - User invokes from a Docker context that copied code without
+#     `.git/`.
+#   - User starts a fresh project with `bundle init` + a few specs
+#     before running `git init`.
+#
+# The engine's main code path does NOT depend on git — only the
+# remote-cache surface (UserTasks + GitAncestry) does. So a non-git
+# invocation should:
+#
+#   1. Run rspec to completion without crashing.
+#   2. Write the canonical cache + reports.
+#   3. NOT shell out to `git` from any non-remote-cache code path
+#      (boot, tracker, filter, reporters).
+#
+# Drives a subprocess inside `Bundler.with_unbundled_env` + a tmpdir
+# CWD to ensure no `.git/` is reachable from the project root or any
+# parent directory; verifies the run produces a usable cache.
+#
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'rspec-tracer in a non-git working directory (M8.10)' do
+  let(:project_root) { File.expand_path('../..', __dir__) }
+  let(:gemfile_path) { File.join(project_root, 'Gemfile') }
+
+  let(:inline_spec_body) do
+    <<~RUBY
+      require "rspec_tracer"
+      RSpecTracer.start
+
+      RSpec.describe "non-git invocation" do
+        it "runs to completion without crashing on missing git history" do
+          expect(true).to be(true)
+        end
+
+        it "exercises a second example for cache + dependency tracking" do
+          expect(2 + 2).to eq(4)
+        end
+      end
+    RUBY
+  end
+
+  it 'runs rspec to completion + writes a usable cache without a .git/ directory present' do
+    Dir.mktmpdir do |dir|
+      # Verify no .git/ reachable from the run dir or any ancestor we
+      # might walk through. Dir.mktmpdir defaults to /tmp/* (or
+      # /var/folders/* on macOS); the chosen dir is git-detached.
+      expect(File.directory?(File.join(dir, '.git'))).to be(false)
+
+      spec_path = File.join(dir, 'non_git_smoke_spec.rb')
+      File.write(spec_path, inline_spec_body)
+
+      out, status = Bundler.with_unbundled_env do
+        env = {
+          'BUNDLE_GEMFILE' => gemfile_path,
+          # No GIT_DEFAULT_BRANCH / GIT_BRANCH set: covers the
+          # "user just runs rspec in a scratch dir" case where
+          # remote_cache is not configured and the engine should
+          # never try to shell out to git on its own.
+          'GIT_DEFAULT_BRANCH' => nil,
+          'GIT_BRANCH' => nil
+        }
+        Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color', spec_path,
+                        chdir: dir)
+      end
+
+      expect(status.success?).to(
+        be(true),
+        "rspec subprocess in non-git dir failed (exit=#{status.exitstatus}):\n#{out}"
+      )
+
+      cache_dir = File.join(dir, 'rspec_tracer_cache')
+      manifest_path = File.join(cache_dir, 'last_run.json')
+      expect(File).to(
+        exist(manifest_path),
+        "expected rspec-tracer cache manifest at #{manifest_path}; got: " \
+        "#{Dir.exist?(cache_dir) ? Dir.children(cache_dir).inspect : '(no cache dir)'}"
+      )
+
+      manifest = JSON.parse(File.read(manifest_path, encoding: 'UTF-8'))
+      run_id = manifest.fetch('run_id')
+      all_examples = JSON.parse(File.read(File.join(cache_dir, run_id, 'all_examples.json'), encoding: 'UTF-8'))
+      expect(all_examples.size).to eq(2)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/integration/parallel_tests_spec.rb
+++ b/spec/integration/parallel_tests_spec.rb
@@ -116,6 +116,27 @@ RSpec.describe 'parallel_tests v2 engine integration' do
       expect(all_examples.keys).not_to be_empty
       expect(all_examples.keys.size).to be >= 3
     end
+
+    # M8.10: pre-fix, every worker emitted reports into per-worker
+    # `parallel_tests_N` dirs and then `purge_worker_dirs!` deleted
+    # them, leaving zero usable output for the user. Now the
+    # last-process merge emits reporters ONCE at the top-level
+    # location BEFORE the purge, so the user sees one HTML report,
+    # one JSON report, and zero leftover per-worker report dirs.
+    # rubocop:disable RSpec/ExampleLength
+    it 'writes a single merged HTML + JSON report at the top-level report dir (M8.10)' do
+      run_parallel
+
+      report_root = ParallelTestsSpecHelpers::REPORT_ROOT
+      expect(File).to(exist(File.join(report_root, 'index.html')),
+                      'expected merged HTML report at rspec_tracer_report/index.html')
+      expect(File).to(exist(File.join(report_root, 'report.json')),
+                      'expected merged JSON report at rspec_tracer_report/report.json')
+
+      stragglers = Dir.glob(File.join(report_root, 'parallel_tests_*'))
+      expect(stragglers).to(be_empty, "leftover per-worker report dirs: #{stragglers.inspect}")
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 
   describe 'warm parallel run' do

--- a/spec/integration/remote_cache_local_fs_spec.rb
+++ b/spec/integration/remote_cache_local_fs_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'securerandom'
+require 'tmpdir'
+
+require 'rspec_tracer/remote_cache/local_fs_backend'
+require 'rspec_tracer/storage/schema'
+
+# M8.10: Local-FS remote-cache integration spec.
+#
+# Mirrors `spec/integration/remote_cache_spec.rb`'s S3Backend
+# round-trip shape against a tmpdir-backed Local-FS root. The S3 +
+# Redis backends had integration coverage; LocalFs only had unit
+# tests in `spec/remote_cache/local_fs_backend_spec.rb` until M8.10
+# closed the parity gap.
+#
+# Asserts on the content of what was uploaded / downloaded
+# (per `feedback_v2_integration_exit_status`: exit-status checks
+# mask cache-persistence bugs). The round-trip proves the two-tier
+# layout matches S3 semantics + the schema_version envelope is
+# preserved across the archive boundary.
+#
+# rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable
+# rubocop:disable RSpec/BeforeAfterAll, RSpec/MultipleExpectations
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe 'RemoteCache::LocalFsBackend round-trip integration (M8.10)' do
+  let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
+
+  before(:all) do
+    @local_fs_root = Dir.mktmpdir('rspec-tracer-localfs-it')
+  end
+
+  after(:all) do
+    FileUtils.rm_rf(@local_fs_root) if @local_fs_root
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @cache_path = dir
+      example.run
+    end
+  end
+
+  def write_local_cache(run_id: 'run-abc-123')
+    File.write(
+      File.join(@cache_path, 'last_run.json'),
+      JSON.pretty_generate(
+        'schema_version' => current_schema,
+        'run_id' => run_id,
+        'timestamp' => Time.now.utc.iso8601
+      )
+    )
+    FileUtils.mkdir_p(File.join(@cache_path, run_id))
+    File.write(
+      File.join(@cache_path, run_id, 'all_examples.json'),
+      JSON.pretty_generate('examples' => { 'ex1' => 'passed' })
+    )
+    File.write(
+      File.join(@cache_path, run_id, 'dependency.json'),
+      JSON.pretty_generate('ex1' => ['lib/foo.rb'])
+    )
+  end
+
+  def build_backend(branch:, default_branch: 'main', test_suite_id: nil, root_subdir: nil)
+    root = File.join(@local_fs_root, root_subdir || SecureRandom.hex(4))
+    RSpecTracer::RemoteCache::LocalFsBackend.new(
+      root: root,
+      branch: branch,
+      default_branch: default_branch,
+      test_suite_id: test_suite_id,
+      cache_path: @cache_path
+    )
+  end
+
+  describe 'upload + download round-trip on main tier' do
+    it 'preserves last_run.json and the run-dir contents byte-for-byte' do
+      backend = build_backend(branch: 'main', default_branch: 'main',
+                              root_subdir: "main-tier-#{SecureRandom.hex(4)}")
+      write_local_cache(run_id: 'run-main')
+      original_content = File.read(File.join(@cache_path, 'run-main', 'all_examples.json'),
+                                   encoding: 'UTF-8')
+
+      backend.upload('main-sha-1')
+
+      # Wipe the local cache and re-download into it.
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      result = backend.download('main-sha-1')
+
+      expect(result).to be(true)
+      expect(File.read(File.join(@cache_path, 'run-main', 'all_examples.json'),
+                       encoding: 'UTF-8'))
+        .to eq(original_content)
+      manifest = JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))
+      expect(manifest['schema_version']).to eq(current_schema)
+    end
+  end
+
+  describe 'upload + download round-trip on pr tier' do
+    it 'uploads under pr/<branch>/<sha>/ and downloads cleanly' do
+      backend = build_backend(branch: 'feat-123', default_branch: 'main',
+                              root_subdir: "pr-tier-#{SecureRandom.hex(4)}")
+      write_local_cache(run_id: 'run-pr')
+
+      backend.upload('feat-sha-1')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      expect(backend.download('feat-sha-1')).to be(true)
+
+      manifest = JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))
+      expect(manifest['run_id']).to eq('run-pr')
+    end
+  end
+
+  describe 'pr-tier download falls back to main-tier on miss' do
+    it 'finds the upstream main-tier cache when no pr-tier cache exists for the SHA' do
+      shared_root = "shared-#{SecureRandom.hex(4)}"
+      main_backend = build_backend(branch: 'main', default_branch: 'main', root_subdir: shared_root)
+      write_local_cache(run_id: 'run-main-fallback')
+      main_backend.upload('shared-sha-1')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      pr_backend = build_backend(branch: 'feat-fallback', default_branch: 'main', root_subdir: shared_root)
+
+      # The PR tier has nothing under feat-fallback/shared-sha-1; the
+      # backend should fall back to main/shared-sha-1 and succeed.
+      expect(pr_backend.download('shared-sha-1')).to be(true)
+      manifest = JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))
+      expect(manifest['run_id']).to eq('run-main-fallback')
+    end
+  end
+
+  describe 'test_suite_id scoping' do
+    it 'isolates uploads by test_suite_id (sharded suites do not collide)' do
+      shared_root = "sharded-#{SecureRandom.hex(4)}"
+
+      backend_a = build_backend(branch: 'main', default_branch: 'main',
+                                test_suite_id: 'shard-a', root_subdir: shared_root)
+      write_local_cache(run_id: 'run-shard-a')
+      backend_a.upload('multi-shard-sha')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      backend_b = build_backend(branch: 'main', default_branch: 'main',
+                                test_suite_id: 'shard-b', root_subdir: shared_root)
+      write_local_cache(run_id: 'run-shard-b')
+      backend_b.upload('multi-shard-sha')
+
+      # Each suite's cache lives in its own shard-A or shard-B path.
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      expect(backend_a.download('multi-shard-sha')).to be(true)
+      expect(JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))['run_id']).to eq('run-shard-a')
+
+      FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))
+      expect(backend_b.download('multi-shard-sha')).to be(true)
+      expect(JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))['run_id']).to eq('run-shard-b')
+    end
+  end
+
+  describe 'graceful degradation on malformed remote cache' do
+    # The download contract per the lib comment is: "Cleans up
+    # partially-extracted state on failure." So a failed download
+    # leaves the local cache in a known cold-run-able state, NOT in
+    # the prior contents. The user-facing assurance is: download
+    # returns false + no raise propagates into the caller (matches
+    # the gem-wide graceful-degradation contract).
+    it 'returns false without raising when the archive is corrupt' do
+      backend = build_backend(branch: 'main', default_branch: 'main',
+                              root_subdir: "corrupt-#{SecureRandom.hex(4)}")
+      write_local_cache(run_id: 'run-corrupt')
+      backend.upload('sha-corrupt')
+
+      # Corrupt the on-remote archive so download has something to fail on.
+      archive = Dir.glob(File.join(@local_fs_root, '*', 'main', 'sha-corrupt', 'cache.tar.gz')).first
+      raise 'archive missing post-upload' if archive.nil?
+
+      File.write(archive, 'not a real tar.gz')
+
+      expect { @result = backend.download('sha-corrupt') }.not_to raise_error
+      expect(@result).to be(false)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/InstanceVariable
+# rubocop:enable RSpec/BeforeAfterAll, RSpec/MultipleExpectations
+# rubocop:enable RSpec/ExampleLength

--- a/spec/integration/schema_version_upgrade_spec.rb
+++ b/spec/integration/schema_version_upgrade_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+require 'rspec_tracer/storage/json_backend'
+require 'rspec_tracer/storage/schema'
+
+# M8.10: 1.x -> 2.0 cache schema-version cold-run integration spec.
+#
+# The 1.x cache shape on disk wrote `last_run.json` WITHOUT a
+# `schema_version` field (or under an older numeric value); the 2.0
+# JsonBackend's `load_graph` checks `Schema.supported?(stored) &&
+# stored == schema_version` and falls through to a cold run with an
+# info-level log when the stored shape is incompatible.
+#
+# Every existing 1.x user hits this code path on first 2.0 upgrade.
+# Pre-M8.10 the path was wired but no integration spec exercised the
+# actual upgrade ceremony; M8.9 doctor's `cache_schema_version_check`
+# surfaces the state at diagnostic time, but the lib-level handling
+# was unverified at integration level. This spec drives the
+# JsonBackend with three concrete 1.x-shaped cache fixtures (no
+# schema_version field / older numeric / unsupported new shape) and
+# asserts the contract:
+#
+#   - load_graph returns nil (graceful degradation; never raises)
+#   - logger.info fires with a 'cold run' message
+#   - save_graph still works after the cold-run fallback (next run
+#     writes a fresh schema_version-tagged manifest)
+#
+# Per `feedback_v2_integration_exit_status`: assert on the contract
+# behavior (logger output + nil return + post-fallback save), not
+# just on absence-of-raise.
+# rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable, RSpec/ContextWording
+# rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'Storage::JsonBackend 1.x -> 2.0 cache schema cold-run upgrade ceremony (M8.10)' do
+  let(:logger) { instance_double(RSpecTracer::Logger, debug: nil, info: nil, warn: nil, error: nil) }
+  let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @cache_path = dir
+      example.run
+    end
+  end
+
+  def write_legacy_manifest(payload)
+    FileUtils.mkdir_p(@cache_path)
+    File.write(File.join(@cache_path, 'last_run.json'), JSON.dump(payload))
+  end
+
+  def write_legacy_run_dir(run_id, files)
+    run_dir = File.join(@cache_path, run_id.to_s)
+    FileUtils.mkdir_p(run_dir)
+    files.each { |name, content| File.write(File.join(run_dir, name), content) }
+  end
+
+  def build_backend
+    RSpecTracer::Storage::JsonBackend.new(
+      cache_path: @cache_path,
+      logger: logger
+    )
+  end
+
+  context 'when the on-disk cache predates schema_version (1.x layout)' do
+    before do
+      # 1.x layout: last_run.json carries `last_run` + `pid` only,
+      # no schema_version field at all. The run dir holds the 10
+      # legacy files keyed off `last_run`.
+      write_legacy_manifest('last_run' => '20240115T103045', 'pid' => 12_345)
+      write_legacy_run_dir(
+        '20240115T103045',
+        'all_examples.json' => JSON.dump('legacy[1:1]' => { 'description' => '...' })
+      )
+    end
+
+    it 'falls back to a cold run gracefully' do
+      result = build_backend.load_graph(schema_version: current_schema)
+
+      expect(result).to be_nil
+    end
+
+    it 'emits an info-level cold-run log line that names the mismatch' do
+      build_backend.load_graph(schema_version: current_schema)
+
+      expect(logger).to have_received(:info)
+        .with(a_string_including('schema_version mismatch').and(a_string_including('cold run')))
+    end
+  end
+
+  context 'when the on-disk cache carries an older numeric schema (e.g. 1 or 2)' do
+    before do
+      write_legacy_manifest('schema_version' => 1, 'run_id' => 'old-run')
+      write_legacy_run_dir('old-run', 'all_examples.json' => JSON.dump({}))
+    end
+
+    it 'falls back to cold run + logs the version delta' do
+      result = build_backend.load_graph(schema_version: current_schema)
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:info)
+        .with(a_string_including('stored=1').and(a_string_including('cold run')))
+    end
+  end
+
+  context 'when the on-disk cache carries a future / unsupported schema' do
+    before do
+      write_legacy_manifest('schema_version' => 999_999, 'run_id' => 'future-run')
+    end
+
+    it 'falls back to cold run rather than crashing on the unknown shape' do
+      result = build_backend.load_graph(schema_version: current_schema)
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:info).with(a_string_including('cold run'))
+    end
+  end
+
+  context 'after the cold-run fallback fires' do
+    let(:backend) { build_backend }
+    let(:current_run_id) { 'fresh-run-2.0' }
+
+    before do
+      # Drop a 1.x-shaped manifest so load_graph returns nil + logs.
+      write_legacy_manifest('last_run' => '20240115T103045')
+      backend.load_graph(schema_version: current_schema)
+    end
+
+    # The cold-run fallback must not corrupt the cache directory
+    # so the NEXT run's save_graph writes a fresh schema_version-
+    # tagged manifest cleanly. Mirrors the user's experience:
+    # first run after upgrade is silent cold, second run is warm
+    # against the 2.0 schema.
+    it 'allows save_graph to write a fresh 2.0 manifest on the next run' do
+      empty_snapshot = RSpecTracer::Storage::Snapshot.empty(
+        schema_version: current_schema, run_id: current_run_id
+      )
+
+      backend.save_graph(empty_snapshot, schema_version: current_schema)
+
+      manifest = JSON.parse(File.read(File.join(@cache_path, 'last_run.json')))
+      expect(manifest['schema_version']).to eq(current_schema)
+      expect(manifest['run_id']).to eq(current_run_id)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/InstanceVariable, RSpec/ContextWording
+# rubocop:enable RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/regressions/knapsack_coexistence_spec.rb
+++ b/spec/regressions/knapsack_coexistence_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+# M8.10: knapsack composition smoke spec.
+#
+# knapsack (https://github.com/KnapsackPro/knapsack) is the dominant
+# free test-splitter on production Rails CI - it pre-filters which
+# spec files run on each CI node so the suite parallelizes across
+# machines. M9.0 shipped coexistence smokes for rspec-retry +
+# rspec-rerun (which prepend RSpec::Core::Example / register a
+# Formatter); knapsack hooks into RSpec.configure callbacks +
+# logs example timings. Different surface from retry/rerun but the
+# same composition concern: rspec-tracer's RunnerHook prepends
+# RSpec::Core::Runner; the two should coexist without raise.
+#
+# Smoke contract:
+#   1. Both gems load alongside each other without raising at boot.
+#   2. A knapsack-bound rspec subprocess with rspec-tracer also
+#      active completes the run.
+#   3. The rspec-tracer cache writes successfully (run_id manifest
+#      + all_examples.json present after the run).
+#
+# Drives a subprocess inside `Bundler.with_unbundled_env` + a tmpdir
+# CWD so the inline test specs don't pollute the project's
+# rspec_tracer_cache + the outer rspec process never loads
+# knapsack's RSpec.configure side-effects (which would otherwise
+# affect every subsequent in-process spec). The outer Gemfile
+# carries knapsack in the :development group (require: false default)
+# so the subprocess can require it on demand.
+#
+# Per `feedback_v2_integration_exit_status`: the cache-state
+# assertion (not just exit-status) is the load-bearing check.
+#
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+require 'tmpdir'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe 'knapsack coexistence (smoke; M8.10)' do
+  let(:project_root) { File.expand_path('../..', __dir__) }
+  let(:gemfile_path) { File.join(project_root, 'Gemfile') }
+
+  let(:inline_spec_body) do
+    <<~RUBY
+      require "rspec_tracer"
+      RSpecTracer.start
+
+      require "knapsack"
+      Knapsack::Adapters::RspecAdapter.bind
+
+      RSpec.describe "knapsack composes with rspec-tracer" do
+        it "passes alongside knapsack's RSpec.configure hooks" do
+          expect(true).to be(true)
+        end
+
+        it "exercises a second example for cache + dependency tracking" do
+          expect(2 + 2).to eq(4)
+        end
+      end
+    RUBY
+  end
+
+  it 'loads both gems without raising and writes a usable rspec-tracer cache' do
+    Dir.mktmpdir do |dir|
+      spec_path = File.join(dir, 'knapsack_smoke_spec.rb')
+      File.write(spec_path, inline_spec_body)
+
+      # knapsack's after(:suite) hook reads `knapsack_rspec_report.json`
+      # to compare per-example timings against the saved baseline. On
+      # first run the file doesn't exist; pre-creating an empty
+      # report keeps the smoke focused on COMPOSITION (does
+      # rspec-tracer + knapsack load + run cleanly?) rather than on
+      # knapsack's own bootstrap ceremony. Per
+      # feedback_v2_integration_exit_status the load-bearing
+      # assertion is the cache-state, but we still want a clean
+      # exit so the smoke is unambiguous.
+      File.write(File.join(dir, 'knapsack_rspec_report.json'), '{}')
+
+      out, status = Bundler.with_unbundled_env do
+        env = {
+          'BUNDLE_GEMFILE' => gemfile_path,
+          'KNAPSACK_TEST_FILE_PATTERN' => nil
+        }
+        Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color', spec_path,
+                        chdir: dir)
+      end
+
+      expect(status.success?).to(
+        be(true),
+        "knapsack coexistence subprocess failed (exit=#{status.exitstatus}):\n#{out}"
+      )
+
+      cache_dir = File.join(dir, 'rspec_tracer_cache')
+      manifest_path = File.join(cache_dir, 'last_run.json')
+      expect(File).to(
+        exist(manifest_path),
+        "expected rspec-tracer cache manifest at #{manifest_path}; got: " \
+        "#{Dir.exist?(cache_dir) ? Dir.children(cache_dir).inspect : '(no cache dir)'}"
+      )
+
+      manifest = JSON.parse(File.read(manifest_path))
+      run_id = manifest.fetch('run_id')
+      all_examples = JSON.parse(File.read(File.join(cache_dir, run_id, 'all_examples.json')))
+
+      expect(all_examples.size).to(
+        eq(2),
+        "expected 2 registered examples, got #{all_examples.size}: " \
+        "#{all_examples.values.map { |m| m['description'] }.inspect}"
+      )
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:enable RSpec/ExampleLength

--- a/spec/remote_cache/user_tasks_spec.rb
+++ b/spec/remote_cache/user_tasks_spec.rb
@@ -154,6 +154,48 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
     end
   end
 
+  # M8.10: missing GIT_DEFAULT_BRANCH degrades gracefully (per the
+  # `Never propagate storage errors` contract) - the remote-cache
+  # rake-task surface returns false + logs a clear, actionable
+  # message at warn level, rather than letting the require_env raise
+  # propagate up into `bundle exec rake` as a non-zero exit. The user
+  # sees the env-name in the log line and knows what to fix.
+  describe 'missing GIT_DEFAULT_BRANCH (M8.10)' do
+    let(:config) { build_config(remote_cache_backend_entry: [fake_backend_class, {}]) }
+
+    def warn_messages
+      captured_logs.select { |(level, _)| level == :warn }.map(&:last)
+    end
+
+    it 'returns false + logs a clear warn when #download! is called without GIT_DEFAULT_BRANCH' do
+      runner = described_class.new(configuration: config, env: { 'GIT_BRANCH' => 'feat-1' })
+
+      expect(runner.download!).to be(false)
+      expect(warn_messages).to include(
+        a_string_including('download failed').and(a_string_including('GIT_DEFAULT_BRANCH'))
+      )
+    end
+
+    it 'treats GIT_DEFAULT_BRANCH=empty the same as unset' do
+      runner = described_class.new(
+        configuration: config,
+        env: { 'GIT_DEFAULT_BRANCH' => '', 'GIT_BRANCH' => 'feat-1' }
+      )
+
+      expect(runner.download!).to be(false)
+      expect(warn_messages).to include(a_string_including('GIT_DEFAULT_BRANCH'))
+    end
+
+    it 'returns false + logs a clear warn from #upload! (consistent UX across both rake tasks)' do
+      runner = described_class.new(configuration: config, env: { 'GIT_BRANCH' => 'main' })
+
+      expect(runner.upload!).to be(false)
+      expect(warn_messages).to include(
+        a_string_including('upload failed').and(a_string_including('GIT_DEFAULT_BRANCH'))
+      )
+    end
+  end
+
   describe '.download!' do
     it 'is a class-level convenience that dispatches to an instance' do
       config = build_config(remote_cache_backend_entry: nil)

--- a/spec/rspec/parallel_tests_spec.rb
+++ b/spec/rspec/parallel_tests_spec.rb
@@ -281,6 +281,7 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       allow(ParallelTests).to receive(:wait_for_other_processes_to_finish)
       allow(described_class).to receive(:merge_snapshot!)
       allow(described_class).to receive(:merge_coverage!)
+      allow(described_class).to receive(:emit_merged_reporters!)
       allow(described_class).to receive(:purge_worker_dirs!)
     end
 
@@ -302,6 +303,7 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(result).to be(true)
       expect(described_class).to have_received(:merge_snapshot!)
       expect(described_class).to have_received(:merge_coverage!)
+      expect(described_class).to have_received(:emit_merged_reporters!)
       expect(described_class).to have_received(:purge_worker_dirs!)
       expect(File.exist?(lock_file)).to be(false)
     end
@@ -314,11 +316,76 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(described_class).not_to have_received(:merge_coverage!)
     end
 
+    # M8.10: emit_merged_reporters! must run BEFORE purge_worker_dirs!
+    # so the reporter Registry consumes the merged top-level snapshot
+    # AND writes its terminal/JSON/HTML output before the per-worker
+    # parallel_tests_N dirs are removed.
+    it 'emits merged reporters before purging the per-worker dirs (M8.10)' do
+      ordering = []
+      allow(described_class).to receive(:emit_merged_reporters!) { ordering << :emit }
+      allow(described_class).to receive(:purge_worker_dirs!) { ordering << :purge }
+
+      described_class.finalize!
+
+      expect(ordering).to eq(%i[emit purge])
+    end
+
     it 'logs and returns false on StandardError — never propagates exit status' do
       allow(described_class).to receive(:merge_snapshot!).and_raise(StandardError, 'disk full')
 
       expect(described_class.finalize!).to be(false)
       expect(logger).to have_received(:warn).with(/parallel_tests finalize failed/)
+    end
+  end
+
+  describe '.emit_merged_reporters! (M8.10)' do
+    let(:base_dir) { File.dirname(cache_path) }
+    let(:top_report_dir) { File.dirname(report_path) }
+    let(:merged_snapshot) { instance_double(RSpecTracer::Storage::Snapshot) }
+
+    before do
+      allow(RSpecTracer).to receive_messages(storage_backend: :json,
+                                             storage_backend_opts: {})
+      allow(RSpecTracer).to receive(:rails?).and_return(false)
+    end
+
+    it 'is a no-op for non-:json storage backends (M3.8 SqliteBackend)' do
+      allow(RSpecTracer).to receive(:storage_backend).and_return(:sqlite)
+      expect(RSpecTracer::Reporters::Registry).not_to receive(:emit_all)
+
+      described_class.emit_merged_reporters!
+    end
+
+    it 'returns early when load_graph yields no merged snapshot' do
+      backend = instance_double(RSpecTracer::Storage::JsonBackend, load_graph: nil)
+      allow(RSpecTracer::Storage::JsonBackend).to receive(:new).and_return(backend)
+      expect(RSpecTracer::Reporters::Registry).not_to receive(:emit_all)
+
+      described_class.emit_merged_reporters!
+    end
+
+    it 'emits the registry against the merged snapshot at the top-level report dir' do
+      backend = instance_double(RSpecTracer::Storage::JsonBackend, load_graph: merged_snapshot)
+      allow(RSpecTracer::Storage::JsonBackend).to receive(:new).and_return(backend)
+      expect(RSpecTracer::Reporters::Registry).to receive(:emit_all).with(
+        hash_including(
+          configuration: RSpecTracer,
+          snapshot: merged_snapshot,
+          report_dir: top_report_dir,
+          run_metadata: hash_including(parallel_tests: true, cache_path: base_dir)
+        )
+      )
+
+      described_class.emit_merged_reporters!
+    end
+
+    it 'logs and continues on StandardError (purge / lock cleanup not blocked)' do
+      backend = instance_double(RSpecTracer::Storage::JsonBackend)
+      allow(backend).to receive(:load_graph).and_raise(StandardError, 'boom')
+      allow(RSpecTracer::Storage::JsonBackend).to receive(:new).and_return(backend)
+
+      expect { described_class.emit_merged_reporters! }.not_to raise_error
+      expect(logger).to have_received(:warn).with(/merged reporter emission failed/)
     end
   end
 


### PR DESCRIPTION
## Summary

Promotes 6 high-value items from the 2.1 deferral surface into 2.0 shipping scope. Each was either a half-done feature where infrastructure existed but wasn't wired through to user-visible output, or critical-path integration coverage every upgrading user hits.

**Lib bug fix:** parallel-aware reporters. Pre-fix, every `parallel_tests` worker emitted reports into per-worker `parallel_tests_N/` dirs that the elected last-process worker then deleted at finalize time — net result, every parallel_tests user got ZERO usable HTML/JSON/terminal reports at run-end. Fix gates per-worker emit on `!parallel_tests?` and adds `ParallelTests.emit_merged_reporters!` running between `merge_snapshot!` and `purge_worker_dirs!` so the user sees ONE consolidated report set at the top-level location.

**4 new integration specs:** 1.x→2.0 cache schema upgrade ceremony, non-git repo invocation graceful degradation, missing `GIT_DEFAULT_BRANCH` graceful degradation (assertions added to existing user_tasks_spec), Local-FS remote-cache round-trip parity with S3 + Redis, Knapsack composition smoke (closes asymmetry with M9.0's retry+rerun coverage).

**1 new doc:** `docs/CI_RECIPES.md` translates the M8.4-D GHA pattern to CircleCI / GitLab CI / Buildkite / Heroku CI.

11 files changed (+1015, -8). 1754 unit specs + 25 property + 1 dogfood + benchmark all green. No filter-engine / storage / coverage internals touched beyond the parallel-aware reporter wiring.

## Test plan

- [x] \`task lint:ruby\` (219 files, 0 offenses)
- [x] \`task lint:actions\` + \`task lint:yaml --strict\`
- [x] \`task check:bundle\`
- [x] \`task security:bundle-audit\` (0 vulnerabilities) + \`task security:trivy\`
- [x] \`task test:unit\` (1754 examples, 0 failures)
- [x] \`task test:property\` (25, 0)
- [x] \`task test:dogfood\` (1, 0)
- [x] \`task benchmark:smoke\` (cold_ruby 0.62x + warm_noop 0.66x; both well under threshold)
- [ ] CI matrix green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)