### PR TITLE
docs: comprehensive 2.0 pass — YARD + cookbook + internals + WCAG + GH Pages

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -1,0 +1,73 @@
+# Build + publish the docs site (YARD API reference + sample HTML
+# report + landing page) to GitHub Pages.
+#
+# Triggers:
+#   - push to main (continuous deployment of latest docs)
+#   - tag push v* (deployment of release docs)
+#   - workflow_dispatch (manual re-run, e.g. after enabling Pages)
+#
+# Required setup (one-time, repo owner):
+#   1. Settings -> Pages -> Source: GitHub Actions.
+#   2. The `pages: write` + `id-token: write` permissions below need
+#      no further config; GitHub grants them on the workflow trigger.
+#
+# The site lives at:
+#   https://avmnu-sng.github.io/rspec-tracer/
+
+name: docs-publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+# Single in-flight run per ref; new pushes cancel older builds.
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build docs site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Install task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build the docs site
+        run: task docs:site:build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.yardopts
+++ b/.yardopts
@@ -1,14 +1,14 @@
 --readme README.md
 --markup markdown
 --output-dir doc/yard
---no-private
+--protected
 --exclude lib/rspec_tracer/storage/lazy_snapshot.rb
 --exclude lib/rspec_tracer/tracker/io_hooks.rb
---protected
 -
 ARCHITECTURE.md
 UPGRADING.md
 CHANGELOG.md
 ROADMAP.md
+COOKBOOK.md
 LICENSE
 lib/**/*.rb

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -1,0 +1,530 @@
+# Cookbook
+
+Recipes for common rspec-tracer setups. Each recipe is self-contained
+and shows the minimum config + commands you need.
+
+For the conceptual model see [`README.md`](README.md). For migration
+from 1.x see [`UPGRADING.md`](UPGRADING.md). For internals see
+[`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+## Index
+
+1. [Add to a fresh Ruby gem](#1-add-to-a-fresh-ruby-gem)
+2. [Add to an existing Rails app](#2-add-to-an-existing-rails-app)
+3. [Migrate a 1.x project to 2.0](#3-migrate-a-1x-project-to-20)
+4. [Configure remote cache (S3 / Local-FS / Redis)](#4-configure-remote-cache)
+5. [Run with `parallel_tests`](#5-run-with-parallel_tests)
+6. [Run on JRuby](#6-run-on-jruby)
+7. [Track non-Ruby deps via `tracks:`](#7-track-non-ruby-deps-via-tracks)
+8. [Track env-var branching](#8-track-env-var-branching)
+9. [Use SQLite storage instead of JSON](#9-use-sqlite-storage-instead-of-json)
+10. [Debug "why did this test re-run?"](#10-debug-why-did-this-test-re-run)
+11. [Compose with Knapsack / RSpec::Retry / RSpec::Rerun](#11-compose-with-knapsack--rspecretry--rspecrerun)
+12. [Write a custom storage backend](#12-write-a-custom-storage-backend)
+13. [Write a custom reporter](#13-write-a-custom-reporter)
+
+---
+
+## 1. Add to a fresh Ruby gem
+
+Goal: skip already-passing examples on subsequent runs.
+
+```ruby
+# Gemfile
+gem 'rspec-tracer', '~> 2.0', group: :test, require: false
+```
+
+```sh
+bundle install
+```
+
+```ruby
+# spec/spec_helper.rb (very first line)
+require 'rspec_tracer'
+RSpecTracer.start
+
+# ... your existing spec_helper config below
+```
+
+```
+# .gitignore
+rspec_tracer.lock
+rspec_tracer_cache/
+rspec_tracer_coverage/
+rspec_tracer_report/
+```
+
+Run the suite twice. The second run skips examples whose inputs
+didn't change between runs:
+
+```sh
+bundle exec rspec       # cold; everything runs
+bundle exec rspec       # warm; skips unaffected examples
+```
+
+The `rspec_tracer_report/index.html` file gives you per-example +
+per-file dependency views.
+
+---
+
+## 2. Add to an existing Rails app
+
+Goal: get rspec-tracer's per-example skip behavior on a Rails app
+with views, locales, fixtures, schema, and per-example AR queries.
+
+```ruby
+# Gemfile (test group)
+gem 'rspec-tracer', '~> 2.0', group: :test, require: false
+```
+
+```ruby
+# spec/rails_helper.rb (top of file)
+require 'simplecov'   # if you use it; load BEFORE rspec_tracer
+SimpleCov.start
+
+require 'rspec_tracer'
+RSpecTracer.start
+
+# Existing rails_helper.rb config follows
+require File.expand_path('../config/environment', __dir__)
+require 'rspec/rails'
+```
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  track_rails_defaults
+end
+```
+
+`track_rails_defaults` attaches the common Rails-side declared globs
+(views, locales, fixtures, factories, helpers, config, schema). For
+narrower per-example schema attribution, see recipe
+[#4](#4-configure-remote-cache) below.
+
+**Trade-off worth knowing**: if your test env runs with
+`config.eager_load = true` (Rails CI default), all `app/` files
+load at boot and any `app/` edit triggers a whole-suite re-run. To
+recover per-example precision, set `config.eager_load = false` in
+`config/environments/test.rb`. See README "How it works" for the
+full rationale.
+
+---
+
+## 3. Migrate a 1.x project to 2.0
+
+Goal: zero-touch upgrade preserving every 1.x behavior + adopting
+the new `track_rails_defaults` to close Rails blind spots.
+
+```sh
+bundle update rspec-tracer
+bundle exec rspec       # one cold run (cache schema bumped)
+bundle exec rspec       # warm again
+```
+
+The 1.x cache is refused; the first 2.0 run rebuilds it. Subsequent
+runs warm-skip as before.
+
+**1.x → 2.0 deprecated DSL** (still works, fires a one-time warn):
+
+| 1.x                                 | 2.0 replacement                                       |
+|-------------------------------------|-------------------------------------------------------|
+| `reports_s3_path 's3://...'`        | `remote_cache_uri 's3://...'`                         |
+| `use_local_aws true`                | `remote_cache_backend :s3, local: true`               |
+| `RSPEC_TRACER_REPORTS_S3_PATH=...`  | `RSPEC_TRACER_REMOTE_CACHE_URI=...`                   |
+| `RSPEC_TRACER_USE_LOCAL_AWS=true`   | Pass via `remote_cache_backend` params instead.       |
+
+The `rake rspec_tracer:remote_cache:download` / `:upload` task
+surface is unchanged. See [`UPGRADING.md`](UPGRADING.md) for the
+complete migration guide.
+
+---
+
+## 4. Configure remote cache
+
+Pick one backend in `.rspec-tracer`. The `rake` task surface stays
+identical — only the storage substrate differs.
+
+### S3 (preserves 1.x layout)
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  remote_cache_backend :s3, bucket: 'my-bucket', prefix: 'rspec-tracer'
+end
+```
+
+```sh
+# In CI:
+GIT_DEFAULT_BRANCH=main GIT_BRANCH=$BRANCH \
+AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... \
+bundle exec rake rspec_tracer:remote_cache:download
+bundle exec rspec
+bundle exec rake rspec_tracer:remote_cache:upload
+```
+
+### LocalStack / awslocal (development)
+
+```ruby
+RSpecTracer.configure do
+  remote_cache_backend :s3, bucket: 'local-bucket',
+                       prefix: 'rspec-tracer', local: true
+end
+```
+
+### Filesystem-backed (no S3 needed)
+
+```ruby
+RSpecTracer.configure do
+  remote_cache_backend :local_fs, root: '/tmp/rspec-tracer-cache'
+end
+```
+
+Useful when you have a shared NFS / EFS mount across CI workers, or
+when you just want to test the upload/download flow locally without
+LocalStack.
+
+### Redis (with optional TTL + PR-branch tracking)
+
+```ruby
+RSpecTracer.configure do
+  remote_cache_backend :redis,
+                       url: ENV.fetch('REDIS_URL'),
+                       ttl: 7 * 86_400  # 1 week per-key TTL
+end
+```
+
+PR-tier uploads also write to a `<prefix>:pr_branches` Redis Set —
+useful for ops dashboards (`SMEMBERS rspec-tracer:pr_branches`)
+without enumerating the full key namespace.
+
+---
+
+## 5. Run with `parallel_tests`
+
+`parallel_tests` works out of the box. The tracker writes per-worker
+caches under `rspec_tracer_cache/parallel_tests_N/` and merges them
+into the top-level cache at finalize on the elected last worker.
+
+```sh
+bundle exec parallel_rspec spec/
+```
+
+If you interrupt mid-run, delete the lock file before the next
+attempt:
+
+```sh
+rm -f rspec_tracer.lock && bundle exec parallel_rspec spec/
+```
+
+The HTML / JSON / terminal reports emit ONCE at the merged top-level
+location after merge completes (not per-worker — the per-worker
+reports get purged at finalize alongside the per-worker cache dirs).
+
+---
+
+## 6. Run on JRuby
+
+```sh
+export JRUBY_OPTS="--debug -X+O"
+```
+
+In your project's `Gemfile`, add the JDBC adapter for your Rails
+line (the major number tracks Rails: `~> 71.0` for Rails 7.1):
+
+```ruby
+gem 'activerecord-jdbcsqlite3-adapter', '~> 71.0', platforms: :jruby
+```
+
+`config/database.yml`'s `adapter: sqlite3` resolves to the JDBC
+chain transparently.
+
+**JRuby caveats**:
+- The `:sqlite` storage backend is unavailable; rspec-tracer auto-
+  falls-back to the `:json` backend with a one-time warn.
+- Per-iter benchmark times are higher because every test subprocess
+  pays full JVM boot. This is JVM cost, not tracer overhead.
+- Rails 8.0 + JRuby is unsupported (no `~> 80.0` JDBC adapter
+  upstream); pin Rails to 7.x on JRuby.
+
+---
+
+## 7. Track non-Ruby deps via `tracks:`
+
+Goal: invalidate specific examples when a config file or non-Ruby
+asset they read changes.
+
+```ruby
+RSpec.describe AdminController,
+               tracks: { files: 'app/policies/**/*.rb' } do
+  it 'gates by role' do
+    # ...
+  end
+end
+```
+
+Now editing any `app/policies/*.rb` file re-runs only the
+AdminController examples — not the entire suite.
+
+`:files` accepts a single string glob or an array:
+
+```ruby
+tracks: { files: ['app/policies/**/*.rb', 'config/roles.yml'] }
+```
+
+**Cascade**: nested describes contribute additively; the inner
+group does NOT clobber the outer:
+
+```ruby
+RSpec.describe Admin, tracks: { files: 'config/roles.yml' } do
+  context 'with policy DSL', tracks: { files: 'app/policies/**/*.rb' } do
+    # both globs apply to examples in this context
+  end
+end
+```
+
+For files **every** test depends on, use `track_files` at config
+level instead — declaring per-example via `tracks:` is for narrow
+attribution.
+
+---
+
+## 8. Track env-var branching
+
+Goal: invalidate examples when an env var they branch on changes
+between runs.
+
+### Config-level (every example depends on the var)
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  track_env 'AUTH_TOKEN', 'DATABASE_URL', 'RAILS_*'
+end
+```
+
+Wildcards: `'PREFIX_*'`, `'*_SUFFIX'`, bare `'*'`. Expanded against
+the live ENV at config load; the persisted snapshot
+(`env_snapshot.json`) carries concrete keys only.
+
+### Per-example (only specific examples branch on it)
+
+```ruby
+RSpec.describe Auth, tracks: { env: 'JWT_SECRET' } do
+  it 'verifies the token' do
+    # ...
+  end
+end
+```
+
+Or with wildcards:
+
+```ruby
+tracks: { env: 'OAUTH_*' }
+```
+
+A missing env var is digested as the empty string. Changing the
+value (or setting/unsetting) invalidates the dependent examples.
+
+---
+
+## 9. Use SQLite storage instead of JSON
+
+Goal: faster cold reads on suites with > ~5,000 examples.
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  storage_backend :sqlite
+end
+```
+
+Or as a per-run override:
+
+```sh
+RSPEC_TRACER_STORAGE=sqlite bundle exec rspec
+```
+
+The on-disk layout becomes a single `rspec_tracer.sqlite3` file
+instead of the 10-file JSON directory. Both backends store the
+same data; the SQLite backend avoids the per-file open overhead at
+cold-read time.
+
+**JRuby**: `:sqlite` is unsupported; the engine warns once and
+falls back to `:json` automatically.
+
+---
+
+## 10. Debug "why did this test re-run?"
+
+Use `bin/rspec-tracer explain <example_id_or_substring>`:
+
+```sh
+bin/rspec-tracer explain 'AdminController#create'
+```
+
+Prints the example's last-run status, dependency set, and the run-
+decision reason (e.g. `"Files changed: app/controllers/admin_controller.rb"`,
+`"Whole-suite invalidator changed: Gemfile.lock"`,
+`"Failed previously"`).
+
+For a suite-wide breakdown, the terminal output already shows the
+top-level reasons after each run:
+
+```
+rspec-tracer: 1,820 examples · 42 re-run · 1,778 skipped (97% cached)
+by reason: 38 Files changed · 4 Failed previously
+```
+
+For deeper config-level debugging, `bin/rspec-tracer doctor`
+diagnoses the boot-time state of every contract (SimpleCov load
+order, schema version, remote-cache reachability, AR-schema config).
+
+---
+
+## 11. Compose with Knapsack / RSpec::Retry / RSpec::Rerun
+
+These all coexist with rspec-tracer; their RSpec hooks compose with
+the tracer's `Module#prepend` chain. Add the gems normally.
+
+### Knapsack (free) — shard your suite across CI workers
+
+```ruby
+# Gemfile
+gem 'knapsack'
+```
+
+```sh
+KNAPSACK_TEST_FILE_PATTERN='spec/**/*_spec.rb' \
+CI_NODE_TOTAL=4 CI_NODE_INDEX=$INDEX \
+bundle exec rake knapsack:rspec
+```
+
+Compose: shard with knapsack, skip with rspec-tracer on each shard.
+The skip decisions are per-shard since each worker has its own
+cache.
+
+### RSpec::Retry — retry flaky failures
+
+```ruby
+gem 'rspec-retry'
+```
+
+```ruby
+# spec_helper.rb
+require 'rspec/retry'
+RSpec.configure do |config|
+  config.verbose_retry = true
+  config.default_retry_count = 2
+end
+```
+
+rspec-tracer detects flaky examples (same inputs, different
+outcomes) and refuses to skip them on subsequent runs even after
+retry succeeds — so the next run always re-investigates the flake.
+
+### RSpec::Rerun — re-run only failures
+
+```ruby
+gem 'rspec-rerun'
+```
+
+```sh
+bundle exec rake rspec-rerun:spec
+```
+
+Composes cleanly. rspec-tracer's per-example tracking proceeds
+through the rerun chain.
+
+---
+
+## 12. Write a custom storage backend
+
+Implement `RSpecTracer::Storage::Backend`'s 5-method protocol:
+
+```ruby
+class MyBackend
+  def initialize(connection_string:)
+    @conn = open_my_storage(connection_string)
+  end
+
+  def load_graph(schema_version:)
+    # Return RSpecTracer::Storage::Snapshot or nil.
+    # Nil = no cache OR schema mismatch (treat as cold run).
+    # Never raise on corruption — log + return nil.
+  end
+
+  def save_graph(snapshot, schema_version:)
+    # Persist the snapshot atomically.
+  end
+
+  def last_run_id
+    # Return the most-recent run_id, or nil.
+  end
+
+  def transactional_save(&block)
+    # Yield with single-writer semantics; commit on clean exit;
+    # roll back on raise.
+    yield
+  end
+
+  def clear!
+    # Remove everything this backend owns.
+  end
+end
+```
+
+Register:
+
+```ruby
+RSpecTracer.configure do
+  storage_backend MyBackend.new(connection_string: ENV['MY_DB_URL'])
+end
+```
+
+The protocol contract + invariants live in
+[`ARCHITECTURE.md`](ARCHITECTURE.md). The shared-examples group at
+`spec/contracts/storage_backend.rb` exercises every requirement —
+add your backend's spec to it.
+
+---
+
+## 13. Write a custom reporter
+
+Subclass `RSpecTracer::Reporters::Base`:
+
+```ruby
+class SlackReporter < RSpecTracer::Reporters::Base
+  def generate
+    return if no_op?
+
+    payload = {
+      examples: snapshot.all_examples.size,
+      re_run: snapshot.re_run_examples.size,
+      skipped: snapshot.skipped_examples.size,
+      run_time: run_metadata[:run_time]
+    }
+    HTTP.post(options[:webhook], json: payload)
+  end
+end
+```
+
+Register with reporter-specific opts:
+
+```ruby
+RSpecTracer.configure do
+  add_reporter SlackReporter, webhook: ENV.fetch('SLACK_WEBHOOK')
+end
+```
+
+Errors inside `generate` are caught by the Registry's per-reporter
+rescue + warn — a buggy custom reporter never breaks the test
+suite. Same graceful-degradation contract as Storage backends.
+
+---
+
+## Got a recipe to add?
+
+Open a [Discussion](https://github.com/avmnu-sng/rspec-tracer/discussions/categories/ideas)
+with the scenario + minimum config; if it's a common pattern it'll
+land here in a future docs pass.

--- a/docs/CI_RECIPES.md
+++ b/docs/CI_RECIPES.md
@@ -1,8 +1,8 @@
 # CI recipes for rspec-tracer
 
 The canonical GitHub Actions pattern lives at
-[`.github/workflows/example-tracer-cache.yml`](../.github/workflows/example-tracer-cache.yml)
-(M8.4-D). This doc translates the same cache-key shape to four other
+[`.github/workflows/example-tracer-cache.yml`](../.github/workflows/example-tracer-cache.yml).
+This doc translates the same cache-key shape to four other
 popular CI providers — **CircleCI**, **GitLab CI**, **Buildkite**,
 and **Heroku CI**. The cache contract is the same on every platform:
 

--- a/docs/WCAG_AUDIT.md
+++ b/docs/WCAG_AUDIT.md
@@ -1,0 +1,113 @@
+# Accessibility audit — HTML reporter
+
+This doc records the accessibility-audit baseline for rspec-tracer's
+HTML reporter (`rspec_tracer_report/index.html`). Re-run the audit
+on any PR that materially changes the HTML reporter's markup or
+styling.
+
+## Standards
+
+The reporter targets **WCAG 2.1 AA** (which is a superset of WCAG
+2.0 AA). The audit uses [`axe-core`](https://github.com/dequelabs/axe-core)
+4.11.x — the de-facto industry baseline for automated WCAG
+checking.
+
+## Latest audit
+
+**Date:** 2026-05-04
+**Tooling:** axe-core 4.11.4 via `@axe-core/cli`, headless Chrome 147.
+**Tags:** `wcag2aa,wcag21aa`
+**Result:** **0 violations**.
+
+Pages audited:
+- `rspec_tracer_report/index.html` (single-page HTML report; the
+  reporter ships as one self-contained page with assets bundled
+  under `rspec_tracer_report/assets/`).
+
+## How to re-run
+
+```sh
+task docs:wcag
+```
+
+(or directly:)
+
+```sh
+npx --yes @axe-core/cli "file://$(pwd)/rspec_tracer_report/index.html" \
+  --tags wcag2aa,wcag21aa \
+  --timeout 240
+```
+
+You'll need a generated HTML report on disk — run any of the
+fixture-driving integration specs first:
+
+```sh
+task test:features:rails              # generates fixture report
+ls spec/fixtures/rails_app/rspec_tracer_report/index.html
+```
+
+Then point axe at the path above instead.
+
+## Important caveat — automated scope
+
+axe-core's documentation notes: **"only 20% to 50% of all
+accessibility issues can be automatically detected"**. A passing
+axe run is necessary but not sufficient.
+
+Issues axe-core CANNOT catch automatically:
+- **Color choice meaning**: red-only-vs-green semantic distinctions
+  (color-blind users see no difference).
+- **Reading order**: visual layout vs DOM order mismatches.
+- **Cognitive load**: dense data tables, jargon, lack of summaries.
+- **Keyboard navigation flow**: tab order coherence, focus traps.
+- **Screen reader announcements**: whether the surfaced text
+  matches user mental model.
+
+The automated audit is the floor — manual testing with a screen
+reader (VoiceOver on macOS, NVDA on Windows) catches the rest.
+
+## Manual checklist
+
+When making material HTML reporter changes, walk this list manually:
+
+- [ ] Tab through every interactive element (links, buttons,
+      sortable column headers, search inputs); focus indicator is
+      visible at every stop.
+- [ ] Activate every interactive element via keyboard (Enter /
+      Space) without using the mouse.
+- [ ] Open the page with a screen reader. Verify:
+  - The page title announces meaningfully.
+  - Headings (`h1` / `h2` / `h3`) form a logical outline.
+  - Tables have `<th scope>` annotations and announce row + column
+    headers when navigating cells.
+  - Status indicators (passed / failed / flaky / skipped) have
+    text-equivalent meaning, not just color.
+- [ ] Increase browser zoom to 200%; layout doesn't break, text
+      doesn't get clipped.
+- [ ] Use [axe DevTools browser extension](https://www.deque.com/axe/browser-extensions/)
+      for an interactive walkthrough — surfaces issues axe-cli's
+      headless run misses.
+
+## Browser support
+
+The reporter is tested on:
+
+- Chrome / Edge (Chromium-based; current + previous major).
+- Firefox (current ESR + current).
+- Safari (current major + current macOS).
+
+No support for browsers older than the above.
+
+## Commitment
+
+We treat accessibility violations as P1 bugs:
+
+- A new violation introduced by a PR blocks merge.
+- A pre-existing violation discovered by audit gets fixed in the
+  next docs-touching PR.
+- Major reporter redesigns get a manual + automated audit BEFORE
+  ship, not after.
+
+If you find a violation not surfaced by `task docs:wcag`, open an
+issue with the violation rule + the screen reader / browser combo
+that surfaced it.

--- a/docs/internals/HOW_PARALLEL_TESTS_MERGE.md
+++ b/docs/internals/HOW_PARALLEL_TESTS_MERGE.md
@@ -1,0 +1,180 @@
+# How `parallel_tests` workers coordinate + merge
+
+`parallel_tests` runs your suite across N worker processes. Each
+worker has its own tracker instance, its own cache directory, and
+its own report directory. At finalize, one elected worker merges
+everything into top-level outputs.
+
+This doc walks the lifecycle: detection → per-worker isolation →
+last-process election → merge → report emission → cleanup.
+
+## Detection at boot
+
+`RSpecTracer.start` checks `RSpecTracer::RSpec::ParallelTests.active?`,
+which returns `true` if `ParallelTests.first_process?` resolves
+without raising (which it does only when `parallel_tests` set the
+environment).
+
+Memoized as `RSpecTracer.parallel_tests?`. Every downstream
+component branches on this flag.
+
+## Per-worker directory layout
+
+Each worker writes into a per-worker subdirectory under each of the
+3 canonical directories:
+
+```
+rspec_tracer_cache/
+├── parallel_tests_1/      ← worker 1
+│   ├── last_run.json
+│   └── <run_id>/
+│       └── ... (10 files)
+├── parallel_tests_2/      ← worker 2
+│   └── ...
+└── ... (etc.)
+
+rspec_tracer_coverage/
+├── parallel_tests_1/
+└── ...
+
+rspec_tracer_report/
+├── parallel_tests_1/
+└── ...
+```
+
+The per-worker subdir name comes from `Configuration#parallel_tests_id`:
+`parallel_tests_<TEST_ENV_NUMBER>`. So worker N's `cache_path` is
+`<root>/rspec_tracer_cache/parallel_tests_<N>`.
+
+This isolation is mandatory: workers run concurrently with no shared
+locks on cache writes. Without per-worker dirs, two workers writing
+to `last_run.json` simultaneously would corrupt each other's state.
+
+## Last-process election
+
+After all workers finish their examples, ONE elected worker runs
+`finalize!` to merge per-worker outputs into top-level files.
+
+Election uses `ParallelTests.first_process?` — a property of the
+parent's worker spawn order, NOT a runtime race. The parent
+`parallel_tests` process labels worker 1 with `TEST_ENV_NUMBER=` (or
+`'1'` depending on version); subsequent workers get `'2'`, `'3'`,
+etc. Worker 1 is always the elected last-process.
+
+We previously used a lock-file election (max `TEST_ENV_NUMBER`-by-
+mtime), which raced under slow CI: a fast worker reaching `at_exit`
+before the slowest worker had even loaded `spec_helper` would self-
+elect, leading to two workers both trying to merge. The
+`ParallelTests.first_process?` API resolves this without races —
+parent-set env, never updated post-spawn.
+
+## The finalize! lifecycle
+
+The elected worker runs:
+
+1. **`wait_for_other_processes_to_finish`** — blocks on the per-
+   worker pid table until the last peer has exited.
+2. **`merge_snapshot!`** — walks every `parallel_tests_N/<run_id>/`
+   directory, loads the per-worker snapshots via JsonBackend, and
+   unions:
+   - `all_examples` — Set of every example_id seen by any worker.
+   - `all_files` — Set of every dependency file across all workers.
+   - `dependency` — Hash[example_id => Set<file>], unioning per-
+     worker entries (an example_id only appears in one worker's
+     output, so no merge conflict).
+   - `boot_set` — Set of files loaded at boot time (intersected
+     across workers, since boot-set is per-process; the union would
+     over-attribute to examples that didn't actually load all of
+     them).
+   - `whole_suite_invalidators` — Set of files whose change
+     invalidates everything; identical across workers (computed
+     from declared-globs at boot).
+   - `env_snapshot` — Hash[env_name => digest]; identical across
+     workers since env is per-process and parent-spawned.
+3. **`emit_merged_reporters!`** — emits HTML / JSON / terminal
+   reports against the MERGED top-level snapshot, into the top-
+   level `rspec_tracer_report/` (NOT `rspec_tracer_report/
+   parallel_tests_N/`). This produces the single user-visible report
+   set.
+4. **`purge_worker_dirs!`** — removes every `parallel_tests_N/`
+   subdirectory under the cache + coverage + report roots. The
+   merged output supersedes the per-worker raw data.
+5. **`remove_lock_file!`** — deletes `rspec_tracer.lock` so the
+   next run starts clean.
+
+## Why reporters emit AFTER merge, not per-worker
+
+Pre-2.0 (and in some early 2.0 betas), per-worker `at_exit`
+emitted reports into each `rspec_tracer_report/parallel_tests_N/`
+directory, then `purge_worker_dirs!` removed those directories.
+Net result: every parallel_tests user got ZERO usable reports at
+run-end.
+
+The fix gates `emit_reporters` on `!parallel_tests?` in
+`run_exit_tasks` (per-worker emission no-ops) and adds
+`emit_merged_reporters!` to the elected worker's `finalize!` chain
+AFTER `merge_snapshot!` (so the merged top-level cache exists) and
+BEFORE `purge_worker_dirs!` (so the merged top-level reports
+exist when purge runs).
+
+The merged emission is wrapped in its own rescue so a failed
+reporter doesn't block purge / lock cleanup (graceful degradation
+contract).
+
+## Coverage merging
+
+Coverage data from `::Coverage.peek_result` is per-process and not
+trivially mergeable. Each worker writes its own `coverage.json` to
+`rspec_tracer_coverage/parallel_tests_N/`; users typically rely on
+SimpleCov's own collation (which understands the per-worker layout
+via `SimpleCov.collate`).
+
+If you don't use SimpleCov + you need merged coverage, your
+collation step happens AFTER rspec-tracer's `purge_worker_dirs!`
+runs. Workaround: copy the per-worker files to a sibling location
+in a `before(:suite)` shutdown hook.
+
+## Interruption recovery
+
+Killing the parent `parallel_rspec` process mid-run leaves the
+lock file (`rspec_tracer.lock`) in place. The next run sees the
+stale lock and refuses to start.
+
+Recovery:
+
+```sh
+rm -f rspec_tracer.lock && bundle exec parallel_rspec spec/
+```
+
+We don't auto-clean the lock at startup because doing so would mask
+genuine concurrency bugs: if two `parallel_rspec` invocations were
+running simultaneously, auto-cleanup of the lock would let them
+collide.
+
+## Caveats
+
+- **TruffleRuby `parallel_tests`**: the `ParallelTests.first_process?`
+  API works on TruffleRuby but the cell is best-effort
+  (`continue-on-error` in CI). Per-worker spawn timing is more
+  variable on TruffleRuby's runtime.
+- **`TEST_ENV_NUMBER`+`TEST_SUITE_ID` interaction**: when both env
+  vars are set (e.g. sharded CI suite running parallel_tests
+  inside each shard), the cache_path nests:
+  `<root>/rspec_tracer_cache/<TEST_SUITE_ID>/parallel_tests_<N>/`.
+  Merge happens within one shard; cross-shard merging is not
+  rspec-tracer's concern (the remote-cache backend handles
+  cross-shard distribution).
+- **Custom storage backends + parallel_tests**: a custom
+  storage backend MUST handle per-worker isolation itself. The
+  default JSON / SQLite backends key off `cache_path`; a custom
+  backend writing to a single shared SQL database would need its
+  own per-worker scoping (e.g. `WHERE worker_id = ?` filters).
+
+## Where to read code
+
+- `lib/rspec_tracer/rspec/parallel_tests.rb` — election + lifecycle
+  hooks.
+- `lib/rspec_tracer/storage/json_backend.rb` (`Merger` class) — the
+  per-field merge implementations.
+- `spec/integration/parallel_tests_spec.rb` — end-to-end test
+  driving the actual fixture under `parallel_rspec`.

--- a/docs/internals/HOW_REMOTE_CACHE_BACKENDS.md
+++ b/docs/internals/HOW_REMOTE_CACHE_BACKENDS.md
@@ -1,0 +1,246 @@
+# How remote-cache backends work
+
+The remote-cache layer ships caches across CI workers + builds via
+S3, the local filesystem, or Redis. This doc walks tier routing
+(main vs PR), the candidate-ref walk, branch_refs, retention, and
+the graceful-degradation contract.
+
+## The protocol contract
+
+`RSpecTracer::RemoteCache::Backend` is a 6-method protocol every
+backend implements:
+
+```ruby
+download(ref)               # -> true/false; never raises on wire failure
+upload(ref)                 # -> raises on wire failure
+branch_refs(branch_name)    # -> Hash; {} when no refs file exists
+write_branch_refs(branch_name, refs)  # -> no-op on main tier
+prune!(...)                 # -> Integer (refs removed); never raises
+prune_all!(pr_branch_ttl_seconds:)    # -> Integer; cross-tier; never raises
+```
+
+The shared-examples group at
+`spec/contracts/remote_cache_backend.rb` exercises every requirement
+on every shipping backend (S3 / LocalFS / Redis).
+
+## Tier routing
+
+A backend is constructed with branch + default_branch state:
+
+```ruby
+RemoteCache::S3Backend.new(
+  bucket:         'my-bucket',
+  prefix:         'rspec-tracer',
+  branch:         'feat-new-thing',     # current build's branch
+  default_branch: 'main',
+  test_suite_id:  '3',                  # optional: from TEST_SUITE_ID
+  local:          false,
+  cache_path:     '/abs/path/to/cache'
+)
+```
+
+The backend internally routes uploads + downloads to one of two
+tiers based on `branch == default_branch`:
+
+```
+<prefix>/main/<commit-sha>/cache.tar.gz       ← main tier
+<prefix>/pr/<branch>/<commit-sha>/cache.tar.gz ← pr tier
+```
+
+- **main tier**: history-strict; the `<commit-sha>` is the actual
+  HEAD SHA. The 25-commit Git ancestry walk traverses recent main
+  history to find the nearest viable cache.
+- **pr tier**: per-branch; PR builds upload under `pr/<branch>/`
+  so concurrent PRs don't collide. Falls back to main tier on a
+  miss (the PR may not have its own cache yet).
+
+`<test_suite_id>/` is appended after `<commit-sha>/` when
+`TEST_SUITE_ID` is set, so sharded suites maintain separate caches.
+
+## The candidate-ref walk on download
+
+`download(ref)` doesn't just try the exact `ref`. It walks the
+25-commit Git ancestry chain (`git rev-list --max-count=25 $ref`) +
+the persisted branch_refs (last 25 commits seen on this branch
+across recent runs), and tries each candidate ref until it finds
+a usable cache or exhausts the list.
+
+The order matters:
+1. **Branch refs first** — the branch's own recent commits, which
+   have the most relevant cache state (your latest pre-rebase
+   work).
+2. **Ancestry walk second** — main-line ancestors, which give
+   "good enough" caches when the branch refs are exhausted (e.g.
+   first run on a new branch).
+
+For the PR tier, the candidate list is constructed against the PR
+branch's refs; for the main tier, against `default_branch`.
+
+The first candidate that:
+- exists at the backend's storage location, AND
+- has a valid `last_run.json` with the current `schema_version`,
+- contains the expected file count for the suite
+
+…wins. Subsequent candidates are skipped.
+
+## branch_refs persistence (PR tier only)
+
+Each PR-tier upload writes (or appends to) a `branch-refs/<branch>/
+branch_refs.json` file:
+
+```json
+{
+  "abc1234": 1700000000,
+  "def5678": 1700000100
+}
+```
+
+The keys are commit SHAs; values are committer Unix timestamps.
+The file is appended to on each upload (with deduplication +
+re-sorting by timestamp), capped at the last 25 entries per branch.
+
+Why this exists: after a `git rebase main` on a PR branch, every
+commit SHA changes. The Git ancestry walk for the new HEAD won't
+find the pre-rebase caches because the SHAs are gone. branch_refs
+remembers the SHAs across runs, so the post-rebase HEAD's download
+walk still finds the pre-rebase cache.
+
+Main tier doesn't need branch_refs because the default branch's
+history doesn't get rewritten in normal usage.
+
+## tree-SHA secondary index
+
+In addition to the SHA-based primary lookup, S3Backend writes a
+tree-SHA pointer at `<tier>/by_tree/<tree_sha>` on every upload (when
+`tree_sha:` is passed). On download, if the requested commit-SHA
+misses but the same tree-SHA was uploaded under a different commit,
+the tree pointer resolves to that prior commit's archive.
+
+Use case: rebases + reverts produce different commit-SHAs but the
+SAME tree-SHA. Without the tree index, the post-rebase / post-
+revert build pays a cold cache; with it, the cache hits via the tree
+match.
+
+## Retention
+
+Three knobs in the configuration DSL:
+
+- `cache_retention_count(N)` — keep the N most recent main-tier
+  refs.
+- `cache_retention_duration('7d')` — keep main-tier refs newer
+  than the duration. Mutually exclusive with `cache_retention_count`.
+- `cache_retention_pr_branch_ttl('48h')` — drop PR branches
+  whose newest ref is older than the TTL. Independent of main
+  tier (PR branches are typically short-lived).
+
+`prune!` runs at upload time and prunes the backend's own tier.
+`prune_all!` walks every PR branch under the configured prefix and
+applies the TTL — used for periodic cross-tier cleanup (typically
+called from a separate scheduled rake task, not on every CI run).
+
+Both methods catch every `StandardError` and log + return what they
+managed to delete; storage errors never propagate non-zero into the
+test suite (graceful degradation).
+
+## The three shipping backends
+
+### S3Backend (`s3:`)
+
+- Uses the `aws` (or `awslocal` when `local: true`) CLI for every
+  operation. Matches 1.x's behavior; users with `aws configure`
+  already done don't need to install a Ruby AWS SDK gem.
+- Single tar.gz per ref containing the cache_path's full contents.
+- LocalStack support via `local: true` + `awslocal` CLI on PATH.
+- Requires AWS credentials (`AWS_ACCESS_KEY_ID` /
+  `AWS_SECRET_ACCESS_KEY` env vars OR `~/.aws/credentials`).
+
+### LocalFsBackend (`local_fs:`)
+
+- Filesystem-backed. The "remote" is a local directory tree
+  (typically a shared NFS / EFS mount).
+- Same tier layout as S3Backend (`<root>/main/<sha>/cache.tar.gz`).
+- Useful when you have shared filesystem across CI workers but no
+  S3 bucket.
+
+### RedisBackend (`redis:`)
+
+- Uses `connection_pool` for thread-safe pooling.
+- Cache contents are stored as Redis hash fields (DEL+HSET inside
+  a `MULTI` for atomicity).
+- Optional `ttl: <seconds>` on construction sets per-key EXPIRE
+  inside the same MULTI; `nil` disables and falls back to user
+  Redis eviction policy / explicit prune.
+- PR-tier uploads also `SADD` into `<prefix>:pr_branches` (atomic
+  with the cache write). Useful for ops dashboards: `SMEMBERS
+  <prefix>:pr_branches` enumerates active PR branches without
+  scanning the full key namespace.
+
+## Graceful-degradation contract
+
+Per `ARCHITECTURE.md`'s "Cache corruption recovery" + the
+`Storage::Backend` contract: **rspec-tracer must never propagate a
+remote-cache failure into the user's test suite**.
+
+The `download!` orchestrator (in `RemoteCache::UserTasks`) wraps
+every backend call in a rescue + log + return false. A failed
+download is "cold run" from the user's perspective; tests proceed
+normally.
+
+The `upload!` path is similar: a failed upload is logged + warned
+but doesn't change exit status. The tests already passed (or
+already failed); the upload outcome shouldn't change that signal.
+
+The Rake tasks at `lib/rspec_tracer/remote_cache/Rakefile` mirror
+this contract — they print the orchestrator's log line and exit 0
+even if the orchestrator returned false.
+
+## When the cache decides "cold run"
+
+Beyond the hard "no candidate found" case, the cache also falls
+back to cold when:
+
+- `last_run.json`'s `schema_version` doesn't match the current
+  rspec-tracer version's expected schema. Logged as
+  `"cold run: cache schema_version mismatch (got X, want Y)"`.
+- The downloaded archive's file count doesn't match the expected
+  per-suite count (`1 + N` for the manifest + per-run files).
+  Logged as `"cold run: cache file count mismatch"`.
+- The download attempt itself raised (network error, S3 403,
+  Redis disconnect). Logged as the underlying error class +
+  message.
+
+## Custom backends
+
+The protocol is small + the contract is well-specified. To register
+a custom backend:
+
+```ruby
+RSpecTracer.configure do
+  remote_cache_backend MyCustomBackend, my_opt: 'value'
+end
+```
+
+Run the shared-examples group (`require
+'spec/contracts/remote_cache_backend.rb'`) against your backend to
+verify the contract. The 1.x → 2.0 cache schema cut is your
+greenfield: backends never need to read 1.x layouts.
+
+## Where to read code
+
+- `lib/rspec_tracer/remote_cache/backend.rb` — the protocol
+  module + REQUIRED_METHODS.
+- `lib/rspec_tracer/remote_cache/s3_backend.rb` /
+  `local_fs_backend.rb` / `redis_backend.rb` — implementations.
+- `lib/rspec_tracer/remote_cache/git_ancestry.rb` — the candidate
+  ref walk.
+- `lib/rspec_tracer/remote_cache/user_tasks.rb` — the
+  orchestrator the rake tasks call.
+- `lib/rspec_tracer/remote_cache/Rakefile` — the user-facing
+  rake task surface.
+- `spec/integration/remote_cache_spec.rb` — S3 round-trip against
+  LocalStack.
+- `spec/integration/remote_cache_redis_spec.rb` — Redis round-trip.
+- `spec/integration/remote_cache_local_fs_spec.rb` — Local-FS
+  round-trip.
+- `spec/integration/rake_remote_cache_spec.rb` — the
+  user-facing rake task surface end-to-end.

--- a/docs/internals/HOW_STORAGE_BACKENDS.md
+++ b/docs/internals/HOW_STORAGE_BACKENDS.md
@@ -1,0 +1,250 @@
+# How storage backends work
+
+Two on-disk storage backends ship in 2.0: `:json` (default;
+preserves the 1.x 10-file layout) and `:sqlite` (single-file;
+faster cold reads above ~5,000 examples). This doc walks the
+on-disk shapes, the schema-version cold-run policy, and how the
+backends compose with the optional MessagePack serializer.
+
+## The protocol contract
+
+`RSpecTracer::Storage::Backend` is a 5-method protocol:
+
+```ruby
+load_graph(schema_version:)         # -> Snapshot or nil
+save_graph(snapshot, schema_version:)   # -> persists atomically
+last_run_id                         # -> String or nil
+transactional_save(&block)          # -> single-writer semantics
+clear!                              # -> remove everything backend owns
+```
+
+The shared-examples group at
+`spec/contracts/storage_backend.rb` exercises every requirement on
+every shipping backend. JsonBackend is the legacy 1.x carry-forward;
+SqliteBackend arrived in 2.0 to open up larger-suite scaling.
+
+## JsonBackend — the 10-file layout
+
+```
+rspec_tracer_cache/
+├── last_run.json               ← manifest pointer
+└── <run_id>/
+    ├── all_examples.json
+    ├── duplicate_examples.json
+    ├── interrupted_examples.json
+    ├── flaky_examples.json
+    ├── failed_examples.json
+    ├── pending_examples.json
+    ├── skipped_examples.json
+    ├── all_files.json
+    ├── dependency.json
+    └── examples_coverage.json
+```
+
+**`last_run.json`** is the entry point. Holds:
+- `schema_version` — Integer; current is 2.
+- `run_id` — String; UUID-like ref to the per-run subdirectory.
+- `timestamp` — ISO 8601 UTC.
+
+The 10 per-run files under `<run_id>/` carry the dependency graph,
+example registry, and coverage data. Each is a self-contained JSON
+document the backend can load independently — useful for partial
+recovery on disk corruption (one bad file doesn't poison the others).
+
+The 1.x cache had 9 files (no `cache_hit_reason.json`); 2.0 added
+this 10th file as a per-run aggregate of why each cached example
+got reused. Documented as a 2.0 file-count bump in CHANGELOG.
+
+### Atomic writes
+
+`save_graph` writes via `transactional_save`'s block. Implementation
+strategy: write each file to a `<name>.tmp` sibling, then rename
+each into place after all writes succeed. A crash mid-save leaves
+either the prior consistent state OR all 10 new files — never a
+half-applied state.
+
+### branch_refs lives separately
+
+The remote-cache layer's `branch_refs.json` is NOT one of the 10
+per-run files — it lives at
+`<remote-cache-root>/branch-refs/<branch>/branch_refs.json` (per-
+branch, not per-run). Backends that aggregate counts (e.g. file-
+count validators) need to special-case it.
+
+## SqliteBackend — the single-file layout
+
+```
+rspec_tracer_cache/
+└── rspec_tracer.sqlite3
+```
+
+A single SQLite database file. Schema:
+
+```sql
+-- meta table: schema_version, run_id, timestamp (replaces last_run.json)
+CREATE TABLE meta (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+-- per-run snapshots, one row per "save_graph" call
+CREATE TABLE snapshots (
+  run_id    TEXT PRIMARY KEY,
+  data      BLOB NOT NULL,    -- msgpack-serialized snapshot
+  timestamp INTEGER NOT NULL  -- Unix epoch
+);
+```
+
+**Why msgpack and not JSON for the BLOB?** Two reasons:
+1. **Size**: msgpack is ~30-40% smaller than JSON for the typical
+   snapshot shape (lots of repeated string keys + small integer
+   values).
+2. **Speed**: msgpack deserializes faster than JSON's ad-hoc parser,
+   especially for large nested hashes.
+
+The `:json` backend can ALSO opt into msgpack via
+`storage_backend :json, serializer: :msgpack`, but the
+files-on-disk layout remains 10-file (each file becomes a `.msgpack`
+binary instead of `.json` text).
+
+### busy_timeout PRAGMA ordering
+
+SQLite's PRAGMA ordering matters: `db.busy_timeout` MUST be set
+BEFORE any write-locking PRAGMA (`journal_mode`, etc.), or
+concurrent writers raise on the PRAGMA itself instead of waiting.
+
+`SqliteBackend#initialize`:
+
+```ruby
+@db = SQLite3::Database.new(path)
+@db.busy_timeout = 5_000  # FIRST
+@db.execute('PRAGMA journal_mode = WAL')  # SECOND
+```
+
+Reversing this ordering would intermittently fail under
+parallel_tests when two workers initialize their own SqliteBackend
+instances against the same file.
+
+### JRuby fallback
+
+`sqlite3` gem has no `-java` platform variant. On JRuby:
+- `Storage::SqliteBackend` raises `SqliteBackendError` on init.
+- The engine catches it and falls back to JsonBackend with a
+  one-time warn:
+  ```
+  rspec-tracer: SQLite storage backend unavailable on JRuby; using :json
+  ```
+- The warn fires at `Engine#setup` time so the user sees it before
+  any example runs.
+
+## Schema versioning + cold-run policy
+
+`schema_version` is an integer field. Current: `2`. Stored:
+- In `last_run.json` for JsonBackend.
+- In the `meta` table for SqliteBackend.
+
+When `load_graph(schema_version: N)` reads a cache whose
+`schema_version` doesn't equal N (whether N+1 / N-1 / completely
+different value), the backend:
+
+1. Logs `cold run: cache schema_version mismatch (got X, want Y)`
+   at info level.
+2. Returns nil.
+
+The engine treats `nil` as "no cache" — proceeds with a cold run +
+writes a fresh schema-version-tagged manifest at finalize. No
+migrators; users pay one cold run on schema bumps.
+
+The schema bumps in 2.0 baseline (1.x cache becomes unreadable);
+subsequent 2.x schema bumps are similar — old caches refuse, cold
+run proceeds, new cache writes.
+
+## How the engine talks to a backend
+
+`Engine#setup`:
+
+```ruby
+backend = configuration.storage_backend_class.new(
+  cache_path: configuration.cache_path,
+  **configuration.storage_backend_opts
+)
+@previous_snapshot = backend.load_graph(
+  schema_version: RSpecTracer::Storage::Schema::CURRENT
+)
+```
+
+`Engine#finalize`:
+
+```ruby
+@storage_backend.transactional_save do
+  @storage_backend.save_graph(
+    @snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+  )
+end
+```
+
+Both Json + Sqlite backends accept the same constructor signature
+(`cache_path:` + opts hash). The Configuration DSL's
+`storage_backend(:json, ...)` resolves the symbol to the class
+internally; user code never instantiates a backend directly.
+
+## Custom storage backends
+
+The protocol is small + the contract is exhaustive:
+
+```ruby
+class MyBackend
+  def initialize(cache_path:, **opts)
+    @cache_path = cache_path
+    @opts = opts
+  end
+
+  def load_graph(schema_version:)
+    # Return RSpecTracer::Storage::Snapshot or nil.
+    # Nil = no cache OR schema mismatch.
+    # Never raise on corruption — log + return nil.
+  end
+
+  def save_graph(snapshot, schema_version:)
+    # Persist atomically. Either the whole save succeeds or none of it.
+  end
+
+  def last_run_id
+    # Return the most-recent run_id, or nil.
+  end
+
+  def transactional_save(&block)
+    # Yield with single-writer semantics; commit on clean exit;
+    # roll back on raise.
+    yield
+  end
+
+  def clear!
+    # Remove everything this backend owns at @cache_path.
+  end
+end
+
+RSpecTracer.configure do
+  storage_backend MyBackend.new(cache_path: my_path, my_opt: 'value')
+end
+```
+
+Wire your backend's spec into `spec/contracts/storage_backend.rb`'s
+shared-examples group to verify the contract.
+
+## Where to read code
+
+- `lib/rspec_tracer/storage/backend.rb` — the protocol.
+- `lib/rspec_tracer/storage/json_backend.rb` — JSON impl + `Merger`
+  class for parallel_tests merge.
+- `lib/rspec_tracer/storage/sqlite_backend.rb` — SQLite impl.
+- `lib/rspec_tracer/storage/snapshot.rb` — the data class returned
+  by `load_graph`.
+- `lib/rspec_tracer/storage/lazy_snapshot.rb` — lazy-load wrapper
+  for partial reads.
+- `lib/rspec_tracer/storage/schema.rb` — `CURRENT` schema version
+  constant.
+- `spec/storage/json_backend_spec.rb` + `spec/storage/sqlite_backend_spec.rb`
+  — unit tests.
+- `spec/integration/coverage_json_round_trip_spec.rb` — byte-
+  equivalence test for the coverage payload.

--- a/docs/internals/HOW_TRACKS_CASCADES.md
+++ b/docs/internals/HOW_TRACKS_CASCADES.md
@@ -1,0 +1,178 @@
+# How the `tracks:` DSL cascades
+
+The per-example `tracks: { files:, env: }` metadata DSL declares
+extra inputs the tracker can't auto-observe. This doc walks how
+nested describe groups combine those declarations and why we ship a
+custom walker instead of relying on RSpec's built-in metadata
+inheritance.
+
+## The DSL surface (recap)
+
+```ruby
+RSpec.describe AdminController,
+               tracks: { files: 'app/policies/**/*.rb', env: 'ROLE_CONFIG' } do
+  context 'with feature flag', tracks: { env: 'FEATURE_X' } do
+    it 'gates by role' do
+      # ...
+    end
+  end
+end
+```
+
+The example inside the inner `context` should pick up:
+
+- `:files` from the outer describe (`app/policies/**/*.rb`)
+- `:env` from BOTH groups (`ROLE_CONFIG` + `FEATURE_X`, unioned)
+
+That's the cascade contract: nested groups contribute additively;
+inner groups never clobber outer ones on shared keys.
+
+## Why we don't use RSpec's built-in metadata inheritance
+
+RSpec already cascades metadata from describe → context → example.
+But its built-in cascade is **replace-on-conflict, not union**.
+
+For scalar metadata (`type: :request`, `:slow`, etc.) replace-on-
+conflict is the right choice. For our hash-valued `tracks:`, replace
+would silently drop the outer's `:env` value when an inner group
+re-declares `:env`:
+
+```ruby
+# With RSpec's built-in cascade (HYPOTHETICAL — NOT what we do):
+describe Foo, tracks: { env: 'A' } do
+  context 'inner', tracks: { env: 'B' } do
+    it 'silently loses A' do      # would track only :env => 'B'
+    end
+  end
+end
+```
+
+That's a silent-degradation surprise. The user wrote `tracks: { env:
+'A' }` on the outer expecting it to apply; the inner group
+unintentionally removed it.
+
+## Our walker: union explicitly
+
+`RSpecTracer::RSpec::Metadata.tracks_for(example)` walks the example
+group ancestor chain bottom-up and unions the `:files` + `:env`
+values:
+
+```ruby
+# Pseudocode of the walker shape (see lib/rspec_tracer/rspec/metadata.rb)
+def self.tracks_for(example)
+  files = Set.new
+  envs  = Set.new
+  ancestor = example.example_group
+  while ancestor
+    tracks = ancestor.metadata[:tracks] || {}
+    files.merge(Array(tracks[:files]))
+    envs.merge(Array(tracks[:env]))
+    ancestor = ancestor.superclass
+  end
+  { files: files, env: envs }
+end
+```
+
+Walking bottom-up + accumulating into Sets means:
+- Outer + inner contributions both land.
+- No duplicate-glob processing if both groups happen to declare the
+  same path.
+- Order doesn't matter (Sets are unordered) — the dependency graph
+  ultimately stores file digests, not ordering.
+
+The walker's actual implementation is at
+[`lib/rspec_tracer/rspec/metadata.rb`](../../lib/rspec_tracer/rspec/metadata.rb)
+with unit specs at `spec/rspec/metadata_inheritance_spec.rb` covering
+the cascade interaction (single group / nested / cousin groups /
+shared examples).
+
+## How the walker output flows into the engine
+
+1. **At per-example start time**: the `RunnerHook`'s
+   `example_started` callback calls `tracks_for(example)` to get the
+   `{files:, env:}` Set pair.
+2. **The Set pair gets passed to** `Engine#register_tracks` which:
+   - Resolves each `:files` glob via `Dir.glob(glob, FNM_PATHNAME |
+     FNM_EXTGLOB)`, memoizing per-glob results so the second
+     example with the same glob doesn't re-walk the filesystem.
+   - For each matched file, registers a `:declared`-kind Input on
+     the example's dep set.
+   - For each `:env` name, applies wildcard expansion against the
+     live ENV (`Tracker::EnvMatcher`) and adds the concrete keys
+     to the example's tracked-env set.
+3. **At finalize**: env values get digested into
+   `env_snapshot.json`. Files roll into the existing `dependency.json`
+   / `all_files.json` / `reverse_dependency.json` shape — they're
+   not stored separately by source.
+
+## Wildcard env expansion
+
+`tracks: { env: 'PREFIX_*' }` expands at register-tracks time, not
+at digest time. Implication: only env vars that **existed at the
+time the example registered tracks** get attribution.
+
+```ruby
+ENV['ROLE_CONFIG_ADMIN'] = 'a'
+ENV['ROLE_CONFIG_USER']  = 'b'
+
+RSpec.describe Auth, tracks: { env: 'ROLE_CONFIG_*' } do
+  it 'attributes both' do
+    # tracked: ['ROLE_CONFIG_ADMIN', 'ROLE_CONFIG_USER']
+  end
+end
+```
+
+If `ROLE_CONFIG_GUEST=c` gets set later in the same run (e.g. in a
+`before` block), it does NOT get retroactively attributed to the
+example — the wildcard expansion already concluded.
+
+The persisted `env_snapshot.json` only carries concrete keys, never
+the wildcard pattern itself. This means re-defining a wildcard
+between runs simply updates which concrete keys the next snapshot
+covers; old keys (no longer matching) get dropped.
+
+Pattern grammar (rejected at config-load time with `ArgumentError`):
+
+- Multi-segment / embedded wildcards: `'A_*_B'`
+- Multiple wildcards: `'A_*_B_*'`
+- Character classes / negation / glob `?` / `\\`: `'A_[X]'`,
+  `'A_!B'`, `'A_?'`
+
+The full grammar lives in `lib/rspec_tracer/tracker/env_matcher.rb`.
+
+## Cascade with shared examples
+
+```ruby
+RSpec.shared_examples 'role-gated', tracks: { files: 'app/policies/**/*.rb' } do
+  it 'gates by role' do
+  end
+end
+
+RSpec.describe AdminController, tracks: { env: 'ADMIN_TOKEN' } do
+  it_behaves_like 'role-gated'   # picks up BOTH :files + :env
+end
+```
+
+Shared example groups participate in the ancestor walk just like any
+other group. Both contributions union.
+
+## What the `tracks:` DSL does NOT do
+
+- **Doesn't bypass `track_files` precedence.** When both a per-
+  example `tracks: { files: 'X' }` AND a config-level `track_files
+  'X'` declare the same file, the declared-glob attribution wins
+  (deterministic; see ARCHITECTURE.md "Input taxonomy" → "declared
+  takes precedence" rule).
+- **Doesn't replace `track_env` for the global case.** Use
+  `track_env` for env vars **every** test depends on; use `tracks: {
+  env: ... }` for env vars only specific examples branch on.
+- **Doesn't observe metadata changes mid-run.** The walker runs at
+  example-start time; modifying `metadata[:tracks]` after that
+  doesn't affect attribution.
+
+## Debugging cascade
+
+`bin/rspec-tracer explain <example_id>` shows the resolved per-
+example deps including `:tracks:`-attributed files and env names.
+If a cascade isn't behaving as expected, that's the fastest way to
+see what the walker actually unioned.

--- a/docs/internals/README.md
+++ b/docs/internals/README.md
@@ -1,0 +1,46 @@
+# Internals
+
+Detailed walkthroughs of how rspec-tracer's subsystems work. These
+docs go below the level of [`ARCHITECTURE.md`](../../ARCHITECTURE.md):
+that file gives the layered mental model + protocols; these docs walk
+the actual code paths for specific scenarios.
+
+Audience: contributors + curious users debugging unexpected behavior.
+
+## Documents
+
+- [`HOW_TRACKS_CASCADES.md`](HOW_TRACKS_CASCADES.md) — the per-example
+  `tracks: { files:, env: }` DSL: how nested describes union (rather
+  than overwrite) parent metadata, why we ship our own walker instead
+  of using RSpec's built-in cascade, and how wildcard env patterns
+  expand.
+- [`HOW_PARALLEL_TESTS_MERGE.md`](HOW_PARALLEL_TESTS_MERGE.md) — what
+  happens when `parallel_tests` runs N workers: per-worker cache
+  directory layout, the elected-last-worker pattern, the merge
+  algorithm at finalize, and the report-emission ordering that
+  ensures users see merged output instead of per-worker noise.
+- [`HOW_REMOTE_CACHE_BACKENDS.md`](HOW_REMOTE_CACHE_BACKENDS.md) — the
+  three remote-cache backends (S3 / Local-FS / Redis): tier routing
+  (main vs PR), branch_refs persistence, retention semantics
+  (count + duration + per-PR-branch TTL), and the graceful-degradation
+  contract.
+- [`HOW_STORAGE_BACKENDS.md`](HOW_STORAGE_BACKENDS.md) — JSON vs SQLite
+  on-disk layouts: the 10-file JSON layout (bit-for-bit 1.x compat),
+  the SQLite schema, the schema_version cold-run policy, and how the
+  backends compose with the optional MessagePack serializer.
+
+## When to read which doc
+
+- **"Why didn't my `tracks:` annotation narrow this re-run?"** →
+  [`HOW_TRACKS_CASCADES.md`](HOW_TRACKS_CASCADES.md).
+- **"Why is my parallel_tests run producing N report directories?"** →
+  [`HOW_PARALLEL_TESTS_MERGE.md`](HOW_PARALLEL_TESTS_MERGE.md).
+- **"Why did the cache fall back to cold on a PR build?"** →
+  [`HOW_REMOTE_CACHE_BACKENDS.md`](HOW_REMOTE_CACHE_BACKENDS.md).
+- **"What does the on-disk cache actually look like?"** →
+  [`HOW_STORAGE_BACKENDS.md`](HOW_STORAGE_BACKENDS.md).
+
+For the **why** behind any architectural choice (separate from the
+**how** these docs describe), see
+[`../../ARCHITECTURE.md`](../../ARCHITECTURE.md)'s "Input taxonomy"
+section.

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>rspec-tracer — Documentation</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #fff;
+      --fg: #1a1a1a;
+      --muted: #666;
+      --accent: #c33;
+      --border: #ddd;
+      --code-bg: #f6f8fa;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #1a1a1a;
+        --fg: #f0f0f0;
+        --muted: #aaa;
+        --accent: #f55;
+        --border: #444;
+        --code-bg: #2a2a2a;
+      }
+    }
+    * { box-sizing: border-box; }
+    body {
+      font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI",
+            Roboto, "Helvetica Neue", Arial, sans-serif;
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+      color: var(--fg);
+      background: var(--bg);
+    }
+    h1 { font-size: 2rem; margin: 0 0 0.5rem; }
+    h2 { font-size: 1.25rem; margin-top: 2.5rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+    .lede { font-size: 1.1rem; color: var(--muted); margin: 0 0 1.5rem; }
+    a { color: var(--accent); }
+    a:hover { text-decoration: underline; }
+    a:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); margin-top: 1rem; }
+    .card { border: 1px solid var(--border); border-radius: 6px; padding: 1.25rem; }
+    .card h3 { margin: 0 0 0.5rem; font-size: 1.1rem; }
+    .card p { margin: 0 0 0.5rem; color: var(--muted); font-size: 0.95rem; }
+    code { background: var(--code-bg); padding: 0.15em 0.35em; border-radius: 3px; font-size: 0.9em; }
+    .badges img { margin-right: 0.5rem; vertical-align: middle; }
+    footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--border); color: var(--muted); font-size: 0.9rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>rspec-tracer</h1>
+    <p class="lede">Specs dependency analyzer, flaky-test detector, test accelerator, and coverage reporter for RSpec.</p>
+    <p class="badges">
+      <a href="https://github.com/avmnu-sng/rspec-tracer/actions/workflows/lint-and-specs.yml">
+        <img alt="CI status" src="https://github.com/avmnu-sng/rspec-tracer/actions/workflows/lint-and-specs.yml/badge.svg">
+      </a>
+      <a href="https://badge.fury.io/rb/rspec-tracer">
+        <img alt="Gem version" src="https://badge.fury.io/rb/rspec-tracer.svg">
+      </a>
+    </p>
+  </header>
+
+  <h2>Quick links</h2>
+  <div class="grid">
+    <article class="card">
+      <h3><a href="https://github.com/avmnu-sng/rspec-tracer#readme">README</a></h3>
+      <p>Getting started, configuration, CI integration, FAQ.</p>
+    </article>
+    <article class="card">
+      <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/UPGRADING.md">UPGRADING</a></h3>
+      <p>Migrating from rspec-tracer 1.x to 2.0. Floors, deprecated DSLs, behavior changes.</p>
+    </article>
+    <article class="card">
+      <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/COOKBOOK.md">COOKBOOK</a></h3>
+      <p>13 recipes for common setups: Rails apps, parallel_tests, JRuby, custom backends.</p>
+    </article>
+    <article class="card">
+      <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/ARCHITECTURE.md">ARCHITECTURE</a></h3>
+      <p>The input-taxonomy mental model, layer structure, contracts between layers.</p>
+    </article>
+    <article class="card">
+      <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/ROADMAP.md">ROADMAP</a></h3>
+      <p>Shipped in 2.0, planned for 2.1, considering for 3.0+.</p>
+    </article>
+    <article class="card">
+      <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/CHANGELOG.md">CHANGELOG</a></h3>
+      <p>Every release with a Keep-a-Changelog summary.</p>
+    </article>
+  </div>
+
+  <h2>API reference</h2>
+  <p>Full YARD-generated API docs for every public method, the
+  Configuration DSL, and the backend protocols.</p>
+  <p><a href="yard/index.html">→ Browse the YARD API reference</a></p>
+
+  <h2>Live HTML report demo</h2>
+  <p>The HTML reporter rspec-tracer generates after each test run.
+  This sample is generated from the in-repo Rails fixture; your own
+  reports will look the same shape with your suite's data.</p>
+  <p><a href="demo/index.html">→ Open the sample HTML report</a></p>
+
+  <h2>Internals (contributor docs)</h2>
+  <ul>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/docs/internals/HOW_TRACKS_CASCADES.md">How <code>tracks:</code> cascades</a></li>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/docs/internals/HOW_PARALLEL_TESTS_MERGE.md">How parallel_tests merge works</a></li>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/docs/internals/HOW_REMOTE_CACHE_BACKENDS.md">How remote-cache backends work</a></li>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/docs/internals/HOW_STORAGE_BACKENDS.md">How storage backends work</a></li>
+  </ul>
+
+  <h2>Community</h2>
+  <ul>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/discussions">GitHub Discussions</a> — usage questions, ideas, general chat.</li>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/issues">GitHub Issues</a> — reproducible bugs + concrete feature requests.</li>
+    <li><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/.github/CONTRIBUTING.md">CONTRIBUTING</a> — how to land a PR.</li>
+  </ul>
+
+  <footer>
+    <p>rspec-tracer is released under the
+    <a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/LICENSE">MIT License</a>.
+    Built with <code>task docs:site:build</code>; published via GitHub Actions.</p>
+  </footer>
+</body>
+</html>

--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -124,23 +124,41 @@ module RSpecTracer
       RSpecTracer.running = false
     end
 
+    # The current {RSpecTracer::Engine} instance, or nil if
+    # {.start} hasn't been called yet.
+    #
+    # @return [RSpecTracer::Engine, nil]
     def engine
       @engine if defined?(@engine)
     end
 
+    # True if SimpleCov was loaded AND running at the time
+    # {.start} was invoked. Determines whether rspec-tracer
+    # owns `::Coverage.start` itself (false) or defers to
+    # SimpleCov's coverage lifecycle (true).
+    #
+    # @return [Boolean]
     def simplecov?
       defined?(@simplecov) && @simplecov == true
     end
 
+    # True if `parallel_tests` is in use (detected via
+    # `ParallelTests.active?` at {.start} time). Affects
+    # cache + report directory scoping (per-worker dirs)
+    # and finalize-time merging.
+    #
+    # @return [Boolean]
     def parallel_tests?
       defined?(@parallel_tests) && @parallel_tests == true
     end
 
-    # True iff Rails is loaded in this process. Computed once during
-    # `initial_setup` (via `setup_rails`) and memoized; subsequent Rails
-    # activations within the same run are not re-detected. Matches the
-    # `simplecov?` / `parallel_tests?` shape so callers can branch on
-    # framework presence uniformly.
+    # True if Rails is loaded in this process (detected via
+    # `defined?(::Rails::VERSION)` at {.start} time). Memoized;
+    # subsequent Rails activations within the same run are not
+    # re-detected. Drives the auto-installation of Rails-side
+    # observers (template + AR notification subscribers).
+    #
+    # @return [Boolean]
     def rails?
       defined?(@rails) && @rails == true
     end

--- a/lib/rspec_tracer/cli/cache_clear.rb
+++ b/lib/rspec_tracer/cli/cache_clear.rb
@@ -8,6 +8,11 @@ module RSpecTracer
     # directories. Prompts for confirmation unless `--yes` is passed.
     # The next rspec run is a cold run.
     module CacheClear
+      # @param args [Array<String>] sub-command args (`-y` / `--yes`
+      #   skips confirmation; `-h` / `--help` prints help).
+      # @param stdout [IO]
+      # @param stderr [IO]
+      # @return [Integer] exit status (0 = success / aborted, 1 = error).
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 

--- a/lib/rspec_tracer/cli/cache_info.rb
+++ b/lib/rspec_tracer/cli/cache_info.rb
@@ -8,6 +8,10 @@ module RSpecTracer
     # invalidation stats. Reads `last_run.json` + the run-id'd JSON
     # files written by Storage::JsonBackend.
     module CacheInfo
+      # @param args [Array<String>] sub-command args (`-h` / `--help`).
+      # @param stdout [IO]
+      # @param stderr [IO]
+      # @return [Integer] exit status (0 = success).
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 

--- a/lib/rspec_tracer/cli/doctor.rb
+++ b/lib/rspec_tracer/cli/doctor.rb
@@ -7,6 +7,11 @@ module RSpecTracer
     # cache / coverage / report directory state, and SimpleCov / Rails
     # presence. Exits 0 on healthy diagnosis, 1 if any check fails.
     module Doctor
+      # @param args [Array<String>] sub-command args (`-h` / `--help`).
+      # @param stdout [IO]
+      # @param stderr [IO]
+      # @return [Integer] exit status (0 = healthy, 1 = any check
+      #   FAILed; warnings keep status 0).
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 

--- a/lib/rspec_tracer/cli/explain.rb
+++ b/lib/rspec_tracer/cli/explain.rb
@@ -10,6 +10,12 @@ module RSpecTracer
     # + failed_examples.json + flaky_examples.json) to surface the
     # dependency set, last-run status, and the run-decision reason.
     module Explain
+      # @param args [Array<String>] sub-command args. First positional
+      #   arg is the example_id (or substring) to explain.
+      # @param stdout [IO]
+      # @param stderr [IO]
+      # @return [Integer] exit status (0 = explanation printed,
+      #   1 = example not found / cache missing).
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.empty? || args.include?('-h') || args.include?('--help')
 

--- a/lib/rspec_tracer/cli/report_open.rb
+++ b/lib/rspec_tracer/cli/report_open.rb
@@ -7,6 +7,11 @@ module RSpecTracer
     # `open` (macOS) / `xdg-open` (Linux). Falls back to printing the
     # path when no opener is available.
     module ReportOpen
+      # @param args [Array<String>] sub-command args (`-h` / `--help`).
+      # @param stdout [IO]
+      # @param stderr [IO]
+      # @return [Integer] exit status (0 = opened or path printed,
+      #   1 = report missing).
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -6,8 +6,42 @@ require_relative 'filter'
 require_relative 'logger'
 
 module RSpecTracer
+  # The user-facing configuration DSL. Mixed into `RSpecTracer` itself,
+  # so calls inside a `.rspec-tracer` (or `~/.rspec-tracer`) file appear
+  # against the top-level module:
+  #
+  # @example A typical `.rspec-tracer`
+  #   RSpecTracer.configure do
+  #     project_name 'My App'
+  #     track_files 'config/locales/**/*.yml', 'db/schema.rb', 'Gemfile.lock'
+  #     track_env   'AUTH_TOKEN', 'DATABASE_URL', 'RAILS_*'
+  #     track_rails_defaults
+  #
+  #     storage_backend :sqlite
+  #     remote_cache_backend :s3, bucket: 'my-bucket', prefix: 'rspec-tracer'
+  #
+  #     add_filter '/vendor/'
+  #     add_coverage_filter %w[/spec/ /test/]
+  #   end
+  #
+  # The DSL methods are technically `private` in Ruby; the `configure`
+  # block uses Docile to expose them as if public. Calling them
+  # outside a `.rspec-tracer` file raises `InvalidUsageError`. The
+  # configuration loader allowlist enforces this gate (see
+  # {ALLOWED_CONFIGURER}).
+  #
+  # See also:
+  # - {file:README.md} — user guide.
+  # - {file:UPGRADING.md} — 1.x → 2.0 migration.
+  # - {file:ARCHITECTURE.md} — input taxonomy + layer structure.
+  # - {file:COOKBOOK.md} — recipes for common scenarios.
+  #
   # rubocop:disable Metrics/ModuleLength
   module Configuration
+    # Raised when the configuration DSL is invoked outside a
+    # `.rspec-tracer` / `~/.rspec-tracer` loader, when a typo'd DSL
+    # method is called (with a `did_you_mean?` suggestion when one
+    # exists), or when an option value fails validation.
     class InvalidUsageError < StandardError; end
 
     ALLOWED_CONFIGURER = %w[
@@ -87,6 +121,16 @@ module RSpecTracer
 
     private
 
+    # Set the project root directory. Defaults to `Dir.getwd`.
+    # Affects how all other path-based DSL methods (`cache_dir`,
+    # `report_dir`, `coverage_dir`, `track_files` globs) are
+    # resolved.
+    #
+    # @param root [String, nil] absolute or relative path; nil
+    #   returns the current value (or default).
+    # @return [String] absolute project root path.
+    # @example
+    #   RSpecTracer.configure { root '/path/to/project' }
     def root(root = nil)
       return @root if defined?(@root) && root.nil?
 
@@ -97,6 +141,11 @@ module RSpecTracer
       @root = File.expand_path(root || Dir.getwd)
     end
 
+    # Set the project's display name; appears in HTML reports.
+    # Defaults to a humanized form of the project root's basename.
+    #
+    # @param new_name [String, nil] human-readable project name.
+    # @return [String] the configured (or derived) project name.
     def project_name(new_name = nil)
       return @project_name if defined?(@project_name) && @project_name && new_name.nil?
 
@@ -104,6 +153,14 @@ module RSpecTracer
       @project_name ||= File.basename(root.split('/').last).capitalize.tr('_', ' ')
     end
 
+    # Override the on-disk cache directory (default
+    # `rspec_tracer_cache`). Also reads `RSPEC_TRACER_CACHE_DIR`
+    # from env when set. The directory ships in the canonical
+    # `.gitignore` recipe; renaming silently leaks cache into
+    # source control.
+    #
+    # @param dir [String, nil] relative-to-root or absolute path.
+    # @return [String] configured cache directory.
     def cache_dir(dir = nil)
       return @cache_dir if defined?(@cache_dir) && dir.nil?
 
@@ -115,6 +172,11 @@ module RSpecTracer
                    end
     end
 
+    # Resolve the absolute cache path; expanded against {#root} and
+    # scoped per `TEST_SUITE_ID` / `parallel_tests` worker. Creates
+    # the directory on first access.
+    #
+    # @return [String] absolute cache path.
     def cache_path
       @cache_path ||= begin
         cache_path = File.expand_path(cache_dir, root)
@@ -127,6 +189,11 @@ module RSpecTracer
       end
     end
 
+    # Override the on-disk HTML/JSON report directory (default
+    # `rspec_tracer_report`). Also reads `RSPEC_TRACER_REPORT_DIR`.
+    #
+    # @param dir [String, nil] relative-to-root or absolute path.
+    # @return [String] configured report directory.
     def report_dir(dir = nil)
       return @report_dir if defined?(@report_dir) && dir.nil?
 
@@ -138,6 +205,11 @@ module RSpecTracer
                     end
     end
 
+    # Resolve the absolute report path; expanded against {#root} and
+    # scoped per `TEST_SUITE_ID` / `parallel_tests` worker. Creates
+    # the directory on first access.
+    #
+    # @return [String] absolute report path.
     def report_path
       @report_path ||= begin
         report_path = File.expand_path(report_dir, root)
@@ -150,6 +222,11 @@ module RSpecTracer
       end
     end
 
+    # Override the coverage output directory (default
+    # `rspec_tracer_coverage`). Also reads `RSPEC_TRACER_COVERAGE_DIR`.
+    #
+    # @param dir [String, nil] relative-to-root or absolute path.
+    # @return [String] configured coverage directory.
     def coverage_dir(dir = nil)
       return @coverage_dir if defined?(@coverage_dir) && dir.nil?
 
@@ -161,6 +238,11 @@ module RSpecTracer
                       end
     end
 
+    # Resolve the absolute coverage path; expanded against {#root}
+    # and scoped per `TEST_SUITE_ID` / `parallel_tests` worker.
+    # Creates the directory on first access.
+    #
+    # @return [String] absolute coverage path.
     def coverage_path
       @coverage_path ||= begin
         coverage_path = File.expand_path(coverage_dir, root)
@@ -173,19 +255,29 @@ module RSpecTracer
       end
     end
 
-    # M7.1 canonical DSL for the remote cache backend. Single-entry
-    # accumulator; raises on a second call so a misconfigured
-    # `.rspec-tracer` fails fast instead of silently picking one.
+    # Configure the remote-cache backend used by the
+    # `rake rspec_tracer:remote_cache:download` / `:upload` tasks.
+    # Single-entry accumulator: a second call raises
+    # {InvalidUsageError} so a misconfigured `.rspec-tracer` fails
+    # fast.
     #
-    # Shapes:
+    # @param name_or_class [Symbol, Class] one of `:s3`, `:local_fs`,
+    #   `:redis`, OR a custom class implementing
+    #   {RSpecTracer::RemoteCache::Backend}.
+    # @param opts [Hash] backend-specific keyword args (e.g. `bucket:`
+    #   `prefix:` for `:s3`; `root:` for `:local_fs`; `url:` `ttl:`
+    #   for `:redis`).
+    # @return [Array(Symbol, Hash)] the persisted entry pair.
+    # @example S3 (preserves the 1.x layout)
     #   remote_cache_backend :s3, bucket: 'my-bucket', prefix: 'rspec-tracer'
-    #   remote_cache_backend :s3, bucket: 'x', prefix: 'y', local: true
-    #   remote_cache_backend MyBackend, some_opt: 'value'
-    #
-    # Symbol names are not validated at config time because M7.2
-    # backends (`:local_fs`, `:redis`) resolve at UserTasks build time;
-    # a typo there surfaces as an "unknown remote_cache_backend: :s3x"
-    # error in the Rake task, which is the right layer for the message.
+    # @example LocalStack / awslocal (development)
+    #   remote_cache_backend :s3, bucket: 'my-bucket', prefix: 'x', local: true
+    # @example Filesystem-backed (no S3 needed)
+    #   remote_cache_backend :local_fs, root: '/tmp/rspec-tracer-cache'
+    # @example Redis (with TTL + PR-branch tracking sidecar)
+    #   remote_cache_backend :redis, url: ENV['REDIS_URL'], ttl: 7 * 86_400
+    # @example Custom backend class
+    #   remote_cache_backend MyCustomBackend, custom_opt: 'value'
     def remote_cache_backend(name_or_class, **opts)
       if defined?(@remote_cache_backend_entry) && @remote_cache_backend_entry
         raise InvalidUsageError, 'remote_cache_backend already configured'
@@ -213,6 +305,22 @@ module RSpecTracer
       end
     end
 
+    # Convenience DSL accepting a single URI string and dispatching
+    # to {#remote_cache_backend} with the parsed bucket / prefix /
+    # host / path. Also reads `RSPEC_TRACER_REMOTE_CACHE_URI` from env.
+    #
+    # @param uri [String, nil] one of `s3://bucket/prefix`,
+    #   `file:///abs/path`, `redis://host:port/db`. Pass nil to read
+    #   the env var (or return the cached value if set).
+    # @return [String, nil] the configured URI, or nil when neither
+    #   arg nor env is set.
+    # @example
+    #   remote_cache_uri 's3://my-bucket/rspec-tracer'
+    # @example
+    #   remote_cache_uri 'file:///tmp/rspec-tracer-cache'
+    # @example
+    #   remote_cache_uri 'redis://localhost:6379/0'
+    #
     # Convenience DSL: `remote_cache_uri '<scheme>://...'` parses the
     # URI and calls `remote_cache_backend` with the right backend +
     # connection params. Also accepts ENV `RSPEC_TRACER_REMOTE_CACHE_URI`.
@@ -276,6 +384,14 @@ module RSpecTracer
     # Retention knobs (closes issue #20). Mutually exclusive: count
     # and duration bound the main tier from different axes. PR tier
     # uses `cache_retention_pr_branch_ttl` independently.
+    # Cap remote-cache main-tier refs to a count. Mutually exclusive
+    # with {#cache_retention_duration}; setting both raises.
+    #
+    # @param count [Integer, nil] positive integer; nil reads current
+    #   value.
+    # @return [Integer, nil] configured count.
+    # @raise [InvalidUsageError] when count is non-positive or when
+    #   {#cache_retention_duration} is already set.
     def cache_retention_count(count = nil)
       return @cache_retention_count if defined?(@cache_retention_count) && count.nil?
       return nil if count.nil?
@@ -288,6 +404,15 @@ module RSpecTracer
       @cache_retention_count = count
     end
 
+    # Cap remote-cache main-tier refs by age. Mutually exclusive with
+    # {#cache_retention_count}; setting both raises.
+    #
+    # @param spec [String, Integer, nil] duration string (e.g.
+    #   `'7d'`, `'48h'`, `'30m'`) OR seconds as integer. nil reads
+    #   current.
+    # @return [String, Integer, nil] configured raw spec.
+    # @raise [InvalidUsageError] when spec is unparseable or when
+    #   {#cache_retention_count} is already set.
     def cache_retention_duration(spec = nil)
       return @cache_retention_duration_raw if defined?(@cache_retention_duration_raw) && spec.nil?
       return nil if spec.nil?
@@ -298,12 +423,20 @@ module RSpecTracer
       @cache_retention_duration_seconds = seconds
     end
 
+    # @return [Integer, nil] {#cache_retention_duration} expressed
+    #   in seconds, or nil if not set.
     def cache_retention_duration_seconds
       return nil unless defined?(@cache_retention_duration_seconds)
 
       @cache_retention_duration_seconds
     end
 
+    # Cap remote-cache PR-tier refs by age. Independent of main-tier
+    # retention (PR branches typically need shorter TTLs than the
+    # historical main).
+    #
+    # @param spec [String, Integer, nil] duration string or seconds.
+    # @return [String, Integer, nil] configured raw spec.
     def cache_retention_pr_branch_ttl(spec = nil)
       return @cache_retention_pr_branch_ttl_raw if defined?(@cache_retention_pr_branch_ttl_raw) && spec.nil?
       return nil if spec.nil?
@@ -313,6 +446,8 @@ module RSpecTracer
       @cache_retention_pr_branch_ttl_seconds = seconds
     end
 
+    # @return [Integer, nil] {#cache_retention_pr_branch_ttl}
+    #   expressed in seconds.
     def cache_retention_pr_branch_ttl_seconds
       return nil unless defined?(@cache_retention_pr_branch_ttl_seconds)
 
@@ -363,6 +498,12 @@ module RSpecTracer
     # options keep working with one-time warnings." Migration target:
     # `remote_cache_uri` (for the URI form) or
     # `remote_cache_backend :s3, bucket:, prefix:` (for structured form).
+    # @deprecated Use {#remote_cache_uri} or {#remote_cache_backend}.
+    #   Pre-2.0 1.x compatibility shim. Fires a one-time `logger.warn`
+    #   at first use; the value still resolves so 1.x configs keep
+    #   working until the 3.0 removal.
+    # @param s3_path [String, nil] `s3://bucket/prefix`.
+    # @return [String, nil]
     def reports_s3_path(s3_path = nil)
       return @reports_s3_path if defined?(@reports_s3_path) && s3_path.nil?
 
@@ -384,6 +525,11 @@ module RSpecTracer
     # Deprecated in 2.0. Migration: `remote_cache_backend :s3, ...,
     # local: true`. Kept for backward compat; UserTasks derives the
     # `local:` opt from this when `remote_cache_backend` is absent.
+    # @deprecated Use `remote_cache_backend :s3, ..., local: true`.
+    #   Pre-2.0 1.x compatibility shim for `awslocal` / LocalStack.
+    #   Fires a one-time `logger.warn` at first use.
+    # @param new_flag [Boolean, nil]
+    # @return [Boolean]
     def use_local_aws(new_flag = nil)
       return @use_local_aws if defined?(@use_local_aws) && new_flag.nil?
 
@@ -408,6 +554,12 @@ module RSpecTracer
       logger.warn("rspec-tracer deprecation: #{message}")
     end
 
+    # Allow remote-cache uploads from non-CI environments (default
+    # `false`). Reads `RSPEC_TRACER_UPLOAD_NON_CI_REPORTS=true` as
+    # an alternate enable.
+    #
+    # @param new_flag [Boolean, nil]
+    # @return [Boolean]
     def upload_non_ci_reports(new_flag = nil)
       return @upload_non_ci_reports if defined?(@upload_non_ci_reports) && new_flag.nil?
 
@@ -418,6 +570,13 @@ module RSpecTracer
                                end
     end
 
+    # Force every example to run (default `false` — the tracer's
+    # whole point is to skip unaffected examples). Reads
+    # `RSPEC_TRACER_RUN_ALL_EXAMPLES=true` as an alternate enable.
+    # Useful for one-off "rebaseline the cache" runs.
+    #
+    # @param new_flag [Boolean, nil]
+    # @return [Boolean]
     def run_all_examples(new_flag = nil)
       return @run_all_examples if defined?(@run_all_examples) && new_flag.nil?
 
@@ -428,6 +587,13 @@ module RSpecTracer
                           end
     end
 
+    # Exit with non-zero when duplicate-identity examples are
+    # detected (default `true` — duplicates break per-example
+    # attribution). Reads `RSPEC_TRACER_FAIL_ON_DUPLICATES=false` as
+    # an alternate disable.
+    #
+    # @param new_flag [Boolean, nil]
+    # @return [Boolean]
     def fail_on_duplicates(new_flag = nil)
       return @fail_on_duplicates if defined?(@fail_on_duplicates) && new_flag.nil?
 
@@ -484,12 +650,32 @@ module RSpecTracer
     # :schema category on alongside this flag is a no-op in terms of
     # the final re-run set - declared-glob attaches schema to every
     # example regardless of what this subscriber emits.
+    # Setter DSL — bare call enables, explicit `(false)` disables.
+    # Any other positional value coerces to disabled (defensive for
+    # typos). Read the resulting state via {#track_ar_schema_notifications?}.
+    #
+    # @param args [Array] positional args (bare = enable; `false` =
+    #   disable; anything else = disable defensively).
+    # @return [Boolean]
+    # @note **Common Rails setups widen this to whole-suite-on-schema-
+    #   change.** Per-example AR cleanup mechanisms
+    #   (`use_transactional_fixtures = true`, DatabaseCleaner
+    #   `:truncation` / `:deletion` / `:transaction`) fire
+    #   `sql.active_record` inside the per-example bucket, attributing
+    #   `db/schema.rb` to every AR-touching example. A boot-time warn
+    #   fires when the precondition isn't met. See README "Narrow
+    #   AR-schema attribution".
     def track_ar_schema_notifications(*args)
       # Setter DSL: bare call enables, explicit `(false)` disables,
       # any other positional coerces to false (defensive for typos).
       @track_ar_schema_notifications = args.empty? || args.first == true
     end
 
+    # Reads the resolved AR-schema-notifications state. The
+    # `RSPEC_TRACER_AR_SCHEMA_NOTIFICATIONS` env var overrides the
+    # DSL value when set.
+    #
+    # @return [Boolean]
     def track_ar_schema_notifications?
       return ENV['RSPEC_TRACER_AR_SCHEMA_NOTIFICATIONS'] == 'true' if ENV.key?('RSPEC_TRACER_AR_SCHEMA_NOTIFICATIONS')
       return false unless defined?(@track_ar_schema_notifications)
@@ -497,6 +683,11 @@ module RSpecTracer
       @track_ar_schema_notifications == true
     end
 
+    # Override the parallel_tests lock-file path (default
+    # `rspec_tracer.lock`). Reads `RSPEC_TRACER_LOCK_FILE`.
+    #
+    # @param new_file [String, nil]
+    # @return [String]
     def lock_file(new_file = nil)
       return @lock_file if defined?(@lock_file) && @lock_file && new_file.nil?
 
@@ -507,6 +698,11 @@ module RSpecTracer
                    end
     end
 
+    # Set the tracer's log level. Reads `RSPEC_TRACER_LOG_LEVEL`.
+    #
+    # @param new_level [Symbol, String, nil] one of `:off`, `:debug`,
+    #   `:info`, `:warn`, `:error`. Default `:info`.
+    # @return [Integer] numeric level (LOG_LEVEL constant value).
     def log_level(new_level = nil)
       return @log_level if defined?(@log_level) && @log_level && new_level.nil?
 
@@ -520,23 +716,42 @@ module RSpecTracer
       @log_level = LOG_LEVEL[level.to_s.to_sym].to_i
     end
 
+    # Lazy-initialized {RSpecTracer::Logger} instance honoring
+    # {#log_level}.
+    #
+    # @return [RSpecTracer::Logger]
     def logger
       @logger ||= RSpecTracer::Logger.new(log_level)
     end
 
+    # Track files for SimpleCov coverage emission only (NOT for the
+    # tracer's per-example dependency graph). Use {#track_files} for
+    # the dependency graph.
+    #
+    # @param glob [String] file glob pattern.
+    # @return [String]
     def coverage_track_files(glob)
       @coverage_track_files = glob
     end
 
+    # @return [String, nil] the configured {#coverage_track_files} value.
     def coverage_tracked_files
       @coverage_track_files if defined?(@coverage_track_files)
     end
 
-    # M3.3 declared-globs DSL. Accumulates every call into a single
-    # array that DeclaredGlobs / NewFileDetector consume at boot.
-    # Coexists with legacy `coverage_track_files` (single-arg setter,
-    # overwrite-on-call) without changing that surface - see
-    # `#declared_globs` for the consolidated view.
+    # Declare globs of files every example depends on (e.g.
+    # `Gemfile.lock`, `db/schema.rb`, `config/locales/**/*.yml`).
+    # Globs accumulate across calls; the tracker resolves matched
+    # files at boot and attaches them as `:declared`-kind inputs
+    # to every example. For files only specific examples depend on,
+    # use the per-example `tracks: { files: '...' }` metadata DSL.
+    #
+    # @param globs [Array<String>] file glob patterns (each matched
+    #   via `Dir.glob` with `FNM_PATHNAME | FNM_EXTGLOB`).
+    # @return [Array<String>] the accumulated glob list.
+    # @raise [InvalidUsageError] if called after the tracker started.
+    # @example
+    #   track_files 'config/locales/**/*.yml', 'db/schema.rb', 'Gemfile.lock'
     def track_files(*globs)
       if defined?(@declared_globs_frozen) && @declared_globs_frozen
         raise InvalidUsageError,
@@ -559,17 +774,22 @@ module RSpecTracer
       all.uniq.freeze
     end
 
-    # Rails preset hook. Expands to the Rails glob set defined in
-    # RSpecTracer::Rails::Preset (views, helpers, locales, config,
-    # schema, factories, fixtures) and accumulates those globs into
-    # `@track_files_globs`. Per-category opt-out via the `except:`
-    # keyword argument (e.g. `track_rails_defaults except: [:views]`).
+    # Rails preset — attaches the common Rails-side declared globs in
+    # one DSL call. Expands to the glob set defined in
+    # `RSpecTracer::Rails::Preset` (views, helpers, locales, config,
+    # schema, factories, fixtures).
     #
-    # Requires 'rspec_tracer/rails/preset' lazily so pure-Ruby suites
-    # that never call `track_rails_defaults` do not pay for the file
-    # load. Deduplication and whole-suite-invalidator reuse happen in
-    # `#declared_globs` / `Tracker::WholeSuiteInvalidators`; this method
-    # is intentionally idempotent on repeat calls.
+    # @param except [Array<Symbol>] categories to opt out of (so a
+    #   per-example subscriber attributes them instead). Common
+    #   recipe: `track_rails_defaults except: [:views, :schema]`
+    #   pairs with {#track_ar_schema_notifications} for narrow
+    #   per-example schema attribution.
+    # @return [Array<String>] the resulting accumulated glob list.
+    # @example Default — all categories on
+    #   track_rails_defaults
+    # @example Opt out of views + schema for per-example subscribers
+    #   track_rails_defaults except: [:views, :schema]
+    #   track_ar_schema_notifications
     def track_rails_defaults(except: [])
       require_relative 'rails/preset'
 
@@ -600,6 +820,19 @@ module RSpecTracer
     # internal accumulator). Setter raises if called after
     # `freeze_declared_globs!` flipped the latch (same "tracker has
     # started, no more declarations" contract as `track_files`).
+    # Declare env vars every example depends on. Wildcards expand
+    # against the live ENV at config load. For env vars only specific
+    # examples branch on, use the per-example
+    # `tracks: { env: '...' }` metadata DSL.
+    #
+    # @param names [Array<String, Symbol>] literal env names OR
+    #   single-wildcard patterns (`'PREFIX_*'`, `'*_SUFFIX'`, `'*'`).
+    # @return [Array<String>] frozen accumulated names list.
+    # @raise [InvalidUsageError] if called after the tracker started,
+    #   or if a pattern is malformed (multi-segment wildcards like
+    #   `'A_*_B'`, character classes, etc. are rejected).
+    # @example
+    #   track_env 'AUTH_TOKEN', 'DATABASE_URL', 'RAILS_*', '*_API_KEY'
     def track_env(*names)
       if defined?(@declared_globs_frozen) && @declared_globs_frozen
         raise InvalidUsageError,
@@ -782,6 +1015,24 @@ module RSpecTracer
     # :sqlite does not accept any opts - its storage layout is a
     # single sqlite3 file with a normalized schema; serializer
     # substitution does not apply.
+    # Configure the on-disk storage backend. Reads
+    # `RSPEC_TRACER_STORAGE` for env-based override.
+    #
+    # @param name [Symbol, nil] one of `:json` (default; preserves
+    #   1.x layout) or `:sqlite` (single-file DB; MRI 3.2+ only;
+    #   JRuby auto-falls-back to `:json` with a one-time warn).
+    # @param opts [Hash] backend-specific opts. `:json` accepts
+    #   `serializer:` (`:json` default or `:msgpack`); `:sqlite`
+    #   accepts no opts.
+    # @return [Symbol] the resolved backend name.
+    # @raise [InvalidUsageError] for unknown backend names or
+    #   invalid opts.
+    # @example JSON (default)
+    #   storage_backend :json
+    # @example SQLite (faster cold reads above ~5,000 examples)
+    #   storage_backend :sqlite
+    # @example JSON with msgpack serializer
+    #   storage_backend :json, serializer: :msgpack
     def storage_backend(name = nil, **opts)
       if defined?(@storage_backend_name) && @storage_backend_name && name.nil? && opts.empty?
         return @storage_backend_name
@@ -894,26 +1145,65 @@ module RSpecTracer
       RSpecTracer::Reporters::Registry::BUILT_INS.keys
     end
 
+    # Add a filter to exclude files from the tracer's per-example
+    # dependency graph. Files matching the filter are not registered
+    # as deps, so changes to them don't trigger re-runs.
+    #
+    # @param filter [String, Regexp, Array, RSpecTracer::Filter, nil]
+    #   filter spec. Nil + a block also accepted; the block receives
+    #   a `source_file` Hash (`:name` / `:file_path`) and returns
+    #   true to exclude.
+    # @return [Array] the updated filters list.
+    # @example String match (substring)
+    #   add_filter '/vendor/bundle/'
+    # @example Regex match
+    #   add_filter %r{^/helpers/}
+    # @example Block
+    #   add_filter { |source_file| source_file[:file_path].include?('/helpers/') }
+    # @example Array of mixed types
+    #   add_filter ['/helpers/', %r{^/utils/}]
     def add_filter(filter = nil, &)
       filters << parse_filter(filter, &)
     end
 
+    # @return [Array] the currently-registered dep-graph filters.
+    #   Use `filters.clear` to reset.
     def filters
       @filters ||= []
     end
 
+    # Bulk filters assignment is intentionally rejected — use
+    # {#filters} `.clear` + repeated {#add_filter} instead so each
+    # entry routes through the same parser.
+    #
+    # @raise [NotImplementedError]
     def filters=(new_filteres)
       raise NotImplementedError
     end
 
+    # Add a filter to exclude files from coverage reporting (NOT
+    # from the tracer's dep graph). Use {#add_filter} for the
+    # dep graph; this controls SimpleCov-style coverage output only.
+    #
+    # @param filter [String, Regexp, Array, nil] same shape as
+    #   {#add_filter}'s filter arg.
+    # @return [Array]
+    # @example
+    #   add_coverage_filter %w[/spec/ /test/ /vendor/bundle/]
     def add_coverage_filter(filter = nil, &)
       coverage_filters << parse_filter(filter, &)
     end
 
+    # @return [Array] the currently-registered coverage filters.
+    #   Use `coverage_filters.clear` to reset.
     def coverage_filters
       @coverage_filters ||= []
     end
 
+    # Bulk coverage_filters assignment intentionally rejected — see
+    # {#filters=}.
+    #
+    # @raise [NotImplementedError]
     def coverage_filters=(new_filteres)
       raise NotImplementedError
     end

--- a/lib/rspec_tracer/tracker/example_registry.rb
+++ b/lib/rspec_tracer/tracker/example_registry.rb
@@ -48,7 +48,7 @@ module RSpecTracer
       # identity_hash for duplicate detection. First call wins for
       # the identity_hash binding; subsequent calls with the same
       # identity_hash but a different example_id accumulate into
-      # @duplicates and do not re-bind.
+      # `@duplicates` and do not re-bind.
       def register(example_id, metadata: {}, identity_hash: nil)
         @examples[example_id] ||= { metadata: metadata.dup, status: nil }
         track_identity(example_id, identity_hash) if identity_hash

--- a/lib/rspec_tracer/tracker/io_hooks/file.rb
+++ b/lib/rspec_tracer/tracker/io_hooks/file.rb
@@ -13,7 +13,7 @@ module RSpecTracer
       # the entire process for the life of the run, even between
       # examples and during boot. Without the guard each File.read
       # paid 2 method-dispatch frames + IOHooks._record's
-      # @root_prefix nil-check before the inner bucket check could
+      # `@root_prefix` nil-check before the inner bucket check could
       # bail. With the guard, the bucket check happens at FileReads
       # so the reject path skips IOHooks.record entirely. Cuts the
       # M2 Max reject overhead from ~530 ns/call to ~300 ns/call

--- a/lib/rspec_tracer/tracker/loaded_files_tracker.rb
+++ b/lib/rspec_tracer/tracker/loaded_files_tracker.rb
@@ -136,8 +136,8 @@ module RSpecTracer
       # whole-suite invalidator.
       #
       # Invariant (enforced by capture_boot_set!): every path in
-      # @boot_set has a matching @input_cache entry, so the fetch
-      # never raises. Disabled trackers produce an empty @boot_set,
+      # `@boot_set` has a matching `@input_cache` entry, so the fetch
+      # never raises. Disabled trackers produce an empty `@boot_set`,
       # so the enumeration naturally returns {} without a guard.
       def boot_set_digest_snapshot
         return {} if @boot_set.nil?
@@ -211,7 +211,7 @@ module RSpecTracer
 
       # Full filtered peek - returns a Set of every under-root String
       # path in the peek result. Used by capture_boot_set! (no prior
-      # @loaded_set to diff against).
+      # `@loaded_set` to diff against).
       def filtered_peek_paths
         @peek.call.each_with_object(Set.new) do |path, acc|
           acc << path if path.is_a?(String) && path.start_with?(@root_prefix)
@@ -253,9 +253,9 @@ module RSpecTracer
       # digest failed). Side effect: populates @input_cache.
       #
       # Callers are responsible for passing only paths absent from
-      # @input_cache (capture_boot_set! on empty cache, stop_example
-      # on `filtered_peek_keys - @loaded_set` where @loaded_set
-      # mirrors @input_cache's keys modulo digest failures).
+      # `@input_cache` (capture_boot_set! on empty cache, stop_example
+      # on `filtered_peek_keys - @loaded_set` where `@loaded_set`
+      # mirrors `@input_cache`'s keys modulo digest failures).
       def build_inputs(paths)
         paths.each_with_object(Set.new) do |path, acc|
           digest = file_digest(path)

--- a/taskfiles/docs.yml
+++ b/taskfiles/docs.yml
@@ -26,3 +26,27 @@ tasks:
       which public API methods still lack doc comments.
     cmds:
       - bundle exec yard stats --list-undoc
+
+  docs:wcag:
+    desc: >-
+      Run WCAG 2.1 AA accessibility audit on the HTML reporter via
+      axe-core. Requires Node + Chrome (auto-installs ChromeDriver
+      via browser-driver-manager on first run).
+      Generates rspec_tracer_report/ first if missing by running
+      task test:features:rails.
+    cmds:
+      - test -f rspec_tracer_report/index.html || task test:features:rails
+      - npx --yes @axe-core/cli "file://$(pwd)/rspec_tracer_report/index.html" --tags wcag2aa,wcag21aa --timeout 240
+
+  docs:site:build:
+    desc: >-
+      Build the unified docs site (YARD HTML + sample HTML report
+      + landing page) under doc/site/ for GitHub Pages publishing.
+      The docs-publish workflow runs the same task on push to main.
+    cmds:
+      - rm -rf doc/site
+      - mkdir -p doc/site/yard doc/site/demo
+      - bundle exec yard doc --output-dir doc/site/yard
+      - test -f rspec_tracer_report/index.html || task test:features:rails
+      - cp -r rspec_tracer_report/* doc/site/demo/
+      - cp docs/site/index.html doc/site/index.html


### PR DESCRIPTION
## Summary

Builds on [#150](https://github.com/avmnu-sng/rspec-tracer/pull/150)
(the prior 2.0 documentation pass) by closing every documentation
gap previously deferred for "post-release feedback". Per the
maintainer's "do entire doc, don't defer to anything else" framing
at the prior session's close, this PR ships the comprehensive
follow-up surface in one shot.

### What ships

**Comprehensive YARD pass** (~250 LOC of doc-comments)

- Full YARD coverage on every user-facing Configuration DSL method
  (~25 methods + their reader counterparts).
- Module-level docstring on `RSpecTracer::Configuration` with a
  `.rspec-tracer` example.
- YARD on every CLI sub-command's `.run` entry (`doctor`,
  `cache:info`, `cache:clear`, `report:open`, `explain`).
- YARD on `RSpecTracer.engine`, `simplecov?`, `parallel_tests?`,
  `rails?`.
- `.yardopts` updated: dropped `--no-private` (the DSL methods are
  technically `private` Ruby-side but functionally public via the
  Docile-driven `configure` block).
- Fixed 5 pre-existing `Unknown tag` warnings on internal-helper
  comments; `task docs:yard:check` now exits cleanly with zero
  warnings on the documented public API surface.

**[`COOKBOOK.md`](COOKBOOK.md)** — 13 scenario walkthroughs

Fresh gem · Rails app (with the eager_load tradeoff) · 1.x →
2.0 migration · remote cache (S3 / LocalStack / Local-FS / Redis)
· `parallel_tests` · JRuby · `tracks:` for non-Ruby deps · env-var
branching · SQLite storage · debugging "why did this re-run?" ·
composing with Knapsack / RSpec::Retry / RSpec::Rerun · custom
storage backends · custom reporters.

**[`docs/internals/`](docs/internals/)** — 4 contributor deep-dives

- [`HOW_TRACKS_CASCADES.md`](docs/internals/HOW_TRACKS_CASCADES.md)
- [`HOW_PARALLEL_TESTS_MERGE.md`](docs/internals/HOW_PARALLEL_TESTS_MERGE.md)
- [`HOW_REMOTE_CACHE_BACKENDS.md`](docs/internals/HOW_REMOTE_CACHE_BACKENDS.md)
- [`HOW_STORAGE_BACKENDS.md`](docs/internals/HOW_STORAGE_BACKENDS.md)

Each doc points at concrete `lib/` paths + spec files for the
contributor doing the actual investigation.

**[`docs/WCAG_AUDIT.md`](docs/WCAG_AUDIT.md)** — accessibility baseline

- Audit run via axe-core 4.11.4 against the HTML reporter on
  2026-05-04. Tags: `wcag2aa,wcag21aa`. Result: **0 violations**.
- New `task docs:wcag` re-runs the audit; auto-generates a
  fixture report first if missing.
- Manual checklist for issues axe-core can't catch automatically.

**[`.github/workflows/docs-publish.yml`](.github/workflows/docs-publish.yml)
+ new `task docs:site:build`** — GitHub Pages publishing

- New task assembles `doc/site/` from YARD HTML + a sample HTML
  report + a custom landing page at
  [`docs/site/index.html`](docs/site/index.html).
- Workflow triggers on push to main, tag push (`v*`), and manual
  dispatch. Uses the standard `actions/deploy-pages` chain.
- Site lives at `https://avmnu-sng.github.io/rspec-tracer/` once
  Pages is enabled (Settings → Pages → Source: **GitHub Actions**).
- Landing page links to README / UPGRADING / COOKBOOK /
  ARCHITECTURE / ROADMAP / CHANGELOG plus the YARD reference + the
  live demo report. Dark-mode + responsive layout.

**Other**

- `docs/CI_RECIPES.md` — dropped a stale internal-ID reference in
  the intro that pre-existed in this committed file.

## Test plan

Pre-PR parity (all green locally on Ruby 3.3.10):

- [x] `task lint:ruby` 218/0
- [x] `task lint:actions`
- [x] `task lint:yaml`
- [x] `task check:bundle`
- [x] `task security:bundle-audit` 0 vulns
- [x] `task security:trivy` 0 findings
- [x] `task test:unit` 1792/0
- [x] `task test:property` 25/0
- [x] `task test:dogfood` 1/0
- [x] `task benchmark:smoke` cold_ruby 0.57x + warm_noop 0.59x of threshold
- [x] `task docs:yard:check` 0 warnings
- [x] `task docs:wcag` 0 violations
- [x] `task docs:site:build` produces `doc/site/{index.html,yard/,demo/}`

CI watch-outs:

- [ ] `docs-publish.yml` first run will fail until Pages is enabled
      in **Settings → Pages → Source: GitHub Actions** (one-time
      maintainer setup).
- [ ] First Pages deploy may take 1-2 minutes after the workflow
      reports success.
- [ ] Standard lint + spec matrix should pass — no behavioral lib
      changes; only doc-comments + YARD scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)