### PR TITLE
fix(soak): empty SOAK_ITERATIONS treated as default + ignore rantly >= 3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
       # ignore matching upgrade PRs.
       - dependency-name: "erb"
         versions: [">= 5.0"]
+      # rantly >= 3.0 requires Ruby >= 3.3. Used by spec/properties/
+      # (property-based test suite); pin stays at ~> 2.0 in the
+      # Gemfile to keep Ruby 3.1 / 3.2 cells resolvable.
+      - dependency-name: "rantly"
+        versions: [">= 3.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -66,6 +66,12 @@ jobs:
     env:
       SOAK_PROJECT: ${{ matrix.project }}
       SOAK_FIXTURE_ROOT: ${{ github.workspace }}/tmp/soak-fixtures/${{ matrix.project }}
+      # On `schedule:` triggers GitHub Actions populates `inputs.*`
+      # with each input's default value, which here is `''`. That
+      # propagates as the literal empty string to the env var, which
+      # used to break the spec (`Integer("")` raised). The spec now
+      # treats empty as "use default"; this comment is the trail of
+      # the gotcha for future maintainers reading the YAML alone.
       SOAK_ITERATIONS: ${{ inputs.iterations }}
     steps:
       - name: Checkout rspec-tracer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rspec-tracer
 
-[![CI](https://github.com/avmnu-sng/rspec-tracer/actions/workflows/lint-and-specs.yml/badge.svg)](https://github.com/avmnu-sng/rspec-tracer/actions/workflows/lint-and-specs.yml)
+[![CI](https://github.com/avmnu-sng/rspec-tracer/actions/workflows/ci.yml/badge.svg)](https://github.com/avmnu-sng/rspec-tracer/actions/workflows/ci.yml)
 [![Gem Version](https://badge.fury.io/rb/rspec-tracer.svg)](https://badge.fury.io/rb/rspec-tracer)
 
 **RSpec Tracer** is a specs dependency analyzer, flaky-test detector,

--- a/spec/soak/realworld_soak_spec.rb
+++ b/spec/soak/realworld_soak_spec.rb
@@ -213,7 +213,17 @@ FIXTURE_ROOT = Pathname(
 GEMFILE_PATH = FIXTURE_ROOT.join(INVOCATION[:gemfile_dir], 'Gemfile')
 ENGINE_PATH = FIXTURE_ROOT.join(INVOCATION[:engine_dir])
 CACHE_PATH = ENGINE_PATH.join('rspec_tracer_cache')
-ITERATIONS = Integer(ENV.fetch('SOAK_ITERATIONS') { DEFAULT_ITERATIONS.fetch(PROJECT).to_s })
+# GitHub Actions populates `inputs.<name>` with each input's default
+# value on `schedule:` triggers (vs `pull_request:` where the inputs
+# context is absent), so the soak workflow's `SOAK_ITERATIONS:
+# ${{ inputs.iterations }}` resolves to "" on cron runs. ENV.fetch's
+# block fallback only fires on UNSET keys, not on set-but-empty ones,
+# so a naive `ENV.fetch('SOAK_ITERATIONS') { default }` returned ""
+# and `Integer("")` raised. Coerce empty string to "use the
+# per-project default" to match the unset semantics.
+soak_iterations_env = ENV['SOAK_ITERATIONS'].to_s
+soak_iterations_env = nil if soak_iterations_env.empty?
+ITERATIONS = Integer(soak_iterations_env || DEFAULT_ITERATIONS.fetch(PROJECT).to_s)
 WARMUP_ITERS = Integer(ENV.fetch('SOAK_WARMUP_ITERS', '5'))
 MEMORY_BOUND = Float(ENV.fetch('SOAK_MEMORY_BOUND', '1.20'))
 


### PR DESCRIPTION
Three independent fixes for nightly-soak + dependabot drift surfaced
during the post-2.0 documentation pass.

## 1. Soak nightly has been failing every run since [#137](https://github.com/avmnu-sng/rspec-tracer/pull/137) merged

Symptom: every \`schedule:\`-triggered soak run since 2026-04-30
failed in <3min with:

\`\`\`
ArgumentError: invalid value for Integer(): ""
  spec/soak/realworld_soak_spec.rb:216:in 'ITERATIONS = Integer(...)'
\`\`\`

Root cause: GitHub Actions populates \`inputs.<name>\` with each
input's \`default:\` value on \`schedule:\` triggers (vs
\`pull_request:\` where the \`inputs\` context is absent entirely).
The workflow's

\`\`\`yaml
SOAK_ITERATIONS: \${{ inputs.iterations }}
\`\`\`

resolves the default \`''\` to the literal empty string in the env
var. \`ENV.fetch\`'s block fallback only fires on UNSET keys, not on
set-but-empty ones, so \`Integer("")\` raises.

[#137](https://github.com/avmnu-sng/rspec-tracer/pull/137) worked
because its \`pull_request\` trigger had no inputs context — the env
var stayed unset, the block fallback fired correctly. Every cron
since has hit the empty-string path.

Fix:
- **Spec-side (defensive)**: treat empty string as "unset" so the
  per-project DEFAULT_ITERATIONS lookup runs. Same code path
  whether the env is unset, set-to-empty, or set-to-nil.
- **Workflow-side (documentation)**: YAML comment in soak.yml
  documents the gotcha for future maintainers.

## 2. Ignore \`rantly >= 3.0\` in dependabot

Dependabot opened
[#153](https://github.com/avmnu-sng/rspec-tracer/pull/153)
proposing rantly \`~> 2.0\` → \`~> 3.0\`. **rantly 3.0 requires
Ruby >= 3.3.0** per its gemspec; the matrix supports Ruby 3.1 + 3.2.
Bumping the constraint would break those cells.

Same shape as the existing \`parallel >= 2.0\` and \`erb >= 5.0\`
ignores. [#153](https://github.com/avmnu-sng/rspec-tracer/pull/153)
closed manually; this entry stops weekly re-proposals.

## Test plan

- [x] \`task lint:ruby\` clean
- [x] \`task lint:yaml\` clean
- [x] \`task lint:actions\` clean
- [ ] After merge, manually re-trigger soak.yml with default
      \`SOAK_ITERATIONS\` (empty string) to confirm fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)