### PR TITLE
fix: default-filter tracer's own output dirs + landing-page badge underline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,23 @@ the `rspec_tracer_cache/` / `rspec_tracer_coverage/` /
   whose `metadata[:file_path]` doesn't resolve to a readable file
   (gem-generated examples, deleted-between-runs files) now log
   debug + skip dependency registration instead of raising.
+- **Default filter list now excludes rspec-tracer's own output
+  directories** — `rspec_tracer_cache/`, `rspec_tracer_coverage/`,
+  `rspec_tracer_report/`, `rspec_tracer.lock`. Previously, tests
+  that read the tracer's own cache files (e.g. integration specs
+  asserting on cache state after a fixture subprocess run) got
+  those paths attributed as deps. The tracer's output is
+  regenerated every run by design and should never invalidate a
+  test. Both `add_filter` (dep graph) and `add_coverage_filter`
+  (coverage report) lists were updated.
+- **`add_filter` / `add_coverage_filter` now apply uniformly to
+  both fresh attributions AND prior-snapshot carry-forward.**
+  Previously, `Engine#seed_all_files_from_previous` and
+  `Engine#seed_graph_from_previous` seeded paths from the previous
+  run's snapshot WITHOUT re-applying the current filter list — so
+  a filter added between runs would NOT exclude already-cached
+  paths until a cold run wiped them. Filter additions now take
+  effect on the very next warm run.
 
 ### Deprecated
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -54,6 +54,9 @@
     .card p { margin: 0 0 0.5rem; color: var(--muted); font-size: 0.95rem; }
     code { background: var(--code-bg); padding: 0.15em 0.35em; border-radius: 3px; font-size: 0.9em; }
     .badges img { margin-right: 0.5rem; vertical-align: middle; }
+    /* Anchors that only wrap images would otherwise underline their
+       leading/trailing whitespace text nodes with the link color. */
+    .badges a { text-decoration: none; }
     .pill { display: inline-block; padding: 0.1em 0.55em; border-radius: 999px; font-size: 0.75rem; font-weight: 600; background: var(--pill-bg); color: var(--pill-fg); margin-left: 0.5rem; vertical-align: middle; }
     .pill.pre { background: var(--pill-pre-bg); color: var(--pill-pre-fg); }
     .version-list { list-style: none; padding: 0; margin: 1rem 0; }
@@ -70,12 +73,12 @@
     <h1>rspec-tracer</h1>
     <p class="lede">Specs dependency analyzer, flaky-test detector, test accelerator, and coverage reporter for RSpec.</p>
     <p class="badges">
-      <a href="https://github.com/avmnu-sng/rspec-tracer/actions/workflows/ci.yml">
-        <img alt="CI status" src="https://github.com/avmnu-sng/rspec-tracer/actions/workflows/ci.yml/badge.svg">
-      </a>
-      <a href="https://badge.fury.io/rb/rspec-tracer">
-        <img alt="Gem version" src="https://badge.fury.io/rb/rspec-tracer.svg">
-      </a>
+      <!-- Single-line per anchor: any internal whitespace would become
+           a text-node child of the <a> and render as an underline in
+           the link color. The .badges a { text-decoration: none } rule
+           above is the belt; this is the suspenders. -->
+      <a href="https://github.com/avmnu-sng/rspec-tracer/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/avmnu-sng/rspec-tracer/actions/workflows/ci.yml/badge.svg"></a>
+      <a href="https://badge.fury.io/rb/rspec-tracer"><img alt="Gem version" src="https://badge.fury.io/rb/rspec-tracer.svg"></a>
     </p>
   </header>
 

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -1149,6 +1149,22 @@ module RSpecTracer
     # dependency graph. Files matching the filter are not registered
     # as deps, so changes to them don't trigger re-runs.
     #
+    # The filter applies uniformly to both fresh per-example
+    # attributions AND prior-snapshot carry-forward (warm-run path).
+    # Adding a filter between runs immediately drops matching paths
+    # from the next warm run's `@all_files` and dependency graph;
+    # no cold run is required.
+    #
+    # The default filter list (loaded by `lib/rspec_tracer/load_default_config.rb`
+    # before the user's `.rspec-tracer` runs) excludes Ruby toolchain
+    # paths (`/vendor/bundle/`, `/usr/local/bundle/`, rbenv / asdf / rvm)
+    # AND rspec-tracer's own output dirs (`/rspec_tracer_cache/`,
+    # `/rspec_tracer_coverage/`, `/rspec_tracer_report/`,
+    # `rspec_tracer.lock`). Use `filters.clear` in `.rspec-tracer`
+    # before adding your own if you need to start from a blank list,
+    # but be aware you'll then need to re-add the toolchain + tracer-
+    # output exclusions yourself.
+    #
     # @param filter [String, Regexp, Array, RSpecTracer::Filter, nil]
     #   filter spec. Nil + a block also accepted; the block receives
     #   a `source_file` Hash (`:name` / `:file_path`) and returns

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -625,6 +625,14 @@ module RSpecTracer
 
     # prev.all_files is file-name-keyed; the engine's @all_files is
     # abs-path-keyed (path_to_file_name round-trips via the root prefix).
+    #
+    # Re-applies the current filter list at seed time so users who
+    # add a filter mid-development see the carried-over file entries
+    # drop on the next run (instead of waiting for a cold run). The
+    # filter contract should hold for both fresh attributions
+    # (attribute_to_example) and prior-snapshot carry-forward —
+    # otherwise add_filter has split semantics and a freshly-added
+    # filter does not exclude already-cached paths.
     def seed_all_files_from_previous(prev)
       return unless prev.all_files.is_a?(Hash)
 
@@ -634,8 +642,11 @@ module RSpecTracer
         file_path = symbol_or_string(meta, :file_path)
         next if file_path.nil?
 
+        file_name = symbol_or_string(meta, :file_name) || path_to_file_name(file_path)
+        next if filtered_by_current_filters?(file_name)
+
         @all_files[file_path] = {
-          file_name: symbol_or_string(meta, :file_name),
+          file_name: file_name,
           file_path: file_path,
           digest: symbol_or_string(meta, :digest)
         }
@@ -645,14 +656,33 @@ module RSpecTracer
     # prev.dependency keys on example_id, values are Set<file_name>.
     # Register in @graph via absolute paths so the on-disk shape
     # (file_name) converts at save time via dependency_by_name.
+    #
+    # Drops paths matching the current filter list so previously-
+    # cached deps that the new filter excludes do not leak through
+    # the carry-forward seed path. Same rationale as
+    # seed_all_files_from_previous: the filter contract is one
+    # contract, applied uniformly across fresh + carry-forward
+    # attributions.
     def seed_graph_from_previous(prev)
       return unless prev.dependency.is_a?(Hash)
 
       prev.dependency.each do |example_id, file_names|
         paths = Set.new
-        file_names.each { |name| paths << absolute_path(name) }
+        file_names.each do |name|
+          next if filtered_by_current_filters?(name)
+
+          paths << absolute_path(name)
+        end
         @graph.register_example(example_id, paths)
       end
+    end
+
+    # Helper: returns true if the file name matches any currently-
+    # configured filter. Mirrors the check site at
+    # `attribute_to_example` (engine.rb:770) so both fresh + carry-
+    # forward attributions converge on the same filter behavior.
+    def filtered_by_current_filters?(file_name)
+      @configuration.filters.any? { |f| f.match?(file_name: file_name) }
     end
 
     def compute_filter_decisions

--- a/lib/rspec_tracer/load_default_config.rb
+++ b/lib/rspec_tracer/load_default_config.rb
@@ -16,6 +16,10 @@ RSpecTracer.configure do
     /.rbenv/versions/
     /.asdf/installs/ruby/
     /.rvm/
+    /rspec_tracer_cache/
+    /rspec_tracer_coverage/
+    /rspec_tracer_report/
+    rspec_tracer.lock
   ].freeze
 
   coverage_filters.clear
@@ -33,6 +37,10 @@ RSpecTracer.configure do
     /.rbenv/versions/
     /.asdf/installs/ruby/
     /.rvm/
+    /rspec_tracer_cache/
+    /rspec_tracer_coverage/
+    /rspec_tracer_report/
+    rspec_tracer.lock
   ].freeze
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -893,5 +893,84 @@ RSpec.describe RSpecTracer::Engine do
       expect(Coverage).to have_received(:peek_result).exactly(2).times
     end
   end
+
+  # The seed_*_from_previous methods carry forward the prior run's
+  # @all_files entries + dependency-graph edges. Without re-applying
+  # the current filter list, a filter added between runs would NOT
+  # exclude already-cached paths — producing split semantics where
+  # add_filter only affects fresh attributions.
+  describe 'carry-forward filter application (seed_*_from_previous)' do
+    let(:string_filter) { RSpecTracer::Filter.register('/excluded_dir/') }
+    let(:configuration_with_filter) do
+      stub_configuration(filters: [string_filter])
+    end
+
+    let(:previous_snapshot) do
+      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |snap|
+        snap.all_files = {
+          '/lib/keep.rb' => {
+            file_name: '/lib/keep.rb',
+            file_path: File.join(root, 'lib/keep.rb'),
+            digest: 'd1'
+          },
+          '/excluded_dir/old.rb' => {
+            file_name: '/excluded_dir/old.rb',
+            file_path: File.join(root, 'excluded_dir/old.rb'),
+            digest: 'd2'
+          }
+        }
+        snap.dependency = {
+          'ex_keep' => Set.new(['/lib/keep.rb']),
+          'ex_excluded' => Set.new(['/lib/keep.rb', '/excluded_dir/old.rb'])
+        }
+        snap.all_examples = {
+          'ex_keep' => build_example('ex_keep'),
+          'ex_excluded' => build_example('ex_excluded')
+        }
+      end
+    end
+
+    def prime_previous_cache
+      backend = RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
+      backend.save_graph(previous_snapshot, schema_version: 3)
+    end
+
+    it 'drops carried-over @all_files entries that match a currently-configured filter' do
+      prime_previous_cache
+      tracker = build_tracker(configuration_with_filter).tap(&:setup)
+
+      file_names = tracker.all_files.values.map { |v| v[:file_name] }
+      expect(file_names).to include('/lib/keep.rb')
+      expect(file_names).not_to include('/excluded_dir/old.rb')
+    end
+
+    it 'drops carried-over dependency-graph edges that match a currently-configured filter' do
+      prime_previous_cache
+      tracker = build_tracker(configuration_with_filter).tap(&:setup)
+
+      ex_excluded_deps = tracker.graph.dependency_hash['ex_excluded'] || Set.new
+      ex_excluded_relative = ex_excluded_deps.to_a.map do |abs|
+        abs.sub(root, '')
+      end
+      expect(ex_excluded_relative).to include('/lib/keep.rb')
+      expect(ex_excluded_relative).not_to include('/excluded_dir/old.rb')
+    end
+
+    it 'still seeds entries that DO NOT match the filter (no false positives)' do
+      prime_previous_cache
+      tracker = build_tracker(configuration_with_filter).tap(&:setup)
+
+      ex_keep_deps = tracker.graph.dependency_hash['ex_keep'] || Set.new
+      expect(ex_keep_deps.size).to eq(1)
+    end
+
+    it 'preserves carry-forward behavior when configuration.filters is empty (no filtering)' do
+      prime_previous_cache
+      tracker = build_tracker.tap(&:setup) # default config has filters: []
+
+      file_names = tracker.all_files.values.map { |v| v[:file_name] }
+      expect(file_names).to include('/lib/keep.rb', '/excluded_dir/old.rb')
+    end
+  end
 end
 # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
Two unrelated post-[#157](https://github.com/avmnu-sng/rspec-tracer/pull/157) fixes surfaced from inspecting the live docs site at \`https://avmnu-sng.github.io/rspec-tracer/\`.

## 1. Default filters didn't exclude tracer's own output dirs

The default filter list at \`lib/rspec_tracer/load_default_config.rb\`
covered Ruby toolchain paths (\`vendor/\`, \`lib/rspec_tracer/\`,
\`rbenv\`, \`asdf\`, \`rvm\`, \`hostedtoolcache\`) but NOT the tracer's
own output directories: \`rspec_tracer_cache/\`, \`rspec_tracer_coverage/\`,
\`rspec_tracer_report/\`, \`rspec_tracer.lock\`.

**Effect**: tests that read the tracer's own cache files (e.g.
integration specs asserting on cache state after a fixture
subprocess run) get those cache paths attributed as deps. The
deployed demo report's "files dependency" view at
\`/main/demo/index.html\` surfaced this — 5 entries pointed at
\`rspec_tracer_cache/<run_id>/*.json\` +
\`rspec_tracer_coverage/coverage.json\`.

**Fix**: add the 4 tracer-self paths to the default \`add_filter\`
+ \`add_coverage_filter\` lists. Cold runs now exclude them
entirely.

**Verified locally**: wiped all caches + re-ran
\`task test:features:rails\` → regenerated \`report.json\`'s
\`files_dependency\` shows 0 leaked tracer-self entries (was 5).

**Related but separate bug** worth a followup: 
\`Engine#seed_all_files_from_previous\` (engine.rb:628) doesn't
re-apply current filters when seeding from the previous snapshot.
Mid-session filter additions therefore don't immediately exclude
already-cached file entries. Won't block the docs site cleanup
because docs-publish.yml always runs from a cold GHA environment;
worth a separate PR for users adding filters mid-development.

## 2. Landing page red-underline artifact between badges

A screenshot from the deployed site showed a small red underscore
between the "ci passing" and "gem version 1.2.1" badges.

**Root cause**: the \`<a>\` tags wrapping each badge image had
whitespace + newlines between the opening tag and the \`<img>\`
child, so browsers parse that whitespace as a TEXT NODE child of
the anchor. Default browser CSS applies
\`text-decoration: underline\` to anchor children, and the landing
page's \`a { color: var(--accent) }\` makes that color red in dark
mode → the whitespace text node renders as a tiny red underline.

**Fix** in \`docs/site/index.html\`:
- CSS: \`.badges a { text-decoration: none; }\` removes the underline
  on any anchor inside the badges block.
- Markup: compress each badge anchor to a single line so the
  HTML has no internal whitespace text node.

Either fix alone is sufficient; both together is belt + suspenders
against future formatting drift.

## Test plan

- [x] \`task lint:ruby\` clean
- [x] \`task lint:yaml\` clean
- [x] \`task lint:actions\` clean (no workflow changes)
- [x] Wiped all caches + re-ran \`task test:features:rails\` →
      regenerated \`rspec_tracer_report/report.json\`'s
      \`files_dependency\` has 0 \`rspec_tracer_*\` entries.
- [ ] After merge: \`docs-publish.yml\` triggers on the merge commit
      → regenerates \`/main/demo/\` with the new filtered report
      → "files dependency" view at the deployed site no longer
      shows tracer-self cache files.
- [ ] After merge: \`docs-publish.yml\` regenerates \`/main/yard/\`
      with the landing page CSS fix → red underscore no longer
      visible between badges on the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)