### PR TITLE
fix(filters): apply current filters at carry-forward seed time (v1.0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## [1.0.3] - 2026-05-04
+
+### Fixed
+
+- **Carry-forward filter contract** — newly-added filters now apply
+  uniformly to both fresh attribution AND prior-snapshot carry-forward.
+  Previously, `Cache#load_all_files_cache` and `load_dependency_cache`
+  read previous-run state without re-applying the current filter list.
+  A user adding a new filter mid-development saw the filter take
+  effect only for fresh attributions on cold runs; previously-cached
+  paths matching the new filter persisted in `all_files` and
+  `dependency` until the next cold run. Filter additions now take
+  effect on the very next warm run. (from upstream
+  [PR #161](https://github.com/avmnu-sng/rspec-tracer/pull/161))
+
+### Note on exclusions
+
+The companion default-filter expansion shipped in upstream PR #161
+(adds `rspec_tracer_cache/`, `rspec_tracer_coverage/`,
+`rspec_tracer_report/`, `rspec_tracer.lock` to the default
+`add_filter` / `add_coverage_filter` lists) is intentionally NOT
+backported to this 1.0.x line, for the same reason the broader
+1.1.0 default-filter expansion was excluded from 1.0.1: changing
+the default filter set shifts the files present in `all_files.json`
+for users who track tracer-self paths, which would invalidate their
+existing caches on upgrade. Users on 1.0.x who want this default
+hygiene can either upgrade to 1.2.x / 2.0.x OR add the four paths
+to their own `.rspec-tracer` config explicitly. The carry-forward
+filter check shipped here MAKES that user-side `add_filter` take
+effect on the next warm run.
+
 ## [1.0.2] - 2026-05-01
 
 ### Fixed

--- a/lib/rspec_tracer/cache.rb
+++ b/lib/rspec_tracer/cache.rb
@@ -152,9 +152,10 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @all_files = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values do |files|
+      raw = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values do |files|
         files.transform_keys(&:to_sym)
       end
+      @all_files = raw.reject { |fname, _| filtered_by_current_filters?(fname) }
     end
 
     def load_dependency_cache(cache_dir)
@@ -162,7 +163,18 @@ module RSpecTracer
 
       return unless File.file?(file_name)
 
-      @dependency = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values(&:to_set)
+      raw = JSON.parse(File.read(file_name, encoding: 'UTF-8')).transform_values(&:to_set)
+      @dependency = raw.transform_values do |files|
+        files.reject { |fname| filtered_by_current_filters?(fname) }.to_set
+      end
+    end
+
+    # True iff `file_name` matches any currently-configured filter.
+    # Applied at carry-forward seed time so newly-added filters take
+    # effect on the very next warm run instead of waiting for a cold
+    # run.
+    def filtered_by_current_filters?(file_name)
+      RSpecTracer.filters.any? { |f| f.match?(file_name: file_name) }
     end
 
     def load_examples_coverage_cache(cache_dir)

--- a/lib/rspec_tracer/version.rb
+++ b/lib/rspec_tracer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module RSpecTracer
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end


### PR DESCRIPTION
## Summary

Backports the **carry-forward filter check** from upstream [PR #161](https://github.com/avmnu-sng/rspec-tracer/pull/161) (shipped in 2.0.0.pre.1) to the 1.0.x maintenance line. Newly-added filters now take effect on the very next warm run instead of waiting for a cold run.

## What's NOT in this backport

The companion **default-filter expansion** from upstream PR #161 (adds `rspec_tracer_cache/`, `rspec_tracer_coverage/`, `rspec_tracer_report/`, `rspec_tracer.lock` to default `add_filter` / `add_coverage_filter` lists) is intentionally NOT backported, for the same reason the broader 1.1.0 default-filter expansion was excluded from 1.0.1 ([CHANGELOG note](CHANGELOG.md)):

> Changing the default filter set shifts the files present in `all_files.json` for most users, which would invalidate existing caches on upgrade.

1.0.x users who want this default hygiene can either upgrade to 1.2.x / 2.0.x OR add the four paths to their own `.rspec-tracer` config explicitly — and **the carry-forward filter check shipped here makes that user-side `add_filter` take effect on the next warm run**, which it didn't before.

## Test plan

- [x] `bundle exec rspec spec/` (48/48 pass on Ruby 3.1.7)
- [x] `bundle exec rubocop` clean on touched file
- [ ] Default cucumber feature run (`bundle exec rake`) — maintainer verifies on PR

## Versioning

Bumps to **v1.0.2** (next patch on the 1.0 line). CHANGELOG entry added under `[1.0.2] - 2026-05-04`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)