### PR TITLE
bench(ratchet): seed cold_rails_v2_warm_iter baseline

### DIFF
--- a/benchmark/ratchet.json
+++ b/benchmark/ratchet.json
@@ -40,6 +40,11 @@
       "p95": 20.396,
       "iterations": 10
     },
+    "cold_rails_v2_warm_iter": {
+      "p50": 5.1733,
+      "p95": 5.334,
+      "iterations": 10
+    },
     "cold_ruby": {
       "p50": 0.4507,
       "p95": 0.4763,


### PR DESCRIPTION
## Summary

Closes the open ratchet entry for the `cold_rails_v2_warm_iter` scenario (long-running parent + fork-per-iter; amortizes Rails-boot to measure steady-state overhead). Without this entry, a future regression in steady-state Rails perf would not be caught by the per-PR `benchmark` CI cell — the harness would just print `:no_baseline` and skip the comparison.

## Methodology

Baseline computed via [`multi-run-ratchet.yml`](.github/workflows/multi-run-ratchet.yml) `workflow_dispatch` run on `main` ([run 25293877928](https://github.com/avmnu-sng/rspec-tracer/actions/runs/25293877928)) — same methodology as every other entry in `benchmark/ratchet.json`:

- 30 parallel GHA `ubuntu-latest` jobs
- Each runs `task benchmark:ratchet:update` (10 iters per scenario)
- `scripts/aggregate_ratchet.rb` computes p95-of-per-run-p50 across the 30 runs
- p95-baseline absorbs CPU-SKU heterogeneity across EPYC 9V74 / 7763 / Xeon 8370C

## Result

```
cold_rails_v2_warm_iter:
  p50 = 5.1733s  (p95-of-per-run-p50 across 30 GHA jobs)
  p95 = 5.334s
  iterations = 10 (per harness invocation)
```

Effective fail threshold = p50 × 1.30 = **~6.73s**. Effective warn threshold = p50 × 1.10 = **~5.69s**.

## CPU SKU distribution observed (this run)

```
AMD EPYC 7763 64-Core Processor: 20
AMD EPYC 9V74 80-Core Processor: 8
Intel(R) Xeon(R) Platinum 8370C: 2
```

## Test plan

- [x] `bundle exec ruby benchmark/harness.rb --smoke --ratchet benchmark/ratchet.json` succeeds locally (smoke set excludes this scenario, but verifies harness loads the new entry cleanly)
- [ ] First per-PR `benchmark` CI cell after merge does not trip the threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)