### PR TITLE
refactor(coverage): shape-agnostic accumulate_skipped; collapse interop install

### DIFF
--- a/lib/rspec_tracer/reporters/coverage_json_reporter.rb
+++ b/lib/rspec_tracer/reporters/coverage_json_reporter.rb
@@ -108,30 +108,75 @@ module RSpecTracer
         finalize_coverage_files(coverage)
       end
 
+      # Shape-agnostic skipped-coverage accumulator. The `coverage`
+      # hash carries one of two per-file shapes interchangeably:
+      #
+      #   - `Array<Integer|nil>`        (lines-only — peek_unfiltered;
+      #                                  the user-facing `coverage.json`
+      #                                  contract)
+      #   - `{ lines: Array, branches: Hash }`
+      #                                 (hash-mode — peek_unfiltered_full;
+      #                                  what SimpleCov needs when branch
+      #                                  coverage is enabled)
+      #
+      # Both callers (`build_coverage` writing coverage.json,
+      # `install_simplecov_interop` feeding SimpleCov.result) share
+      # this one accumulator; the per-shape mechanics are isolated in
+      # `ensure_mutable_lines`. Hash-mode entries keep their
+      # `:branches` sub-hash unchanged (this method only touches
+      # lines); array-mode entries are mutated in place. New entries
+      # synthesised for files Coverage didn't observe go in as Array
+      # (line stubs have no branches to preserve).
       def accumulate_skipped(coverage)
         skipped_ids = engine.registry.ids_with_status(:skipped)
         return coverage if skipped_ids.empty?
 
         engine.merge_skipped_coverage(skipped_ids).each do |file_path, line_map|
-          existing = coverage[file_path]
-          # `Coverage.peek_result` returns frozen line-count arrays on
-          # Ruby 3.2+. Mutating those raises `FrozenError`. dup-on-write
-          # so we own a mutable copy before the merge loop, but only on
-          # the first hit per file_path (subsequent hits write into our
-          # already-mutable copy).
-          if existing.nil?
-            existing = line_stub(file_path)
-            coverage[file_path] = existing
-          elsif existing.frozen?
-            existing = existing.dup
-            coverage[file_path] = existing
-          end
+          line_arr = ensure_mutable_lines(coverage, file_path)
           line_map.each do |line_number, strength|
             idx = line_number.to_i
-            existing[idx] = (existing[idx] || 0) + strength
+            line_arr[idx] = (line_arr[idx] || 0) + strength
           end
         end
         coverage
+      end
+
+      # Returns the mutable `Array<Integer|nil>` view for
+      # `coverage[file_path]` we can write per-line strengths into,
+      # rewriting `coverage[file_path]` in-place when a dup or stub
+      # was needed. `Coverage.peek_result` returns frozen line arrays
+      # on Ruby 3.2+; dup-on-write so subsequent writes share the
+      # mutable copy.
+      #
+      #   nil           → install line_stub (Array shape; new entry
+      #                    has no branches to preserve).
+      #   Hash{lines:,} → if `:lines` is frozen / nil, replace the
+      #                    Hash entry with one carrying a fresh /
+      #                    dup'd lines array + the original branches.
+      #   Array         → if frozen, dup + replace; else mutate in
+      #                    place.
+      def ensure_mutable_lines(coverage, file_path)
+        existing = coverage[file_path]
+
+        case existing
+        when nil
+          stub = line_stub(file_path)
+          coverage[file_path] = stub
+          stub
+        when ::Hash
+          line_arr = existing[:lines]
+          return line_arr if line_arr && !line_arr.frozen?
+
+          line_arr = line_arr ? line_arr.dup : line_stub(file_path)
+          coverage[file_path] = { lines: line_arr, branches: existing[:branches] || {} }
+          line_arr
+        else
+          return existing unless existing.frozen?
+
+          dup = existing.dup
+          coverage[file_path] = dup
+          dup
+        end
       end
 
       # Apply `coverage_filters` + `coverage_tracked_files` glob; sort
@@ -214,65 +259,28 @@ module RSpecTracer
       # side). Preserving this shape keeps SimpleCov's at_exit
       # result-merge seeing whatever it was tracking minus rspec-
       # tracer's narrow filters.
-      # SimpleCov is the consumer here; it expects Coverage.result's
-      # full hash shape when branch coverage is enabled (`{ lines: [...],
-      # branches: {...} }` per file). `peek_unfiltered_full` preserves
-      # that shape — switching back to `peek_unfiltered` here would
-      # silently drop branch data from SimpleCov's report whenever
-      # rspec-tracer dogfoods itself with branch coverage enabled.
       #
-      # When the engine has zero skipped examples (the common path —
-      # any cold run, any warm run with no carried-over skips),
-      # `accumulate_skipped` is a no-op and we hand SimpleCov the
-      # peek output verbatim. Skipping the lines-view dup + merge-
-      # back round-trip on this path matters: long-running benchmark
-      # scenarios fork per-iter, hit at_exit per-iter, and a per-iter
-      # dup of every lib file's line array shows up as a measurable
-      # regression on cold_rails_v2_warm_iter (3.7x ratchet ratio in
-      # the first CI run that exposed it). Only pay the dup cost when
-      # there's actual skipped-coverage attribution to merge in.
+      # `peek_unfiltered_full` preserves Coverage's full
+      # `{lines:, branches:}` hash shape verbatim (vs `peek_unfiltered`
+      # which reduces hash-mode entries to `:lines` only for the
+      # user-facing `coverage.json` Array<Integer|nil> contract).
+      # SimpleCov's branch report needs the branches sub-hash;
+      # silently stripping them here was the pre-PR-#165 bug that
+      # made every dogfooded suite report `Branch Coverage: 0/0`
+      # under `enable_coverage :branch`.
+      #
+      # `accumulate_skipped` is shape-agnostic (handles both
+      # hash-mode and array-mode entries; preserves `:branches`
+      # untouched on hash-mode dup-on-write), so we hand it the full
+      # peek directly without any view-extraction round-trip. Empty
+      # skipped registry → it early-returns + nothing reallocates;
+      # non-empty → only the per-skipped-file line arrays get dup'd.
+      # Either way, no per-call O(N files) allocation.
       def install_simplecov_interop
         coverage = engine.coverage_adapter.peek_unfiltered_full
-        if engine.registry.ids_with_status(:skipped).any?
-          lines = mutable_lines_view(coverage)
-          accumulate_skipped(lines)
-          merge_lines_back(coverage, lines)
-        end
+        accumulate_skipped(coverage)
         SimpleCovInterop.install(coverage)
         nil
-      end
-
-      # Returns a `{ path => Array<Integer|nil> }` view of the full
-      # peek (Hash `{lines:, branches:}` per file in hash mode; Array
-      # already in array mode). dup-on-extract so accumulate_skipped's
-      # in-place mutations never reach back into the frozen Coverage
-      # arrays underlying the hash, and the caller can re-merge the
-      # final view via `merge_lines_back`.
-      def mutable_lines_view(coverage)
-        coverage.each_with_object({}) do |(path, stats), acc|
-          line_arr = stats.is_a?(Hash) ? stats[:lines] : stats
-          acc[path] = line_arr&.dup
-        end
-      end
-
-      # Re-attach the (possibly mutated by accumulate_skipped) line
-      # arrays back into the full `coverage` hash. Hash-mode entries
-      # get a fresh `{lines:, branches:}` Hash with the new lines and
-      # the original branches preserved; array-mode entries get the
-      # mutated array directly. New entries `accumulate_skipped`
-      # synthesised for previously-unseen files (line stubs) propagate
-      # in their array shape — branches are absent because the file
-      # wasn't observed by Coverage.
-      def merge_lines_back(coverage, lines)
-        lines.each do |path, line_arr|
-          existing = coverage[path]
-          coverage[path] =
-            if existing.is_a?(Hash)
-              { lines: line_arr, branches: existing[:branches] || {} }
-            else
-              line_arr
-            end
-        end
       end
 
       # Inner module preserving 1.x's RubyCoverage shim contract. When

--- a/spec/reporters/coverage_json_reporter_spec.rb
+++ b/spec/reporters/coverage_json_reporter_spec.rb
@@ -251,12 +251,12 @@ RSpec.describe RSpecTracer::Reporters::CoverageJsonReporter do
       end
     end
 
-    # Array-mode skipped-coverage attribution path: when peek returns
-    # `Array<Integer|nil>` per file (default mode, no `enable_coverage
-    # :branch`), the merge_lines_back `else` arm rewrites the per-path
-    # entry as the mutated line array directly (no `{lines:, branches:}`
-    # wrapping needed because there are no branches to preserve).
-    it 'merges skipped-coverage attribution into the lines view (array-mode)' do
+    # Array-mode skipped-coverage path: when peek returns
+    # `Array<Integer|nil>` per file (no `enable_coverage :branch`),
+    # accumulate_skipped writes mutated counts back as a plain Array
+    # (no `{lines:, branches:}` wrapping — there are no branches to
+    # preserve).
+    it 'merges skipped-coverage attribution against array-mode coverage (mutable line array)' do
       array_mode = { tracked_file => [1, 0, nil] }
       allow(adapter).to receive(:peek_unfiltered_full).and_return(array_mode)
       allow(registry).to receive(:ids_with_status).with(:skipped).and_return(['ex_skipped'])
@@ -272,14 +272,14 @@ RSpec.describe RSpecTracer::Reporters::CoverageJsonReporter do
         .with(hash_including(tracked_file => [1, 5, nil]))
     end
 
-    # Skipped-coverage attribution path: when the engine has skipped
-    # examples, accumulate_skipped writes their per-line strengths
-    # into a dup'd lines view; merge_lines_back syncs the (now-mutated)
-    # arrays back into the full hash so SimpleCov sees both the
-    # accumulated skipped lines AND the original branches. The early-
-    # return on empty skipped (the common path) is exercised by the
-    # two tests above; this one exercises the dup + merge round-trip.
-    it 'merges skipped-coverage attribution into the lines view (hash-mode)' do
+    # Hash-mode skipped-coverage path: existing entry's `:lines` is
+    # already mutable (rare in practice — `Coverage.peek_result`
+    # returns frozen arrays on Ruby 3.2+, but a previous in-process
+    # mutation could leave a mutable copy). ensure_mutable_lines
+    # returns the existing array directly + accumulate_skipped
+    # mutates it in place; the entry's hash wrapper is untouched and
+    # `:branches` rides along.
+    it 'merges skipped-coverage into a mutable hash-mode entry without rewrapping' do
       branches = { [:if, 0, 1, 0, 1, 10] => { [:then, 1, 1, 0, 1, 5] => 3 } }
       hash_mode = { tracked_file => { lines: [1, 0, nil], branches: branches } }
       allow(adapter).to receive(:peek_unfiltered_full).and_return(hash_mode)
@@ -293,9 +293,61 @@ RSpec.describe RSpecTracer::Reporters::CoverageJsonReporter do
       build_reporter.generate
 
       expect(described_class::SimpleCovInterop).to have_received(:install) do |coverage|
-        # Lines mutated: index 1 = 0 + 5 = 5; index 2 = nil treated as 0 + 7 = 7
+        # Lines mutated: index 1 = 0 + 5 = 5; index 2 = nil treated as 0 + 7 = 7.
         expect(coverage[tracked_file][:lines]).to eq([1, 5, 7])
-        # Branches preserved verbatim
+        # Branches preserved verbatim.
+        expect(coverage[tracked_file][:branches]).to eq(branches)
+      end
+    end
+
+    # Hash-mode skipped-coverage path: the entry's `:lines` array is
+    # FROZEN (the Ruby 3.2+ Coverage.peek_result default). The
+    # ensure_mutable_lines helper must dup the lines array AND replace
+    # the hash entry with a fresh `{lines:, branches:}` wrapper
+    # carrying the dup'd lines + the original (untouched) branches.
+    # Original frozen array must NOT be mutated.
+    it 'dup-on-writes a frozen hash-mode :lines + preserves branches verbatim' do
+      branches = { [:if, 0, 1, 0, 1, 10] => { [:then, 1, 1, 0, 1, 5] => 3 } }
+      frozen_lines = [1, 0, nil].freeze
+      hash_mode = { tracked_file => { lines: frozen_lines, branches: branches } }
+      allow(adapter).to receive(:peek_unfiltered_full).and_return(hash_mode)
+      allow(registry).to receive(:ids_with_status).with(:skipped).and_return(['ex_skipped'])
+      allow(engine).to receive(:merge_skipped_coverage).with(['ex_skipped']).and_return(
+        tracked_file => { 1 => 5 }
+      )
+      allow(RSpecTracer).to receive(:simplecov?).and_return(true)
+      allow(described_class::SimpleCovInterop).to receive(:install)
+
+      expect { build_reporter.generate }.not_to raise_error
+
+      expect(described_class::SimpleCovInterop).to have_received(:install) do |coverage|
+        expect(coverage[tracked_file][:lines]).to eq([1, 5, nil])
+        expect(coverage[tracked_file][:branches]).to eq(branches)
+      end
+      # Frozen original must be untouched (dup-on-write contract).
+      expect(frozen_lines).to eq([1, 0, nil])
+    end
+
+    # Hash-mode skipped-coverage path with `:lines` absent (nil). The
+    # file appeared in the hash-mode peek output (so we have a
+    # `:branches` sub-hash to preserve) but Coverage didn't observe
+    # any executable lines — install a `line_stub`-shaped Array as
+    # the new `:lines` and rewrap with the original branches.
+    it 'creates a line_stub for hash-mode entries with nil :lines + preserves branches' do
+      branches = { [:if, 0, 1, 0, 1, 10] => { [:then, 1, 1, 0, 1, 5] => 3 } }
+      hash_mode = { tracked_file => { lines: nil, branches: branches } }
+      allow(adapter).to receive(:peek_unfiltered_full).and_return(hash_mode)
+      allow(registry).to receive(:ids_with_status).with(:skipped).and_return(['ex_skipped'])
+      allow(engine).to receive(:merge_skipped_coverage).with(['ex_skipped']).and_return(
+        tracked_file => { 0 => 1 }
+      )
+      allow(RSpecTracer).to receive(:simplecov?).and_return(true)
+      allow(described_class::SimpleCovInterop).to receive(:install)
+
+      build_reporter.generate
+
+      expect(described_class::SimpleCovInterop).to have_received(:install) do |coverage|
+        expect(coverage[tracked_file][:lines].first).to eq(1)
         expect(coverage[tracked_file][:branches]).to eq(branches)
       end
     end


### PR DESCRIPTION
## Summary

Cleans up two architectural awkwardnesses that PR #165 shipped while addressing the load-bearing branch-coverage correctness fix:

1. **`mutable_lines_view` + `merge_lines_back` round-trip**: `install_simplecov_interop` had to dup every per-file lines array to a separate hash, run `accumulate_skipped` against the dup, then merge the mutated arrays back into the original `{lines:, branches:}` hash. The round-trip existed only because `accumulate_skipped` was written for lines-only `Array<Integer|nil>` shape and the SimpleCov interop needed to preserve `:branches`.

2. **The `if engine.registry.ids_with_status(:skipped).any?` perf gate**: a workaround for the unconditional O(N files) array dup the round-trip was doing — even on the cold-run common path with no skipped examples to merge.

## Cleanup

`accumulate_skipped` becomes shape-agnostic. It accepts both:

- `Array<Integer|nil>` (lines-only — what `peek_unfiltered` returns; the `coverage.json` on-disk contract)
- `{lines: Array, branches: Hash}` (hash-mode — what `peek_unfiltered_full` returns; what SimpleCov needs with branch coverage enabled)

Per-shape dup-on-write mechanics are isolated in a new `ensure_mutable_lines(coverage, file_path)` helper. Five dup-on-write cases:

| Existing entry | New behavior |
|---|---|
| `nil` | install `line_stub` (Array shape — no branches to preserve) |
| `Hash{lines: frozen}` | dup `:lines` + rewrap with original `:branches` preserved |
| `Hash{lines: nil}` | install `line_stub` + rewrap with original `:branches` preserved |
| `Hash{lines: mutable}` | return existing `:lines` as-is (zero allocation; common path on warm runs that already mutated once) |
| `Array frozen` | dup + replace |
| `Array mutable` | return existing as-is |

`install_simplecov_interop` collapses to three lines:

```ruby
def install_simplecov_interop
  coverage = engine.coverage_adapter.peek_unfiltered_full
  accumulate_skipped(coverage)
  SimpleCovInterop.install(coverage)
  nil
end
```

No view-extraction, no merge-back, no perf gate. The accumulator's natural early-return on empty `skipped_ids` means cold-run paths reallocate nothing; non-empty paths only dup the per-skipped-file line arrays they actually mutate.

`mutable_lines_view` + `merge_lines_back` + the `if any_skipped` conditional are deleted (dead code).

## Spec updates

- Updated 3 existing `install_simplecov_interop` specs to reflect the new shape (the `merge_lines_back` references in comments are gone; assertions describe the new structure).
- Added 2 new specs covering paths the rewrite surfaced:
  - Hash-mode entry with **FROZEN** `:lines` (Coverage 3.2+ default) → dup + rewrap with branches preserved
  - Hash-mode entry with **nil** `:lines` (file appeared in peek but had no executable lines) → line_stub + rewrap

## Test plan

- [x] `task test:unit`: 1807 examples, 0 failures
- [x] `task lint:ruby` clean
- [x] `cold_rails_v2_warm_iter` (M2 Max, 3 iters): 3.11s p50 — matches main's 3.19s baseline; the perf-gate-removal didn't reintroduce any regression
- [ ] CI benchmark cell on the same SHA confirms no ratchet trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)