### PR TITLE
fix(parallel_tests): add .boot/.done filesystem barrier to close purge race

### DIFF
--- a/lib/rspec_tracer/rspec/parallel_tests.rb
+++ b/lib/rspec_tracer/rspec/parallel_tests.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'fileutils'
+require 'json'
 
 module RSpecTracer
   module RSpec
@@ -28,6 +29,35 @@ module RSpecTracer
     # never propagate a non-zero exit into the user's test run.
     module ParallelTests
       LOCK_ENCODING = 'UTF-8'
+
+      # Per-worker boot/done breadcrumbs written to each worker's
+      # `parallel_tests_N/` cache dir. The elected worker uses these
+      # at finalize time to verify every booted peer has reached the
+      # end of its at_exit before merge + purge:
+      #
+      #   .boot — written at setup! time (very early, before any
+      #           cache write). Source-of-truth for "this worker
+      #           ever booted past RSpecTracer.start".
+      #   .done — written at finalize entry, AFTER per-worker
+      #           run_finalize + emit_coverage_json. Must be the
+      #           last write our code does into parallel_tests_N/
+      #           on the worker side - the elected reads its
+      #           presence as "this peer is fully flushed".
+      #
+      # Verification path: see `wait_for_peer_done_markers!`. Without
+      # this the elected trusted only `wait_for_other_processes_to_finish`'s
+      # pid-file barrier, which observed evidence on GHA Linux x86_64
+      # showed could return before a sibling had flushed - leaving a
+      # straggler `parallel_tests_N/` after purge (failing
+      # spec/integration/parallel_tests_spec.rb:88 intermittently).
+      BOOT_MARKER_FILENAME = '.rspec_tracer_boot'
+      DONE_MARKER_FILENAME = '.rspec_tracer_done'
+
+      # Bound on the elected worker's wait for missing .done markers.
+      # 5s comfortably exceeds the at_exit tail of any well-behaved
+      # peer; on timeout we log + proceed (graceful degradation: a
+      # truly-crashed peer must not pin the elected forever).
+      PEER_DONE_DEADLINE_SECONDS = 5
 
       def self.active?
         return false if ::ENV.fetch('TEST_ENV_NUMBER', nil).nil?
@@ -61,29 +91,69 @@ module RSpecTracer
       # Called from RSpecTracer.start when parallel_tests is active.
       # Writes this worker's TEST_ENV_NUMBER into the shared lock file
       # under an exclusive lock so the max-seen value ends up correct
-      # regardless of worker boot order.
+      # regardless of worker boot order, then drops the .boot
+      # breadcrumb so the elected worker can enumerate "every peer
+      # that booted" at finalize time.
       def self.setup!
         return false unless active?
 
         require 'parallel_tests' unless defined?(::ParallelTests)
         track_test_env_number!
+        touch_boot!
         true
       rescue LoadError => e
         RSpecTracer.logger.error("Failed to load parallel_tests gem (#{e.class}: #{e.message})")
         false
       end
 
+      # Write `parallel_tests_N/.rspec_tracer_boot` with this worker's
+      # pid + TEST_ENV_NUMBER + timestamp. Source-of-truth for "this
+      # worker booted past RSpecTracer.start", consumed by the elected
+      # worker's finalize-time peer enumeration. Idempotent: a re-run
+      # of setup! overwrites with current values.
+      def self.touch_boot!
+        ::FileUtils.mkdir_p(RSpecTracer.cache_path)
+        ::File.write(
+          ::File.join(RSpecTracer.cache_path, BOOT_MARKER_FILENAME),
+          ::JSON.generate(
+            pid: ::Process.pid,
+            test_env_number: ::ENV.fetch('TEST_ENV_NUMBER', ''),
+            started_at: ::Time.now.utc.iso8601
+          )
+        )
+      rescue StandardError => e
+        RSpecTracer.logger.warn(
+          "RSpec tracer: failed to write boot marker (#{e.class}: #{e.message})"
+        )
+      end
+
       # Called from at_exit after the per-worker snapshot has been
-      # persisted. No-op unless this worker is the designated last
-      # process. Orchestrates the snapshot merge, the coverage merge
-      # (Reporters::CoverageJsonReporter.merge_parallel - coverage.json
-      # isn't part of the storage backend's snapshot shape), and the
-      # per-worker dir purge.
+      # persisted. Every worker drops its `.done` marker as the very
+      # first step here so the elected worker's verification loop can
+      # observe it; non-elected workers then return. The elected
+      # worker waits for every booted peer's `.done` to appear,
+      # orchestrates the snapshot + coverage merge, emits the merged
+      # reporters, and purges per-worker dirs.
+      #
+      # `touch_done!` MUST stay the last write our code performs into
+      # `parallel_tests_N/` — anything written later would land after
+      # the elected has decided it's safe to purge, leaving stragglers.
       def self.finalize!
         return false unless active?
+
+        touch_done!
+
         return false unless last_process?
 
         ::ParallelTests.wait_for_other_processes_to_finish if defined?(::ParallelTests)
+
+        # Belt-and-suspenders barrier: pid-file said everyone's done,
+        # but observed CI evidence (GHA Linux x86_64, Ruby 3.4 cells)
+        # caught a sibling's `parallel_tests_N/` reappearing post-purge
+        # — i.e., the pid signal returned while a peer hadn't fully
+        # flushed yet. Cross-check via the .boot/.done filesystem
+        # markers before declaring the peer set stable.
+        wait_for_peer_done_markers!
 
         merge_snapshot!
         merge_coverage! unless RSpecTracer.simplecov?
@@ -103,6 +173,72 @@ module RSpecTracer
           "RSpec tracer: parallel_tests finalize failed (#{e.class}: #{e.message})"
         )
         false
+      end
+
+      # Drop `parallel_tests_N/.rspec_tracer_done` as a flush-complete
+      # signal for the elected worker's verification loop. The cache
+      # dir already exists by this point (run_finalize mkdir_p's it
+      # earlier in the at_exit chain); the explicit mkdir_p here is
+      # belt-and-suspenders for the no-examples / early-return paths.
+      # Graceful-degradation rescue keeps a marker-write failure from
+      # propagating into the user's exit status.
+      def self.touch_done!
+        ::FileUtils.mkdir_p(RSpecTracer.cache_path)
+        ::File.write(
+          ::File.join(RSpecTracer.cache_path, DONE_MARKER_FILENAME),
+          ::Time.now.utc.iso8601
+        )
+      rescue StandardError => e
+        RSpecTracer.logger.warn(
+          "RSpec tracer: failed to write done marker (#{e.class}: #{e.message})"
+        )
+      end
+
+      # Block until every peer that wrote `.boot` has also written
+      # `.done`, or the deadline elapses. Polled at 50ms — fine
+      # enough that the typical "barrier returned a tick early" case
+      # closes within one or two polls, coarse enough not to dominate
+      # CPU.
+      #
+      # On timeout we log a warn and proceed: a peer that never wrote
+      # `.done` either crashed (then its dir is orphan content; the
+      # subsequent `purge_worker_dirs!` cleans it) or is genuinely
+      # hung (the elected can't fix that — we choose merge correctness
+      # over indefinite wait).
+      def self.wait_for_peer_done_markers!
+        base_dir = ::File.dirname(RSpecTracer.cache_path)
+        deadline = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) + PEER_DONE_DEADLINE_SECONDS
+
+        loop do
+          missing = peer_dirs_missing_done(base_dir)
+          return if missing.empty?
+
+          if ::Process.clock_gettime(::Process::CLOCK_MONOTONIC) >= deadline
+            RSpecTracer.logger.warn(
+              'RSpec tracer: peers booted without finishing within ' \
+              "#{PEER_DONE_DEADLINE_SECONDS}s: #{missing.inspect}; " \
+              'proceeding (peer dirs will be purged regardless of completion state)'
+            )
+            return
+          end
+
+          sleep 0.05
+        end
+      end
+
+      # Set difference of `.boot`-bearing peer dirs and `.done`-bearing
+      # peer dirs under `base_dir`. A returned entry means "this peer
+      # registered but hasn't signaled completion yet" — either still
+      # mid-flush, or crashed.
+      def self.peer_dirs_missing_done(base_dir)
+        boot_dirs = peer_dirs_with_marker(base_dir, BOOT_MARKER_FILENAME)
+        done_dirs = peer_dirs_with_marker(base_dir, DONE_MARKER_FILENAME)
+        boot_dirs - done_dirs
+      end
+
+      def self.peer_dirs_with_marker(base_dir, marker_filename)
+        paths = ::Dir.glob(::File.join(base_dir, 'parallel_tests_*', marker_filename))
+        paths.map { |path| ::File.dirname(path) }
       end
 
       # M8.10: Emit reporters against the merged top-level snapshot

--- a/spec/rspec/parallel_tests_spec.rb
+++ b/spec/rspec/parallel_tests_spec.rb
@@ -161,6 +161,95 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(described_class.setup!).to be(false)
       expect(logger).to have_received(:error).with(/Failed to load parallel_tests/)
     end
+
+    it 'drops a .rspec_tracer_boot breadcrumb in this worker\'s cache dir' do
+      described_class.setup!
+
+      boot_path = File.join(cache_path, described_class::BOOT_MARKER_FILENAME)
+      expect(File).to exist(boot_path)
+      payload = JSON.parse(File.read(boot_path))
+      expect(payload).to include('pid' => Process.pid, 'test_env_number' => '3')
+      expect(payload['started_at']).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+
+    it 'logs and continues when the boot-marker write raises (graceful degradation)' do
+      allow(File).to receive(:write).and_raise(StandardError, 'disk full')
+
+      expect(described_class.setup!).to be(true)
+      expect(logger).to have_received(:warn).with(/failed to write boot marker/)
+    end
+  end
+
+  describe '.touch_done!' do
+    it 'writes the .rspec_tracer_done marker into the worker cache dir' do
+      described_class.touch_done!
+
+      done_path = File.join(cache_path, described_class::DONE_MARKER_FILENAME)
+      expect(File).to exist(done_path)
+      expect(File.read(done_path)).to match(/\A\d{4}-\d{2}-\d{2}T/)
+    end
+
+    it 'creates the cache dir when it does not yet exist (no-examples / early-exit path)' do
+      FileUtils.rm_rf(File.dirname(cache_path))
+
+      described_class.touch_done!
+
+      expect(File.directory?(cache_path)).to be(true)
+    end
+
+    it 'logs and returns nil on StandardError — never propagates exit status' do
+      allow(File).to receive(:write).and_raise(StandardError, 'disk full')
+
+      expect { described_class.touch_done! }.not_to raise_error
+      expect(logger).to have_received(:warn).with(/failed to write done marker/)
+    end
+  end
+
+  describe '.wait_for_peer_done_markers!' do
+    let(:base_dir) { File.dirname(cache_path) }
+
+    def write_marker(worker, name)
+      dir = File.join(base_dir, "parallel_tests_#{worker}")
+      FileUtils.mkdir_p(dir)
+      File.write(File.join(dir, name), 'x')
+    end
+
+    it 'returns immediately when every booted peer has a .done marker' do
+      write_marker(1, described_class::BOOT_MARKER_FILENAME)
+      write_marker(1, described_class::DONE_MARKER_FILENAME)
+      write_marker(2, described_class::BOOT_MARKER_FILENAME)
+      write_marker(2, described_class::DONE_MARKER_FILENAME)
+
+      expect { described_class.wait_for_peer_done_markers! }.not_to raise_error
+      expect(logger).not_to have_received(:warn)
+    end
+
+    it 'returns immediately when no peer ever wrote .boot (single-process / inactive)' do
+      expect { described_class.wait_for_peer_done_markers! }.not_to raise_error
+    end
+
+    it 'logs the missing-peer warning and proceeds once the deadline elapses' do
+      write_marker(2, described_class::BOOT_MARKER_FILENAME)
+      stub_const("#{described_class}::PEER_DONE_DEADLINE_SECONDS", 0)
+      allow(described_class).to receive(:sleep)
+
+      expect { described_class.wait_for_peer_done_markers! }.not_to raise_error
+      expect(logger).to have_received(:warn)
+        .with(/peers booted without finishing within 0s.*parallel_tests_2/)
+    end
+
+    it 'returns once a previously-missing .done marker appears mid-poll' do
+      write_marker(2, described_class::BOOT_MARKER_FILENAME)
+      polls = 0
+      allow(described_class).to receive(:sleep) do
+        polls += 1
+        write_marker(2, described_class::DONE_MARKER_FILENAME) if polls == 1
+      end
+
+      expect { described_class.wait_for_peer_done_markers! }.not_to raise_error
+      expect(polls).to eq(1)
+      expect(logger).not_to have_received(:warn)
+    end
   end
 
   describe '.last_process?' do
@@ -279,6 +368,7 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       File.write(lock_file, "2\n")
       require 'parallel_tests'
       allow(ParallelTests).to receive(:wait_for_other_processes_to_finish)
+      allow(described_class).to receive(:wait_for_peer_done_markers!)
       allow(described_class).to receive(:merge_snapshot!)
       allow(described_class).to receive(:merge_coverage!)
       allow(described_class).to receive(:emit_merged_reporters!)
@@ -297,10 +387,27 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(described_class).not_to have_received(:merge_snapshot!)
     end
 
+    # Every worker — elected or not — drops a .done marker as the
+    # first thing in finalize. The elected worker's
+    # wait_for_peer_done_markers! reads exactly these markers; if
+    # touch_done! were gated on last_process?, non-elected workers
+    # would never signal completion and the elected would always
+    # time out.
+    it 'writes the .done marker even on non-elected workers' do
+      ENV['TEST_ENV_NUMBER'] = '2'
+      described_class.finalize!
+
+      # `RSpecTracer.cache_path` is stubbed to a fixed path in this
+      # spec (parallel_tests_1 in the helper); the non-elected
+      # branch still routes through that stub, so .done lands there.
+      expect(File).to exist(File.join(cache_path, described_class::DONE_MARKER_FILENAME))
+    end
+
     it 'runs the merge + cleanup sequence on the first (elected) worker' do
       result = described_class.finalize!
 
       expect(result).to be(true)
+      expect(described_class).to have_received(:wait_for_peer_done_markers!)
       expect(described_class).to have_received(:merge_snapshot!)
       expect(described_class).to have_received(:merge_coverage!)
       expect(described_class).to have_received(:emit_merged_reporters!)
@@ -314,6 +421,21 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       described_class.finalize!
 
       expect(described_class).not_to have_received(:merge_coverage!)
+    end
+
+    # The peer-done barrier MUST run after the pid wait + before the
+    # merge. The pid wait alone is the weak signal that motivated
+    # this barrier; running merge before peer-done verification would
+    # let a slow peer's snapshot land mid-merge and miss the union.
+    it 'runs wait_for_peer_done_markers! between pid-wait and merge_snapshot!' do
+      ordering = []
+      allow(ParallelTests).to receive(:wait_for_other_processes_to_finish) { ordering << :pid_wait }
+      allow(described_class).to receive(:wait_for_peer_done_markers!) { ordering << :peer_wait }
+      allow(described_class).to receive(:merge_snapshot!) { ordering << :merge }
+
+      described_class.finalize!
+
+      expect(ordering).to eq(%i[pid_wait peer_wait merge])
     end
 
     # M8.10: emit_merged_reporters! must run BEFORE purge_worker_dirs!


### PR DESCRIPTION
## Summary

- `spec/integration/parallel_tests_spec.rb:88` (\"purges per-worker `parallel_tests_N` directories on the last worker\") flakes intermittently on GHA Linux x86_64 ruby-3.4 cells with a leftover sibling worker dir post-purge. Two confirmed instances on different SHAs / different straggler indices (`parallel_tests_3` and `parallel_tests_4`); always recovers on rerun.
- The elected worker trusted only `parallel_tests`'s pid-file barrier (`wait_for_other_processes_to_finish` polls until `pids.count <= 1`). Under specific GHA scheduling/I/O timing the count drops to 1 while a sibling's at_exit hasn't fully flushed; the subsequent `rm_rf` then either races a concurrent late write or the sibling recreates the dir post-purge.
- Add a filesystem-evidence barrier on top: every worker writes `.rspec_tracer_boot` at setup and `.rspec_tracer_done` at finalize entry; the elected worker waits for every booted peer's `.done` to appear before merge + purge. Pid file + filesystem must agree.

## What changed

- [`lib/rspec_tracer/rspec/parallel_tests.rb`](lib/rspec_tracer/rspec/parallel_tests.rb)
  - `setup!` now writes `parallel_tests_N/.rspec_tracer_boot` (pid + TEST_ENV_NUMBER + timestamp).
  - `finalize!` writes `.rspec_tracer_done` as its first step (for both elected and non-elected workers — the elected reads non-elected `.done`s as the completion signal).
  - The elected worker calls `wait_for_peer_done_markers!` between the existing pid-file wait and `merge_snapshot!`. Polls 50ms; bounded at 5s, then logs a warn and proceeds (graceful degradation: a crashed peer must not pin the elected indefinitely; `purge_worker_dirs!` cleans the dir regardless of completion state).
  - `touch_done!` is documented as the LAST write our code performs into `parallel_tests_N/` — anything later would break the elected's safety contract.
- [`spec/rspec/parallel_tests_spec.rb`](spec/rspec/parallel_tests_spec.rb): unit coverage for `touch_boot!`, `touch_done!`, `wait_for_peer_done_markers!` (immediate return, deadline timeout, mid-poll recovery, graceful-degradation rescue paths). New ordering assertion in `.finalize!`: `pid_wait → peer_wait → merge`. Existing tests adjusted to allow `wait_for_peer_done_markers!`.

## Backend scope

Backend-agnostic. The earlier instinct to gate to the JSON backend was wrong — SQLite parallel runs use the same per-worker dir layout and the same `purge_worker_dirs!` path, so the race surface applied identically. The barrier runs whenever `parallel_tests` is active.

## Why this should hold up where prior \"fixes\" couldn't

The flake doesn't reproduce in any local environment we can build (darwin-arm64, aarch64-linux Docker, amd64-linux Docker — 39 total iterations green pre-fix; 12/12 post-fix in the same amd64-linux Ruby 3.4 container). The barrier is a defense against a CI-only timing window we can't simulate. It's evidence-driven (.boot/.done are independent filesystem signals from the gem's pid file) and the worst case under timeout is the same as today's behavior (skip waiting, purge anyway, accept partial merge).

## Test plan

- [x] `task lint:ruby` — pass
- [x] `task lint:actions` — pass
- [x] `task lint:yaml` — pass
- [x] `bundle exec rspec spec/rspec/parallel_tests_spec.rb` — 61/61, line-coverage gate green
- [x] `bundle exec rspec spec/integration/parallel_tests_spec.rb` — 7/7
- [x] `task test:dogfood` — pass
- [x] `task check` (lint:ruby + test:unit + benchmark:smoke) — pass
- [x] amd64-linux Ruby 3.4 Docker container, 12-iteration stress loop with fix applied — 12/12
- [ ] After merge: monitor `ruby-parallel (ruby-3.4, *)` cells across the next several CI runs to confirm the leftover-worker-dirs assertion no longer flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)