### PR TITLE
fix(docs-publish): split coverage-download into two conditional steps

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -149,24 +149,34 @@ jobs:
       # commit SHA on the tag-push path; the first-party action
       # requires an explicit run-id which we don't have for tags.
       #
-      # On the workflow_run path: pass run_id directly. dawidd6 uses
-      # run_id when set (commit/workflow ignored); the upstream
-      # ci.yml run is a guaranteed ancestor of this docs-publish
-      # run, so the artifact is reachable.
-      #
-      # On tag-push / workflow_dispatch: run_id resolves empty
-      # (NaN), dawidd6 falls back to the workflow + commit lookup
-      # and finds the earlier main-push ci.yml run on the tag SHA
-      # (within actions/upload-artifact's 90-day retention).
-      - name: Download merged coverage from CI run on this SHA
-        id: download_coverage
+      # Two sibling steps (gated on event_name) instead of one with
+      # both `run_id` and `commit` set: dawidd6@v9 explicitly errors
+      # on `pr, commit, branch, run_id` together with
+      # "The following inputs cannot be used together" - so the
+      # workflow_run path must pass ONLY run_id, and the tag/dispatch
+      # path must pass ONLY commit. PR #167's single-step shape
+      # tripped that check (silently caught by continue-on-error,
+      # surfacing as a "No coverage artifact" skip and a 404 on
+      # /<version>/coverage/).
+      - name: Download merged coverage from CI run (workflow_run path)
+        if: github.event_name == 'workflow_run'
+        uses: dawidd6/action-download-artifact@v9
+        continue-on-error: true
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: coverage-merged
+          path: doc/coverage-merged
+          if_no_artifact_found: warn
+
+      - name: Download merged coverage from CI run (tag/dispatch path)
+        if: github.event_name != 'workflow_run'
         uses: dawidd6/action-download-artifact@v9
         continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: ci.yml
-          run_id: ${{ github.event.workflow_run.id }}
-          commit: ${{ github.event.workflow_run.head_sha || github.sha }}
+          commit: ${{ github.sha }}
           name: coverage-merged
           path: doc/coverage-merged
           if_no_artifact_found: warn


### PR DESCRIPTION
## Summary

PR #167 set both \`run_id\` and \`commit\` on \`dawidd6/action-download-artifact@v9\`, intending the action to use \`run_id\` when present and fall back to \`commit\` otherwise. v9 explicitly rejects that combination:

\`\`\`
##[error]The following inputs cannot be used together: pr, commit, branch, run_id
\`\`\`

\`continue-on-error: true\` swallowed the action error, the conditional staging step then saw an empty \`doc/coverage-merged\` and skipped staging coverage. Result: docs deploys (e.g., the post-#167-merge run on \`42b5e79\`) succeeded but [\`https://avmnu-sng.github.io/rspec-tracer/main/coverage/\`](https://avmnu-sng.github.io/rspec-tracer/main/coverage/) stayed 404.

## Fix

Split the download into two steps gated by \`event_name\`:

- workflow_run path: pass ONLY \`run_id\` (the upstream ci.yml run we chained from is a guaranteed ancestor; artifact reachable by run-id).
- tag-push / workflow_dispatch path: pass ONLY \`commit\` (look up the earlier main-push ci.yml run on this SHA within the 90-day artifact retention window).

This is the shape PR #167's design described, just realized in two sibling steps instead of one parameterized step.

No behavior change beyond the artifact lookup itself: the staging \`cp\` and the two peaceiris publishes downstream stay byte-identical.

## Test plan

- [x] \`task lint:yaml\` — pass
- [x] \`task lint:actions\` — pass
- [ ] After merge: next docs-publish run (chained from main-push ci.yml via the existing \`workflow_run\` trigger) lands content under \`/main/coverage/index.html\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)