### PR TITLE
chore(docs-publish): drop gh-pages coverage page; trust Codecov as the canonical surface

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,10 +57,10 @@ See `task --list` for the full command catalogue.
 
 ## Coverage
 
-Coverage is collected via SimpleCov (line + branch) and exported in
-two places: a per-PR Codecov delta + diff-coverage gate (≥ 90% on
-the patch; no project drop), and a per-version HTML report
-published to gh-pages at `/<version>/coverage/`.
+Coverage is collected via SimpleCov (line + branch) and uploaded to
+Codecov for PR delta + diff-coverage gating (≥ 90% on the patch; no
+project drop) and project history. The Codecov UI is the canonical
+public surface — see the badge in the README.
 
 Each `task test:*` task sets a unique `COVERAGE_SUITE` env var so
 per-suite resultsets land under distinct `command_name`s in
@@ -85,8 +85,7 @@ open coverage/index.html
 CI (lint-and-specs.yml): each test job uploads its
 `coverage/.resultset.json` as `coverage-test-<job>` artifact; the
 `coverage` aggregator job downloads them all, runs `task coverage:merge`,
-and pushes the merged JSON to Codecov + uploads HTML for
-docs-publish.yml to stage at `/<version>/coverage/`.
+and pushes the merged JSON to Codecov.
 
 Skip coverage entirely with `COVERAGE=false` (spec_helper guards
 SimpleCov.start on `ENV['COVERAGE'] != 'false'`). Mutation runs

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -12,27 +12,18 @@
 #   /v<version>/demo/
 #
 # Triggers:
-#   - workflow_run on ci.yml completion (continuous deployment of
-#     /main/, chained behind a successful main-push CI run so the
-#     `coverage-merged` artifact is guaranteed to exist when this
-#     workflow queries for it; see "Coverage chain" below)
+#   - push to main (continuous deployment of /main/)
 #   - tag push v* (deployment of /v<version>/ + landing-page refresh)
 #   - workflow_dispatch (manual re-run, e.g. after a registry repair)
 #
-# Coverage chain: the multi-suite SimpleCov merge runs in ci.yml's
-# `coverage` aggregator job (~10-15 min after a main push). docs-
-# publish needs that artifact to stage `/<version>/coverage/`. An
-# earlier shape ran on the same push event in parallel with ci.yml
-# and lost the race (~5 min docs-publish vs ~10-15 min ci.yml ⇒
-# artifact didn't exist yet when dawidd6 queried, so /main/coverage/
-# 404'd silently). Chaining via `workflow_run` makes the ci.yml run
-# a guaranteed ancestor: the artifact is reachable by run-id and the
-# race is gone. Cost: main-push docs deploys are now ci.yml duration
-# + ~5 min instead of ~5 min standalone; deemed acceptable since
-# docs deploys aren't user-facing critical-path. Tag-push docs
-# deploys are unaffected — ci.yml doesn't trigger on tags, so tag
-# pushes still go straight to this workflow and look up coverage
-# via the earlier main-push run on the same SHA.
+# Coverage browsing is owned by Codecov (see README badge → codecov.io
+# /gh/avmnu-sng/rspec-tracer): PR-delta comments, project history, and
+# public read-without-auth UI live there. This workflow used to also
+# stage SimpleCov HTML at /<version>/coverage/ via a workflow_run
+# chain on ci.yml, but the page was strictly redundant with Codecov
+# and the chain added cross-workflow coupling + cache-of-cache bugs
+# (PR #167's dawidd6 input-conflict, PR #169's split fix). Removed
+# in favor of trusting Codecov for the coverage surface.
 #
 # Required GitHub Pages setup (one-time, repo owner):
 #   1. Settings -> Pages -> Source: "Deploy from a branch"
@@ -49,11 +40,8 @@
 name: docs-publish
 
 on:
-  workflow_run:
-    workflows: [ci]
-    types: [completed]
-    branches: [main]
   push:
+    branches: [main]
     tags: ['v*']
   workflow_dispatch:
 
@@ -69,32 +57,10 @@ jobs:
   build-and-publish:
     name: Build + publish docs site
     runs-on: ubuntu-latest
-    # When triggered by workflow_run, only proceed if the upstream
-    # ci.yml run succeeded AND was triggered by a push (not a PR or
-    # workflow_dispatch). PR runs don't deploy docs; ci.yml dispatches
-    # on a non-main ref shouldn't either. The `branches: [main]`
-    # filter on the workflow_run trigger above already restricts to
-    # ci.yml's main-push runs, but the explicit event check is
-    # belt-and-suspenders. Tag pushes / workflow_dispatch (other
-    # event_name values) bypass this gate entirely.
-    if: >-
-      github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push')
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # full history so we can list tags
-          # On the workflow_run path, pin checkout to the SHA that
-          # ci.yml ran on. Without this, github.ref defaults to the
-          # default branch HEAD — which may have advanced past the
-          # ci.yml head_sha if a second main push landed during
-          # ci.yml's run, in which case we'd build docs from a
-          # newer commit but stage coverage from the older run's
-          # artifact (mismatch). Tag pushes / workflow_dispatch fall
-          # through to the default github.sha (= the tag SHA / the
-          # dispatch-ref HEAD), which is correct.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -140,65 +106,12 @@ jobs:
       - name: Build the docs site
         run: task docs:site:build
 
-      # Pull the merged SimpleCov report uploaded by the `coverage`
-      # job in lint-and-specs.yml's run on this same commit. Tolerates
-      # absence (falls back to no /coverage/ subdir for that version)
-      # so docs-publish never blocks on a CI flake. Step uses
-      # dawidd6/action-download-artifact (not the first-party
-      # actions/download-artifact) because we want to look up by
-      # commit SHA on the tag-push path; the first-party action
-      # requires an explicit run-id which we don't have for tags.
-      #
-      # Two sibling steps (gated on event_name) instead of one with
-      # both `run_id` and `commit` set: dawidd6@v9 explicitly errors
-      # on `pr, commit, branch, run_id` together with
-      # "The following inputs cannot be used together" - so the
-      # workflow_run path must pass ONLY run_id, and the tag/dispatch
-      # path must pass ONLY commit. PR #167's single-step shape
-      # tripped that check (silently caught by continue-on-error,
-      # surfacing as a "No coverage artifact" skip and a 404 on
-      # /<version>/coverage/).
-      - name: Download merged coverage from CI run (workflow_run path)
-        if: github.event_name == 'workflow_run'
-        uses: dawidd6/action-download-artifact@v9
-        continue-on-error: true
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          run_id: ${{ github.event.workflow_run.id }}
-          name: coverage-merged
-          path: doc/coverage-merged
-          if_no_artifact_found: warn
-
-      - name: Download merged coverage from CI run (tag/dispatch path)
-        if: github.event_name != 'workflow_run'
-        uses: dawidd6/action-download-artifact@v9
-        continue-on-error: true
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: ci.yml
-          commit: ${{ github.sha }}
-          name: coverage-merged
-          path: doc/coverage-merged
-          if_no_artifact_found: warn
-
       - name: Stage the per-version subdir
         run: |
           rm -rf doc/staged
           mkdir -p doc/staged/${{ steps.target.outputs.target_dir }}
           cp -r doc/site/yard doc/staged/${{ steps.target.outputs.target_dir }}/
           cp -r doc/site/demo doc/staged/${{ steps.target.outputs.target_dir }}/
-
-          # Stage SimpleCov merged HTML + JSON under
-          # /<version>/coverage/ when the CI artifact was downloaded
-          # successfully. The artifact root is the SimpleCov-output
-          # `coverage/` dir (HTML index.html + JSON coverage.json +
-          # assets/), so a recursive copy is enough.
-          if [ -d doc/coverage-merged ] && [ -n "$(ls -A doc/coverage-merged 2>/dev/null)" ]; then
-            cp -r doc/coverage-merged doc/staged/${{ steps.target.outputs.target_dir }}/coverage
-            echo "Coverage staged at /${{ steps.target.outputs.target_dir }}/coverage/"
-          else
-            echo "No coverage artifact for this SHA; skipping /${{ steps.target.outputs.target_dir }}/coverage/"
-          fi
 
       # First publish: write the version-keyed subdir. peaceiris with
       # destination_dir REPLACES that subdir's contents entirely while
@@ -211,13 +124,10 @@ jobs:
           publish_dir: doc/staged/${{ steps.target.outputs.target_dir }}
           destination_dir: ${{ steps.target.outputs.target_dir }}
           # Custom commit message so the gh-pages branch history reads
-          # like a docs deploy log. Cite the SHA actually deployed
-          # (= ci.yml's head_sha on the workflow_run path) rather
-          # than github.sha, which on workflow_run is the default-
-          # branch HEAD and may have advanced past the deployed SHA.
+          # like a docs deploy log.
           commit_message: >-
             docs: publish ${{ steps.target.outputs.version }}
-            (${{ github.event.workflow_run.head_sha || github.sha }})
+            (${{ github.sha }})
 
       - name: Generate root landing page + versions.json
         run: |

--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -168,12 +168,13 @@ jobs:
       # scope for this PR.
 
   # Aggregator: collate every per-job coverage resultset into one
-  # canonical merged report (HTML + JSON). Pushes to Codecov for
-  # PR delta + diff-coverage gating; uploads the merged report as
-  # an artifact so docs-publish.yml can stage it under
-  # /<version>/coverage/ on gh-pages. `if: always()` so a single
-  # red test job doesn't suppress the merge of the others (we
-  # still want to see coverage delta on partial-fail PRs).
+  # canonical merged report (HTML + JSON) and push to Codecov for
+  # PR delta + diff-coverage gating + project history. Codecov is
+  # the only consumer; the merged report is read from the runner
+  # workspace directly and not re-uploaded as a CI artifact.
+  # `if: always()` so a single red test job doesn't suppress the
+  # merge of the others (we still want to see coverage delta on
+  # partial-fail PRs).
   coverage:
     name: coverage
     runs-on: ubuntu-latest
@@ -192,12 +193,6 @@ jobs:
           pattern: coverage-test-*
       - name: Merge resultsets via SimpleCov.collate
         run: task coverage:merge
-      - name: Upload merged coverage report
-        uses: actions/upload-artifact@v7
-        with:
-          name: coverage-merged
-          path: coverage/
-          if-no-files-found: error
       - name: Push to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,11 @@ commit messages are the only materials that survive in the repository.
   `coverage/.resultset.json`; `task coverage:merge` collates them via
   `SimpleCov.collate` and produces `coverage/index.html` +
   `coverage/coverage.json`. CI: `lint-and-specs.yml`'s `coverage` job
-  downloads per-job artifacts + uploads to Codecov + uploads merged
-  HTML for `docs-publish.yml`. Skip with `COVERAGE=false` env;
-  mutation runs auto-skip via `defined?(::Mutant)`.
+  downloads per-job artifacts + pushes the merged JSON to Codecov
+  (sole public consumer; the gh-pages `/coverage/` page used to mirror
+  this and was removed since Codecov is the canonical surface). Skip
+  with `COVERAGE=false` env; mutation runs auto-skip via
+  `defined?(::Mutant)`.
 - `bundle exec rake` is still wired (legacy cucumber path). Removed in
   the 2.0.0 cleanup.
 

--- a/README.md
+++ b/README.md
@@ -457,16 +457,16 @@ dashboards and the terminal one-liner shown in [Quick start](#quick-start).
 
 - **Docs site**: [avmnu-sng.github.io/rspec-tracer](https://avmnu-sng.github.io/rspec-tracer/)
   publishes a YARD API reference, the cookbook, internals deep-dives,
-  the sample HTML report, **and the merged coverage report** for every
-  rolling main + tagged release. The landing page lets you switch
-  versions; per-version subpaths look like
-  `/main/yard/`, `/main/coverage/`, `/v2.0.0.pre.1/yard/`, etc.
+  and the sample HTML report for every rolling main + tagged release.
+  The landing page lets you switch versions; per-version subpaths look
+  like `/main/yard/`, `/main/demo/`, `/v2.0.0.pre.1/yard/`, etc.
 
-- **Coverage**: tracked by Codecov (per-PR delta + diff-coverage gate
-  ≥ 90%) plus the per-version HTML report linked above. Multi-suite
-  resultsets (`unit`, `edge-cases`, `regressions-plain`, `fuzz`) merge
-  via SimpleCov.collate in the CI `coverage` job; the same merger runs
-  locally via `task coverage:merge` after `task test:*` runs.
+- **Coverage**: tracked by [Codecov](https://codecov.io/gh/avmnu-sng/rspec-tracer)
+  (per-PR delta + diff-coverage gate ≥ 90%; project history). Multi-
+  suite resultsets (`unit`, `edge-cases`, `regressions-plain`, `fuzz`)
+  merge via SimpleCov.collate in the CI `coverage` job; the same
+  merger runs locally via `task coverage:merge` after `task test:*`
+  runs (open `coverage/index.html` for the local HTML report).
 
 ## Help and community
 


### PR DESCRIPTION
## Summary

The \`/<version>/coverage/\` page on gh-pages duplicated [Codecov](https://codecov.io/gh/avmnu-sng/rspec-tracer) (PR delta + project history + public read-without-auth UI) with a worse UX (static SimpleCov HTML — no diff/sunburst/PR-comment integration). Keeping it required a cross-workflow chain (workflow_run trigger + dawidd6 download) that produced two distinct production bugs in a week ([#167](https://github.com/avmnu-sng/rspec-tracer/pull/167) + [#169](https://github.com/avmnu-sng/rspec-tracer/pull/169)).

Drop it. Trust Codecov as the canonical coverage surface.

## What changed

### [\`.github/workflows/docs-publish.yml\`](.github/workflows/docs-publish.yml)
- Trigger reverts to \`push: branches: [main]\` + \`push: tags: ['v*']\` + \`workflow_dispatch\` (drop \`workflow_run\` chain).
- Drop the workflow_run-only job-level \`if:\` + checkout \`ref:\` pin + peaceiris \`commit_message\` head_sha fallback.
- Drop both \`Download merged coverage from CI run\` steps and the conditional \`/coverage/\` staging block.
- Update top-of-file comment to point at Codecov.

### [\`.github/workflows/lint-and-specs.yml\`](.github/workflows/lint-and-specs.yml)
- Drop \`actions/upload-artifact\` for \`coverage-merged\`. The Codecov action reads \`coverage/coverage.json\` from the workspace directly; the artifact existed solely to feed docs-publish, and with that consumer gone the upload is dead weight (~440 KB per main run).

### Docs
- [\`README.md\`](README.md): drop \`/main/coverage/\` link; point at Codecov.
- [\`.github/CONTRIBUTING.md\`](.github/CONTRIBUTING.md): drop \`/<version>/coverage/\` references in the Coverage section.
- [\`CLAUDE.md\`](CLAUDE.md): drop the coverage-merged-for-docs-publish line.

### Untouched

- \`/demo/\` + \`/yard/\` + landing page on gh-pages stay exactly as-is. Those are rspec-tracer-specific surfaces Codecov can't replace.
- Codecov's \`secrets.CODECOV_TOKEN\` wiring + \`fail_ci_if_error: false\` stays — same upload path, just no secondary artifact.

## Orphan cleanup (followup)

Pre-existing \`/main/coverage/\` on gh-pages from the last deploy (006d869) becomes an orphan after this lands. peaceiris with \`destination_dir\` doesn't auto-prune. I'll clean that up in a one-shot commit on the \`gh-pages\` branch directly once this merges. The orphan is harmless (~440KB), just hygiene.

## Test plan

- [x] \`task lint:yaml\` — pass
- [x] \`task lint:actions\` — pass
- [x] \`task lint:ruby\` — pass
- [x] grep sweep: no committed file references \`coverage-merged\` / \`/<version>/coverage\` / staging path. (Local-only \`docs/revamp/\` notes still mention them; that tree is gitignored and intentionally not part of the PR.)
- [ ] After merge: confirm next main-push docs-publish run completes without \`Download merged coverage\` steps and \`/main/yard/\` + \`/main/demo/\` still publish cleanly.
- [ ] After merge: clean up gh-pages orphan \`/main/coverage/\` (separate commit on \`gh-pages\` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)