### PR TITLE
test(coverage): close ~70 branch gaps surfaced by #165 + enforce branches by default

### DIFF
--- a/spec/rails/notifications_spec.rb
+++ b/spec/rails/notifications_spec.rb
@@ -440,6 +440,13 @@ RSpec.describe RSpecTracer::Rails::Notifications do
       expect(described_class.instance_variable_get(:@ar_schema_inputs)).to be_empty
     end
 
+    it 'drops ar_schema_paths entries whose digest compute returns nil (e.g. racey delete)' do
+      allow(RSpecTracer::Tracker::FileDigest).to receive(:compute).and_return(nil)
+
+      expect { described_class.install(root: tmpdir, ar_schema_paths: [schema_rb]) }.not_to raise_error
+      expect(described_class.instance_variable_get(:@ar_schema_inputs)).to be_empty
+    end
+
     it 'swallows errors inside record_ar_schema' do
       described_class.install(root: tmpdir, ar_schema_paths: [schema_rb])
       bucket = {}

--- a/spec/remote_cache/archive_spec.rb
+++ b/spec/remote_cache/archive_spec.rb
@@ -194,6 +194,28 @@ RSpec.describe RSpecTracer::RemoteCache::Archive do
     end
   end
 
+  describe '.safe_entry_name' do
+    it 'returns nil on a nil entry name' do
+      expect(described_class.safe_entry_name(nil)).to be_nil
+    end
+
+    it 'returns nil on an empty entry name' do
+      expect(described_class.safe_entry_name('')).to be_nil
+    end
+
+    it 'returns nil on an absolute path' do
+      expect(described_class.safe_entry_name('/etc/passwd')).to be_nil
+    end
+
+    it 'returns nil on a path containing parent traversal' do
+      expect(described_class.safe_entry_name('foo/../etc/passwd')).to be_nil
+    end
+
+    it 'returns the name unchanged on a well-formed relative entry' do
+      expect(described_class.safe_entry_name('run_id/file.json')).to eq('run_id/file.json')
+    end
+  end
+
   describe 'compression ratio' do
     it 'compresses redundant JSON meaningfully (~3-6x typical)' do
       # Compression is opportunistic, not guaranteed; the assertion is

--- a/spec/remote_cache/git_ancestry_spec.rb
+++ b/spec/remote_cache/git_ancestry_spec.rb
@@ -363,6 +363,111 @@ RSpec.describe RSpecTracer::RemoteCache::GitAncestry do
         expect { ancestry.merge_base_branch! }.to raise_error(described_class::GitAncestryError)
       end
     end
+
+    it 'raises when current_branch resolution fails (outside a git repo)' do
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          # branch != default forces merge_base_branch! past the early-return
+          # so current_branch is exercised.
+          ancestry = described_class.new(default_branch: 'main', branch: 'feat')
+
+          expect { ancestry.merge_base_branch! }
+            .to raise_error(described_class::GitAncestryError, /current branch/)
+        end
+      end
+    end
+
+    it 'raises GitAncestryError when neither parent of a merge commit can be resolved' do
+      with_fake_repo do
+        ancestry = described_class.new(default_branch: 'main', branch: 'main')
+        # Force the merge-commit code path; merged_parents will then ask
+        # git rev-parse HEAD^1/HEAD^2 — which we make fail by piggybacking
+        # `system('false')` to set $? to a non-success status.
+        allow(ancestry).to receive(:merge_commit?).and_return(true)
+        allow(ancestry).to receive(:`) do |_cmd|
+          system('false')
+          ''
+        end
+
+        expect { ancestry.send(:merged_parents) }
+          .to raise_error(described_class::GitAncestryError, /merge commit parents/)
+      end
+    end
+
+    it 'raises GitAncestryError when rev_list fails' do
+      with_fake_repo do
+        ancestry = described_class.new(default_branch: 'main', branch: 'main')
+
+        expect { ancestry.send(:rev_list, 'definitely-not-a-real-ref') }
+          .to raise_error(described_class::GitAncestryError, /Could not list revs/)
+      end
+    end
+
+    it 'raises GitAncestryError when refs_committer_timestamp git show fails' do
+      with_fake_repo do
+        ancestry = described_class.new(default_branch: 'main', branch: 'main')
+
+        expect { ancestry.send(:refs_committer_timestamp, Set['definitely-not-a-real-sha']) }
+          .to raise_error(described_class::GitAncestryError, /committer timestamps/)
+      end
+    end
+
+    it 'returns {} from refs_committer_timestamp on an empty ref set' do
+      with_fake_repo do
+        ancestry = described_class.new(default_branch: 'main', branch: 'main')
+
+        expect(ancestry.send(:refs_committer_timestamp, Set.new)).to eq({})
+      end
+    end
+  end
+
+  describe 'merge-commit ancestry walk' do
+    # Hits the `ref_list |= rev_list("…..origin/HEAD") if merge_commit?`
+    # branch in #ancestry_refs — the prior coverage was main-only.
+    it 'unions the origin/HEAD diff into the ancestry walk on a merge-commit branch' do
+      with_fake_repo do
+        create_branch!('feat')
+        write_and_commit('feat.txt', 'feat content', 'feat commit')
+        checkout!('main')
+        write_and_commit('main.txt', 'main content', 'main commit')
+        sh!('git', 'merge', 'feat', '--no-ff', '--no-edit', '--quiet')
+
+        ancestry = described_class.new(default_branch: 'main', branch: 'main')
+
+        refs = ancestry.ancestry_refs
+        expect(refs).to be_a(Hash)
+        # The merge commit's synthetic HEAD must be ignored (was added to
+        # @ignored_refs); the real branch tip + main commits remain.
+        expect(refs.values.all?(Integer)).to be(true)
+      end
+    end
+  end
+
+  describe 'memo reset' do
+    # Hits reset_memo!'s `remove_instance_variable(:@ancestry_refs)
+    # if defined?` :then branch — prior tests only memoized branch_ref.
+    it 'clears a memoized ancestry_refs after merge_base_branch! reruns the walk' do
+      with_fake_repo do
+        create_branch!('feat')
+        write_and_commit('feat.txt', 'feat content', 'feat commit')
+        push_branch!('feat')
+        checkout!('main')
+        write_and_commit('main.txt', 'main content', 'main commit')
+        sh!('git', 'push', '--quiet', 'origin', 'main')
+        checkout!('feat')
+
+        ancestry = described_class.new(default_branch: 'main', branch: 'feat')
+        first = ancestry.ancestry_refs
+
+        ancestry.merge_base_branch!
+        second = ancestry.ancestry_refs
+
+        # Different walks (the merge commit shifted HEAD) — the memo was
+        # invalidated, so the second call recomputed instead of returning
+        # the stale first hash.
+        expect(second).not_to equal(first)
+      end
+    end
   end
 end
 # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/remote_cache/local_fs_backend_spec.rb
+++ b/spec/remote_cache/local_fs_backend_spec.rb
@@ -345,6 +345,44 @@ RSpec.describe RSpecTracer::RemoteCache::LocalFsBackend do
       expect(backend.prune!(pr_branch_ttl_seconds: 1)).to eq(0)
     end
 
+    it 'pr_branch_ttl=nil on PR tier skips the dead-PR check (safe-nav else branch)' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      write_local_cache(run_id: 'run-live')
+      pr.upload('sha1')
+
+      expect(pr.prune!(pr_branch_ttl_seconds: nil)).to eq(0)
+      expect(Dir.exist?(File.join(@root, 'pr', 'feat'))).to be(true)
+    end
+
+    it 'returns 0 when count exceeds existing ref count (no-op short-circuit)' do
+      backend = new_backend
+      write_local_cache(run_id: 'run-1')
+      backend.upload('sha1')
+
+      expect(backend.prune!(count: 50)).to eq(0)
+      expect(Dir.exist?(File.join(@root, 'main', 'sha1'))).to be(true)
+    end
+
+    it 'returns 0 on a PR tier whose archive directory exists but holds no refs (orphan dir)' do
+      pr = new_backend(branch: 'orphan', default_branch: 'main')
+      FileUtils.mkdir_p(File.join(@root, 'pr', 'orphan'))
+
+      expect(pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)).to eq(0)
+    end
+
+    it 'silently swallows per-ref delete failures when no logger is configured (log_warn nil-logger path)' do
+      backend = described_class.new(root: @root, branch: 'main', default_branch: 'main',
+                                    cache_path: @cache_path)
+      write_local_cache(run_id: 'run-x')
+      backend.upload('sha1')
+      sleep 0.05
+      write_local_cache(run_id: 'run-y')
+      backend.upload('sha2')
+      allow(FileUtils).to receive(:rm_rf).and_raise(Errno::EACCES)
+
+      expect { backend.prune!(count: 1) }.not_to raise_error
+    end
+
     it 'continues on per-ref delete failures and logs' do
       logger = instance_double(RSpecTracer::Logger)
       allow(logger).to receive(:debug)
@@ -362,6 +400,34 @@ RSpec.describe RSpecTracer::RemoteCache::LocalFsBackend do
 
       expect { backend.prune!(count: 1) }.not_to raise_error
       expect(logger).to have_received(:warn).at_least(:once)
+    end
+  end
+
+  describe 'list_refs_in_tier (private) skips non-archive entries' do
+    it 'ignores tier subdirs that have no cache.tar.gz archive' do
+      # write a half-uploaded ref dir without the archive file
+      FileUtils.mkdir_p(File.join(@root, 'main', 'partial-ref'))
+
+      backend = new_backend
+      write_local_cache(run_id: 'run-real')
+      backend.upload('real-sha')
+
+      expect(backend.send(:list_refs_in_tier, 'main').map(&:first)).to eq(['real-sha'])
+    end
+  end
+
+  describe 'read_local_run_id (private) graceful nil paths' do
+    it 'returns nil when last_run.json holds non-Hash JSON' do
+      File.write(File.join(@cache_path, 'last_run.json'), JSON.dump([1, 2, 3]))
+
+      expect(new_backend.send(:read_local_run_id)).to be_nil
+    end
+
+    it 'returns nil when last_run.json holds a Hash with a blank run_id' do
+      File.write(File.join(@cache_path, 'last_run.json'),
+                 JSON.dump('schema_version' => current_schema, 'run_id' => ''))
+
+      expect(new_backend.send(:read_local_run_id)).to be_nil
     end
   end
 
@@ -403,6 +469,12 @@ RSpec.describe RSpecTracer::RemoteCache::LocalFsBackend do
   end
 
   describe '#unbounded_warning' do
+    it 'returns nil before any uploads (main tier dir does not yet exist)' do
+      # Hits list_refs_in_tier's `return [] unless File.directory?(dir)`
+      # short-circuit on a fresh backend.
+      expect(new_backend.unbounded_warning).to be_nil
+    end
+
     it 'returns nil when ref count at or below threshold' do
       backend = new_backend
       write_local_cache(run_id: 'run-1')

--- a/spec/remote_cache/redis_backend_spec.rb
+++ b/spec/remote_cache/redis_backend_spec.rb
@@ -658,5 +658,93 @@ RSpec.describe RSpecTracer::RemoteCache::RedisBackend do
       expect(backend.unbounded_warning(warn_threshold: 0)).to be_nil
     end
   end
+
+  describe 'private branch coverage' do
+    let(:logger) do
+      logger = instance_double(RSpecTracer::Logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:warn)
+      logger
+    end
+
+    it 'normalizes an empty test_suite_id to nil' do
+      backend = new_backend(test_suite_id: '')
+
+      expect(backend.instance_variable_get(:@test_suite_id)).to be_nil
+    end
+
+    it 'pr_branch_ttl=nil on PR tier skips the dead-PR check (safe-nav else branch)' do
+      pr = new_backend(branch: 'feat', default_branch: 'main')
+      @fake.hset('rspec-tracer:pr:feat:live-sha', { '_timestamp' => Time.now.to_i.to_s })
+
+      expect(pr.prune!(pr_branch_ttl_seconds: nil)).to eq(0)
+    end
+
+    it 'returns nil from read_local_run_id when last_run.json holds non-Hash JSON' do
+      File.write(File.join(@cache_path, 'last_run.json'), JSON.dump([1, 2, 3]))
+
+      expect(new_backend.send(:read_local_run_id)).to be_nil
+    end
+
+    it 'returns nil from read_local_run_id when last_run.json holds a blank run_id' do
+      File.write(File.join(@cache_path, 'last_run.json'),
+                 JSON.dump('schema_version' => current_schema, 'run_id' => ''))
+
+      expect(new_backend.send(:read_local_run_id)).to be_nil
+    end
+
+    it 'returns nil from fetch_timestamp when the hash field is absent' do
+      backend = new_backend
+      # Key with no _timestamp field; hget returns nil → fetch_timestamp early-returns nil.
+      @fake.hset('rspec-tracer:main:no-ts', 'last_run.json' => '{}')
+
+      expect(backend.send(:fetch_timestamp, 'rspec-tracer:main:no-ts')).to be_nil
+    end
+
+    it 'returns 0 from delete_keys on an empty key list (prune-by-duration with no stale)' do
+      backend = new_backend
+      @fake.hset('rspec-tracer:main:recent', { '_timestamp' => Time.now.to_i.to_s })
+
+      expect(backend.prune!(duration_seconds: 7 * 86_400)).to eq(0)
+    end
+
+    it 'returns 0 from prune_dead_pr_branch! when own tier has no refs (orphan branch_refs key)' do
+      pr = new_backend(branch: 'orphan', default_branch: 'main')
+      # branch_refs key exists, but no actual cache refs — list_refs filters
+      # branch_refs out so entries is empty.
+      @fake.set('rspec-tracer:pr:orphan:branch_refs', '{}')
+
+      expect(pr.prune!(pr_branch_ttl_seconds: 14 * 86_400)).to eq(0)
+    end
+
+    it 'skips DEL when delete_branch_prefix has no matching keys (orphan branch_refs)' do
+      admin = described_class.new(prefix: 'rspec-tracer', branch: 'main', default_branch: 'main',
+                                  cache_path: @cache_path, redis_client: @fake, logger: logger)
+      # An orphan branch_refs key without any backing refs — the keys list
+      # for the deletion is empty, so the bulk DEL is skipped.
+      admin.send(:delete_branch_prefix, 'orphan-branch', 0)
+
+      expect(@fake.calls[:del]).to be_empty
+      expect(logger).to have_received(:debug).with(/pruned dead PR branch/)
+    end
+
+    it 'returns 0 from maybe_prune_branch when the branch has no refs' do
+      admin = new_backend
+      # No keys at all under pr:empty
+      expect(admin.send(:maybe_prune_branch, 'empty', Time.now.to_i)).to eq(0)
+    end
+
+    it 'logs the per-key prune messages when a logger is configured (log_debug then-branch)' do
+      backend = described_class.new(
+        prefix: 'rspec-tracer', branch: 'main', default_branch: 'main',
+        cache_path: @cache_path, redis_client: @fake, logger: logger
+      )
+      @fake.hset('rspec-tracer:main:old-sha', { '_timestamp' => (Time.now.to_i - (30 * 86_400)).to_s })
+
+      backend.prune!(duration_seconds: 7 * 86_400)
+
+      expect(logger).to have_received(:debug).with(/pruned key/).at_least(:once)
+    end
+  end
 end
 # rubocop:enable RSpec/InstanceVariable, RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/remote_cache/s3_backend_spec.rb
+++ b/spec/remote_cache/s3_backend_spec.rb
@@ -856,6 +856,161 @@ RSpec.describe RSpecTracer::RemoteCache::S3Backend do
       expect(backend.unbounded_warning(warn_threshold: 3)).to match(/5 refs/)
     end
   end
+
+  describe 'private branch coverage' do
+    let(:logger) do
+      logger = instance_double(RSpecTracer::Logger)
+      allow(logger).to receive(:debug)
+      allow(logger).to receive(:warn)
+      logger
+    end
+
+    def new_backend_with_logger(**opts)
+      described_class.new(
+        bucket: 'my-bucket', prefix: 'rspec-tracer',
+        branch: 'main', default_branch: 'main',
+        cache_path: @cache_path, logger: logger, **opts
+      )
+    end
+
+    it 'pr_branch_ttl=nil on PR tier skips the dead-PR check (safe-nav else branch)' do
+      pr_backend = new_backend(branch: 'feat', default_branch: 'main')
+      allow(Open3).to receive(:capture3).and_return([JSON.generate('Contents' => []), '', status_ok])
+
+      expect(pr_backend.prune!(pr_branch_ttl_seconds: nil)).to eq(0)
+    end
+
+    it 'returns nil from read_local_run_id when last_run.json holds non-Hash JSON' do
+      File.write(File.join(@cache_path, 'last_run.json'), JSON.dump([1, 2, 3]))
+
+      expect(new_backend.send(:read_local_run_id)).to be_nil
+    end
+
+    it 'returns nil from read_local_run_id when last_run.json holds a blank run_id' do
+      File.write(File.join(@cache_path, 'last_run.json'),
+                 JSON.dump('schema_version' => current_schema, 'run_id' => ''))
+
+      expect(new_backend.send(:read_local_run_id)).to be_nil
+    end
+
+    it 'cleans up the tmp archive in try_download_from even when the path was never assigned' do
+      backend = new_backend
+      # Force the archive_path local to never get assigned by making the
+      # tmp_archive_path call raise before its return value lands.
+      allow(SecureRandom).to receive(:hex).and_raise(RuntimeError, 'rng down')
+
+      expect { backend.send(:try_download_from, 'main', 'sha1') }.to raise_error(RuntimeError)
+      # Implicit: the ensure block evaluated `defined?(archive_path) && archive_path`
+      # in :else mode (defined? returned nil), so no rm_f call was attempted on a nil path.
+    end
+
+    it 'cleans up the tmp pointer in upload_tree_pointer even when the path was never assigned' do
+      backend = new_backend
+      allow(SecureRandom).to receive(:hex).and_raise(RuntimeError, 'rng down')
+
+      expect { backend.send(:upload_tree_pointer, 'sha-ref', 'tree-sha-1') }.to raise_error(RuntimeError)
+    end
+
+    it 'list_refs_in_tier skips entries that are not the cache archive (e.g. tree pointers)' do
+      backend = new_backend
+      now = Time.now.to_i
+      contents = [
+        { 'Key' => 'rspec-tracer/main/sha1/cache.tar.gz', 'LastModified' => Time.at(now).utc.iso8601 },
+        { 'Key' => 'rspec-tracer/main/by_tree/tree-sha-1', 'LastModified' => Time.at(now).utc.iso8601 }
+      ]
+      allow(Open3).to receive(:capture3).and_return([JSON.generate('Contents' => contents), '', status_ok])
+
+      refs = backend.send(:list_refs_in_tier, 'main')
+      expect(refs.map(&:first)).to eq(['sha1'])
+    end
+
+    it 'list_refs_in_tier skips keys whose extract_ref_from_archive_key returns nil' do
+      backend = new_backend
+      now = Time.now.to_i
+      contents = [
+        # Less than 2 segments after tier_head (no ref dir): "main/cache.tar.gz" with no ref segment.
+        { 'Key' => 'rspec-tracer/main/cache.tar.gz', 'LastModified' => Time.at(now).utc.iso8601 },
+        { 'Key' => 'rspec-tracer/main/sha1/cache.tar.gz', 'LastModified' => Time.at(now).utc.iso8601 }
+      ]
+      allow(Open3).to receive(:capture3).and_return([JSON.generate('Contents' => contents), '', status_ok])
+
+      refs = backend.send(:list_refs_in_tier, 'main')
+      expect(refs.map(&:first)).to eq(['sha1'])
+    end
+
+    it 'list_refs_in_tier dedups duplicate keys to the newest LastModified' do
+      backend = new_backend
+      newer = Time.now.to_i
+      older = newer - 3600
+      contents = [
+        { 'Key' => 'rspec-tracer/main/sha1/cache.tar.gz', 'LastModified' => Time.at(newer).utc.iso8601 },
+        { 'Key' => 'rspec-tracer/main/sha1/suite-2/cache.tar.gz', 'LastModified' => Time.at(older).utc.iso8601 }
+      ]
+      allow(Open3).to receive(:capture3).and_return([JSON.generate('Contents' => contents), '', status_ok])
+
+      refs = backend.send(:list_refs_in_tier, 'main')
+      expect(refs).to eq([['sha1', newer]])
+    end
+
+    it 'extract_ref_from_archive_key returns nil for a key outside the tier head' do
+      backend = new_backend
+      result = backend.send(:extract_ref_from_archive_key, 'other-prefix/main/sha1/cache.tar.gz', 'main')
+
+      expect(result).to be_nil
+    end
+
+    it 'extract_ref_from_archive_key returns nil for a key with fewer than 2 segments after the tier head' do
+      backend = new_backend
+      result = backend.send(:extract_ref_from_archive_key, 'rspec-tracer/main/cache.tar.gz', 'main')
+
+      expect(result).to be_nil
+    end
+
+    it 'discover_pr_branches skips an empty-name branch from CommonPrefixes' do
+      backend = new_backend
+      # An entry like `rspec-tracer/pr/` (no branch suffix) decodes to
+      # an empty branch name and gets dropped.
+      common = [{ 'Prefix' => 'rspec-tracer/pr/' }, { 'Prefix' => 'rspec-tracer/pr/feat/' }]
+      allow(Open3).to receive(:capture3).and_return([JSON.generate('CommonPrefixes' => common), '', status_ok])
+
+      expect(backend.send(:discover_pr_branches)).to eq(['feat'])
+    end
+
+    it 'list_common_prefixes returns [] on an empty stdout' do
+      backend = new_backend
+      allow(Open3).to receive(:capture3).and_return(['  ', '', status_ok])
+
+      expect(backend.send(:list_common_prefixes, 'rspec-tracer/pr/')).to eq([])
+    end
+
+    it 'list_objects returns [] on an empty stdout' do
+      backend = new_backend
+      allow(Open3).to receive(:capture3).and_return(['  ', '', status_ok])
+
+      expect(backend.send(:list_objects, 'rspec-tracer/main')).to eq([])
+    end
+
+    it 'maybe_prune_branch returns 0 when the branch has no refs in S3' do
+      backend = new_backend
+      allow(Open3).to receive(:capture3).and_return([JSON.generate('Contents' => []), '', status_ok])
+
+      expect(backend.send(:maybe_prune_branch, 'empty-branch', Time.now.to_i)).to eq(0)
+    end
+
+    it 'log_debug forwards through to a configured logger (then-branch)' do
+      backend = new_backend_with_logger
+      backend.send(:log_debug, 'hello debug')
+
+      expect(logger).to have_received(:debug).with(/hello debug/)
+    end
+
+    it 'log_warn forwards through to a configured logger (then-branch)' do
+      backend = new_backend_with_logger
+      backend.send(:log_warn, 'hello warn')
+
+      expect(logger).to have_received(:warn).with(/hello warn/)
+    end
+  end
 end
 # rubocop:enable RSpec/InstanceVariable, RSpec/ExampleLength, RSpec/MultipleExpectations
 # rubocop:enable RSpec/ContextWording

--- a/spec/remote_cache/user_tasks_spec.rb
+++ b/spec/remote_cache/user_tasks_spec.rb
@@ -302,6 +302,21 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       expect(backend.opts[:local]).to be(true)
     end
 
+    it 'rejects a legacy reports_s3_path with a non-s3 scheme (returns nil → unconfigured)' do
+      config = build_config(
+        remote_cache_backend_entry: nil,
+        reports_s3_path: 'http://example.com/cache'
+      )
+      stub_ancestry
+
+      result = described_class.new(configuration: config, env: build_env).download!
+
+      expect(result).to be(false)
+      expect(captured_logs.any? do |lvl, msg|
+        lvl == :warn && msg.include?('no remote_cache_backend configured')
+      end).to be(true)
+    end
+
     it 'raises when GIT_BRANCH env is missing (caught and logged)' do
       config = build_config(remote_cache_backend_entry: backend_entry)
       stub_ancestry
@@ -396,6 +411,78 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       expect(backend.calls[:prune!]).to be_empty
     end
 
+    it 'skips prune entirely when the backend does not implement prune!' do
+      backend_class_without_prune = Class.new do
+        attr_reader :calls
+
+        def initialize(**)
+          @calls = Hash.new { |h, k| h[k] = [] }
+        end
+
+        def upload(_ref, **) = nil
+        def branch_refs(_name) = {}
+        def write_branch_refs(_name, _refs) = nil
+      end
+
+      config = build_config(
+        remote_cache_backend_entry: [backend_class_without_prune, {}],
+        cache_retention_count: 100
+      )
+      stub_ancestry(branch: 'main', default_branch: 'main')
+
+      expect do
+        described_class.new(configuration: config, env: build_env).upload!
+      end.not_to raise_error
+    end
+
+    it 'logs the pruned-refs count when prune! returns a positive integer' do
+      config = build_config(
+        remote_cache_backend_entry: backend_entry,
+        cache_retention_count: 100
+      )
+      stub_ancestry(branch: 'main', default_branch: 'main')
+      allow(fake_backend_class).to receive(:new).and_wrap_original do |original, **opts|
+        original.call(**opts).stub_prune(7)
+      end
+
+      described_class.new(configuration: config, env: build_env).upload!
+
+      expect(captured_logs.any? { |lvl, msg| lvl == :debug && msg.include?('pruned 7 refs') }).to be(true)
+    end
+
+    it 'prunes with duration_seconds knob and skips the unbounded warning on main tier' do
+      config = build_config(
+        remote_cache_backend_entry: backend_entry,
+        cache_retention_duration_seconds: 7 * 86_400
+      )
+      stub_ancestry(branch: 'main', default_branch: 'main')
+      allow(fake_backend_class).to receive(:new).and_wrap_original do |original, **opts|
+        instance = original.call(**opts)
+        def instance.unbounded_warning(**_) = 'too many refs'
+        instance
+      end
+
+      described_class.new(configuration: config, env: build_env).upload!
+
+      backend = fake_backend_class.all_instances.last
+      expect(backend.calls[:prune!].first).to include(duration_seconds: 7 * 86_400)
+      expect(captured_logs).not_to include([:warn, 'too many refs'])
+    end
+
+    it 'skips logger.warn when the backend reports no unbounded_warning (nil reply)' do
+      config = build_config(remote_cache_backend_entry: backend_entry)
+      stub_ancestry(branch: 'main', default_branch: 'main')
+      allow(fake_backend_class).to receive(:new).and_wrap_original do |original, **opts|
+        instance = original.call(**opts)
+        def instance.unbounded_warning(**_) = nil
+        instance
+      end
+
+      described_class.new(configuration: config, env: build_env).upload!
+
+      expect(captured_logs.none? { |lvl, _msg| lvl == :warn }).to be(true)
+    end
+
     it 'emits unbounded_warning when no retention is configured and the backend reports one' do
       config = build_config(remote_cache_backend_entry: backend_entry)
       stub_ancestry(branch: 'main', default_branch: 'main')
@@ -448,6 +535,28 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
     it 'returns nil when the git binary raises (StandardError rescue)' do
       allow(tasks).to receive(:`).and_raise(Errno::ENOENT, 'No such file or directory')
 
+      expect(tasks.send(:head_tree_sha)).to be_nil
+    end
+
+    it 'returns nil when $CHILD_STATUS is nil (no subprocess yet on this thread)' do
+      # `$CHILD_STATUS` is thread-local; a fresh Ruby thread that has not
+      # yet spawned a subprocess sees `$?` as nil. Combined with a stubbed
+      # backtick that bypasses the subprocess fork entirely, this exercises
+      # the safe-nav else branch in `$CHILD_STATUS&.success?`.
+      result = Thread.new do
+        allow(tasks).to receive(:`).and_return('tree-sha-output')
+        tasks.send(:head_tree_sha)
+      end.value
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil when git rev-parse succeeds but emits empty output' do
+      allow(tasks).to receive(:`).and_return("\n")
+
+      # A successful subprocess elsewhere in this thread set `$?` to a
+      # success status; chomp("\n") -> "" -> output.empty? branch fires.
+      `true`
       expect(tasks.send(:head_tree_sha)).to be_nil
     end
   end

--- a/spec/reporters/coverage_json_reporter_spec.rb
+++ b/spec/reporters/coverage_json_reporter_spec.rb
@@ -150,6 +150,23 @@ RSpec.describe RSpecTracer::Reporters::CoverageJsonReporter do
       expect(payload['RSpecTracer']['coverage'].keys).to eq([tracked_file])
     end
 
+    it 'leaves an out-of-root file path untouched when filtering (file_name_for early-return)' do
+      # Paths outside RSpecTracer.root (e.g. an absolute gem path
+      # surfacing through Coverage.peek_result) skip the prefix-strip.
+      # The filter-match should see the path verbatim.
+      external_file = '/opt/gems/foreign/lib/foo.rb'
+      allow(adapter).to receive(:peek_unfiltered).and_return(
+        tracked_file => [1, 1], external_file => [1]
+      )
+      filter = RSpecTracer::Filter.register(%r{\A/opt/gems/})
+      allow(RSpecTracer).to receive(:coverage_filters).and_return([filter])
+
+      build_reporter.generate
+
+      payload = JSON.parse(File.read(File.join(coverage_dir, 'coverage.json'), encoding: 'UTF-8'))
+      expect(payload['RSpecTracer']['coverage'].keys).to eq([tracked_file])
+    end
+
     it 'logs covered/total LOC + percent through the provided logger' do
       allow(adapter).to receive(:peek_unfiltered).and_return(tracked_file => [1, nil])
       logger = instance_double(RSpecTracer::Logger, info: nil)

--- a/spec/reporters/registry_spec.rb
+++ b/spec/reporters/registry_spec.rb
@@ -117,6 +117,17 @@ RSpec.describe RSpecTracer::Reporters::Registry do
 
       expect(result).to eq([])
     end
+
+    it 'returns [] without inspecting snapshot when entries resolve empty (defensive guard)' do
+      stub_const('RSpecTracer::Reporters::Registry::DEFAULTS', [].freeze)
+      config = fake_config(reporters: nil)
+
+      result = described_class.new(configuration: config).emit_all(
+        snapshot: snapshot, report_dir: report_dir, run_metadata: run_metadata
+      )
+
+      expect(result).to eq([])
+    end
   end
 
   describe 'explicit reporter resolution' do

--- a/spec/reporters/terminal_reporter_spec.rb
+++ b/spec/reporters/terminal_reporter_spec.rb
@@ -259,6 +259,44 @@ RSpec.describe RSpecTracer::Reporters::TerminalReporter do
 
       expect(size_reporter.send(:cache_size_suffix, cache_root)).to eq('')
     end
+
+    it 'returns empty suffix when the snapshot run_id is nil' do
+      blank_id_reporter = described_class.new(
+        snapshot: build_populated_snapshot(run_id: nil), report_dir: report_dir,
+        run_metadata: metadata_with_cache, logger: nil, io: io
+      )
+
+      expect(blank_id_reporter.send(:cache_size_suffix, cache_root)).to eq('')
+    end
+
+    it 'returns empty suffix when the snapshot run_id is an empty string' do
+      blank_id_reporter = described_class.new(
+        snapshot: build_populated_snapshot(run_id: ''), report_dir: report_dir,
+        run_metadata: metadata_with_cache, logger: nil, io: io
+      )
+
+      expect(blank_id_reporter.send(:cache_size_suffix, cache_root)).to eq('')
+    end
+
+    it 'omits the sign character when delta is zero (no growth or shrink)' do
+      File.utime(Time.now - 60, Time.now - 60, write_run_dir('rid-prev', 2048))
+      write_run_dir('rid', 2048)
+      size_reporter.generate
+
+      # delta == 0 hits the inner ternary's else branch, so the sign char
+      # is empty: "(<size>; 0 B vs prev run)".
+      expect(cache_line_in_output).to match(/\(2\.0 KiB; 0 B vs prev run\)/)
+    end
+
+    it 'sums only file entries when the run dir contains nested subdirectories' do
+      run_dir = write_run_dir('rid', 4096)
+      # Adding an empty subdir surfaces a Dir glob entry that fails File.file?
+      # — exercises directory_size_bytes' :else branch (skip-with-zero).
+      FileUtils.mkdir_p(File.join(run_dir, 'nested'))
+      size_reporter.generate
+
+      expect(cache_line_in_output).to include('4.0 KiB')
+    end
   end
 
   describe 'color policy' do

--- a/spec/rspec/parallel_tests_spec.rb
+++ b/spec/rspec/parallel_tests_spec.rb
@@ -458,6 +458,19 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(described_class.finalize!).to be(false)
       expect(logger).to have_received(:warn).with(/parallel_tests finalize failed/)
     end
+
+    it 'skips ParallelTests.wait_for_other_processes_to_finish when the gem constant is not defined' do
+      # last_process? itself short-circuits on `defined?(::ParallelTests)`
+      # before line 148 is reached, so stub it to true to isolate the
+      # line 148 defensive guard branch.
+      allow(described_class).to receive(:last_process?).and_return(true)
+      hide_const('ParallelTests')
+
+      expect(described_class.finalize!).to be(true)
+      # Both barriers (gem-internal pid wait + our peer-done filesystem
+      # check) are independent; the .done-marker barrier still runs.
+      expect(described_class).to have_received(:wait_for_peer_done_markers!)
+    end
   end
 
   describe '.emit_merged_reporters! (M8.10)' do
@@ -560,6 +573,15 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
 
       expect(logger).not_to have_received(:debug)
     end
+
+    it 'is a no-op when storage_backend is not :json (sqlite has no JSON merge surface)' do
+      allow(RSpecTracer).to receive(:storage_backend).and_return(:sqlite)
+      allow(RSpecTracer::Storage::JsonBackend).to receive(:new)
+
+      described_class.merge_snapshot!
+
+      expect(RSpecTracer::Storage::JsonBackend).not_to have_received(:new)
+    end
   end
 
   describe '.merge_coverage!' do
@@ -592,6 +614,18 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
         logger: logger
       )
       expect(logger).to have_received(:debug).with(/merged parallel tests coverage/)
+    end
+
+    it 'suppresses the debug rollup line when log_rollups? is false (non-narrator quiet path)' do
+      allow(RSpecTracer::Reporters::CoverageJsonReporter).to receive(:merge_parallel)
+      allow(described_class).to receive(:log_rollups?).and_return(false)
+      logger = spy('Logger')
+      allow(RSpecTracer).to receive(:logger).and_return(logger)
+
+      described_class.merge_coverage!
+
+      expect(RSpecTracer::Reporters::CoverageJsonReporter).to have_received(:merge_parallel)
+      expect(logger).not_to have_received(:debug)
     end
   end
 

--- a/spec/support/tracker_coverage_gate.rb
+++ b/spec/support/tracker_coverage_gate.rb
@@ -73,25 +73,8 @@ module TrackerCoverageGate
     end
   end
 
-  # Branch enforcement is opt-in via `RSPEC_TRACER_TRACKER_BRANCH_GATE=1`.
-  # Reason: the gate was historically a silent no-op for branches because
-  # `Reporters::CoverageJsonReporter::SimpleCovInterop` hijacked
-  # `Coverage.result` and stripped the `:branches` sub-hash before SimpleCov
-  # received it (see CoverageAdapter#peek_unfiltered, which reduces hash-mode
-  # entries to `:lines` only by design — the user-facing `coverage.json`
-  # contract is `Array<Integer|nil>` per file). `branch_percent` returned
-  # 100.0 on nil branches, so `branch_ok` was vacuously true. Once
-  # `peek_unfiltered_full` started preserving branches into the interop, the
-  # gate began surfacing real test debt across the gated subdirectories
-  # (~85–96% branch coverage on ~12 tracker / reporter / rspec / rails /
-  # remote_cache files) that was never the gate's responsibility while it
-  # was a no-op. The opt-in flag preserves the prior effective behaviour
-  # as the default; the test gaps are tracked for a focused follow-up
-  # session that closes them all + flips the default.
   def self.full_coverage?(file)
     line_ok = file.covered_percent >= (100.0 - EPSILON)
-    return line_ok unless ENV['RSPEC_TRACER_TRACKER_BRANCH_GATE'] == '1'
-
     branch_ok = branch_percent(file) >= (100.0 - EPSILON)
     line_ok && branch_ok
   end

--- a/spec/tracker/io_hooks/file_spec.rb
+++ b/spec/tracker/io_hooks/file_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe RSpecTracer::Tracker::IOHooks::FileReads do
 
       expect(bucket).to have_key('data:fixture.yml')
     end
+
+    it 'forwards to super without recording when no bucket is active' do
+      # Outer rspec-tracer ReporterHook may have installed a bucket on
+      # this example; clear it explicitly so the readlines hot-path
+      # else-branch (Thread.current[BUCKET_KEY] == nil) actually fires.
+      RSpecTracer::Tracker::IOHooks.clear_bucket
+
+      expect(File.readlines(fixture)).to eq(["a: 1\n"])
+    end
   end
 
   describe '#open' do

--- a/spec/tracker/io_hooks/json_spec.rb
+++ b/spec/tracker/io_hooks/json_spec.rb
@@ -38,5 +38,11 @@ RSpec.describe RSpecTracer::Tracker::IOHooks::JSONReads do
     it 'returns the parsed JSON via super' do
       expect(parsed).to eq('a' => 1)
     end
+
+    it 'forwards to super without recording when no bucket is active' do
+      RSpecTracer::Tracker::IOHooks.clear_bucket
+
+      expect(JSON.load_file(fixture)).to eq('a' => 1)
+    end
   end
 end

--- a/spec/tracker/io_hooks/yaml_spec.rb
+++ b/spec/tracker/io_hooks/yaml_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe RSpecTracer::Tracker::IOHooks::YAMLReads do
     it 'returns the parsed YAML via super' do
       expect(parsed).to eq('a' => 1, 'b' => 2)
     end
+
+    it 'forwards to super without recording when no bucket is active' do
+      RSpecTracer::Tracker::IOHooks.clear_bucket
+
+      expect(YAML.load_file(fixture)).to eq('a' => 1, 'b' => 2)
+    end
   end
 
   describe '#safe_load_file' do
@@ -46,6 +52,12 @@ RSpec.describe RSpecTracer::Tracker::IOHooks::YAMLReads do
 
       expect(bucket).to have_key('data:config.yml')
     end
+
+    it 'forwards to super without recording when no bucket is active' do
+      RSpecTracer::Tracker::IOHooks.clear_bucket
+
+      expect(YAML.safe_load_file(fixture)).to eq('a' => 1, 'b' => 2)
+    end
   end
 
   describe '#unsafe_load_file' do
@@ -53,6 +65,12 @@ RSpec.describe RSpecTracer::Tracker::IOHooks::YAMLReads do
       RSpecTracer::Tracker::IOHooks.with_bucket(bucket) { YAML.unsafe_load_file(fixture) }
 
       expect(bucket).to have_key('data:config.yml')
+    end
+
+    it 'forwards to super without recording when no bucket is active' do
+      RSpecTracer::Tracker::IOHooks.clear_bucket
+
+      expect(YAML.unsafe_load_file(fixture)).to eq('a' => 1, 'b' => 2)
     end
   end
 end

--- a/spec/tracker/io_hooks_spec.rb
+++ b/spec/tracker/io_hooks_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe RSpecTracer::Tracker::IOHooks do
     path
   end
 
+  # An Object that explicitly reports it cannot stringify — exercises
+  # `_record`'s `path.is_a?(String) || path.respond_to?(:to_s)` guard's
+  # then-branch (early-return because both checks fail).
+  def build_not_stringable
+    Object.new.tap do |obj|
+      obj.define_singleton_method(:respond_to?) { |method, *| method != :to_s }
+    end
+  end
+
   describe '.install' do
     it 'marks the coordinator installed' do
       expect(described_class.installed?).to be(true)
@@ -208,7 +217,20 @@ RSpec.describe RSpecTracer::Tracker::IOHooks do
     end
 
     it 'is a no-op when no bucket is set' do
+      # The outer rspec-tracer ReporterHook installs a bucket on every
+      # example; clear it explicitly so _record's `bucket.nil?` guard
+      # actually fires (the early-return :then branch).
+      described_class.clear_bucket
+
       expect { described_class.record(write_fixture('a.yml')) }.not_to raise_error
+    end
+
+    it 'is a no-op when path is neither a String nor responds to to_s' do
+      bucket = {}
+      not_stringable = build_not_stringable
+      described_class.with_bucket(bucket) { described_class.record(not_stringable) }
+
+      expect(bucket).to be_empty
     end
 
     it 'is a no-op for paths outside root' do


### PR DESCRIPTION
## Summary

- Closes the ~70 uncovered branches that the tracker coverage gate flagged after [#165](https://github.com/avmnu-sng/rspec-tracer/pull/165) made real branch data flow through `SimpleCov`. Adds 700+ LOC of focused tests across 12 spec files, no lib code touched.
- Flips the gate from opt-in (`RSPEC_TRACER_TRACKER_BRANCH_GATE=1`) to default-on. `spec/support/tracker_coverage_gate.rb`'s `full_coverage?` is now a plain `line_ok && branch_ok` conjunction; the env-knob early-return + explanatory comment are gone.
- Codecov branch coverage on `main` should climb ~10 percentage points after this lands.

## Branches closed (per file)

| File | branch (before) | tests added |
|------|----------------:|------------:|
| `rails/notifications.rb` | 97.37% | 1 |
| `remote_cache/archive.rb` | 96.15% | 5 |
| `remote_cache/git_ancestry.rb` | 80.43% | 6 |
| `remote_cache/local_fs_backend.rb` | 89.74% | 9 |
| `remote_cache/redis_backend.rb` | 89.69% | 10 |
| `remote_cache/s3_backend.rb` | 87.79% | 14 |
| `remote_cache/user_tasks.rb` | 85.71% | 7 |
| `reporters/coverage_json_reporter.rb` | 97.30% | 1 |
| `reporters/registry.rb` | 92.86% | 1 |
| `reporters/terminal_reporter.rb` | 93.48% | 5 |
| `rspec/parallel_tests.rb` | 92.50% | 3 |
| `tracker/io_hooks*.rb` | 90.00% | 6 |

All 12 files now at 100% line + 100% branch. Most missing branches were graceful-degradation paths (filesystem rescues, malformed JSON, nil safe-nav, defensive guards) — high-percentage files where the missed surface was concentrated on the rescue contract.

## Notable test patterns

- `Thread.new { ... }.value` to exercise `$CHILD_STATUS&.success?` else-branches (`$?` is thread-local and nil on a fresh thread that hasn't spawned a subprocess).
- `system('false')` inside a stubbed backtick to reach the rev-parse failure path in `GitAncestry#merged_parents`, whose production precondition `merge_commit?` already gates on rev-parse succeeding.
- `stub_const('Reporters::Registry::DEFAULTS', [].freeze)` to exercise the structurally-unreachable `entries.empty?` defensive guard.
- `IOHooks.clear_bucket` before invoking hooked methods so the no-bucket fast-reject branches actually fire (the outer ReporterHook installs a bucket on every example).
- `SecureRandom.hex` raise-stub to verify `try_download_from` / `upload_tree_pointer` ensure-blocks evaluate `defined?(local_var)` correctly when the tmp-path assignment was preempted.

## Test plan

- [x] `task check` — lint:ruby + test:unit + benchmark:smoke clean
- [x] `task lint:ruby` / `task lint:actions` / `task lint:yaml`
- [x] `task check:bundle`
- [x] `task security:bundle-audit` (clean) / `task security:trivy` (only pre-existing rexml advisory in vendored `lint_roller`'s lockfile, unchanged from main)
- [x] `task test:unit` (1887 examples, 0 failures, gate clean by default)
- [x] `task test:property`
- [x] `task test:mutation:smoke` (Tracker::EnvMatcher 93.18% ≥ 90%)
- [x] `task test:dogfood`
- [x] `task benchmark:smoke` (cold_ruby 0.302s p50, warm_noop 0.287s p50)

🤖 Generated with [Claude Code](https://claude.com/claude-code)