### PR TITLE
chore: scrub internal milestone references from lib comments

### DIFF
--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -16,7 +16,7 @@ require_relative 'rspec_tracer/example'
 # Reporters must load before load_config so the Configuration DSL's
 # `add_reporter` can validate symbol names against
 # `Reporters::Registry::BUILT_INS` when a user `.rspec-tracer` calls
-# it at configure time (M6.1).
+# it at configure time.
 require_relative 'rspec_tracer/reporters/base'
 require_relative 'rspec_tracer/reporters/payload_builder'
 require_relative 'rspec_tracer/reporters/coverage_json_reporter'
@@ -36,7 +36,7 @@ require_relative 'rspec_tracer/source_file'
 require_relative 'rspec_tracer/time_formatter'
 require_relative 'rspec_tracer/version'
 
-# Top-level entry point. Drives the M5.1 lifecycle:
+# Top-level entry point. Drives the lifecycle:
 #
 #   RSpecTracer.start
 #     -> RSpec::Installation.install!  (prepend RunnerHook + ReporterHook)
@@ -48,7 +48,7 @@ require_relative 'rspec_tracer/version'
 #   flow) runs the finalize stack: Engine#finalize writes the 13-file
 #   snapshot via Storage::JsonBackend, Reporters::CoverageJsonReporter
 #   writes coverage.json (single owner, replacing the 1.x
-#   CoverageReporter + CoverageWriter pair retired in M8.0),
+#   CoverageReporter + CoverageWriter pair retired in 2.0),
 #   ParallelTests#finalize! merges per-worker caches on the last worker.
 module RSpecTracer
   class << self
@@ -87,7 +87,7 @@ module RSpecTracer
       initial_setup
     end
 
-    # M8.9: SimpleCov load-order is part of the documented contract -
+    # SimpleCov load-order is part of the documented contract -
     # SimpleCov.start MUST run before RSpecTracer.start when both are
     # used together (see README §SimpleCov interop). When the user
     # has SimpleCov loaded but not started, we'd silently call
@@ -199,15 +199,14 @@ module RSpecTracer
         RSpecTracer.logger.info 'Skipped reports generation since all examples were filtered out'
       else
         snapshot = run_finalize
-        # M8.10: under parallel_tests, defer reporter emission until
+        # Under parallel_tests, defer reporter emission until
         # last-process finalize merges per-worker snapshots into the
         # top-level cache. Each worker still persists its per-worker
-        # snapshot for the merge to consume. Pre-M8.10 every worker
-        # emitted reporters into rspec_tracer_report/parallel_tests_N/
+        # snapshot for the merge to consume. Earlier behavior had every
+        # worker emit reporters into rspec_tracer_report/parallel_tests_N/
         # and purge_worker_dirs! removed those dirs - leaving the user
         # with no usable terminal/JSON/HTML output. Now reporters fire
-        # ONCE at the merged top-level location (3x v1 orphan: M6.2 +
-        # M7.1 + M7.2).
+        # ONCE at the merged top-level location.
         emit_reporters(snapshot) if snapshot && !parallel_tests?
       end
 
@@ -218,7 +217,7 @@ module RSpecTracer
 
     # Engine-owned finalize path. Writes the 15-file JSON cache via
     # Storage::JsonBackend. Per-example coverage deltas live on the
-    # Engine; M8.0 retired the CoverageReporter mid-flow piece (the
+    # Engine; 2.0 retired the CoverageReporter mid-flow piece (the
     # legacy `coverage_reporter.generate_final_examples_coverage +
     # merge_coverage(engine.merge_skipped_coverage(...))` is now folded
     # into Reporters::CoverageJsonReporter#generate, which fires from
@@ -248,7 +247,7 @@ module RSpecTracer
       nil
     end
 
-    # M6.1. Fire the configured reporters against the persisted
+    # Fire the configured reporters against the persisted
     # Snapshot. Fires per-worker under parallel_tests (same cadence as
     # coverage.json emission); each worker produces its own report.json
     # under its per-worker report_dir. The Registry rescues every
@@ -285,7 +284,7 @@ module RSpecTracer
       (::Process.clock_gettime(::Process::CLOCK_MONOTONIC) - @run_monotonic_start).round(4)
     end
 
-    # M8.0: dedicated coverage.json firing path, parallel to the
+    # Dedicated coverage.json firing path, parallel to the
     # report-reporters Registry pipeline. Fires unconditionally - even
     # when no examples ran (matches 1.x where coverage.json gets
     # written with whatever boot-time peek_result returned + filter +

--- a/lib/rspec_tracer/cli/doctor.rb
+++ b/lib/rspec_tracer/cli/doctor.rb
@@ -105,7 +105,7 @@ module RSpecTracer
         end
       end
 
-      # M8.9: surface a 1.x->2.0 cache mismatch BEFORE the user runs
+      # Surface a 1.x->2.0 cache mismatch BEFORE the user runs
       # rspec and watches everything re-run mysteriously. Reads the
       # cached `last_run.json` (if any) and compares its
       # `schema_version` against the gem's `Schema::CURRENT`. Three
@@ -135,7 +135,7 @@ module RSpecTracer
         "WARN schema:      could not read cache manifest: #{e.class}: #{e.message}"
       end
 
-      # M8.9: when remote_cache is configured, verify the backend is
+      # When remote_cache is configured, verify the backend is
       # reachable from doctor's vantage point so the user catches
       # misconfig (typo'd S3 path / unreachable Redis URL / unwritable
       # local-fs dir) BEFORE the next CI run fails. Best-effort: never
@@ -188,15 +188,15 @@ module RSpecTracer
           '(reachability not probed locally; verified end-to-end on next CI run)'
       end
 
-      # M8.9: surface the M8.2-B / M9.0 / M9.1 narrow-attribution
-      # precondition at diagnostic time. When `track_ar_schema_notifications`
-      # is enabled AND Rails is loaded AND the rspec-rails default
-      # `use_transactional_fixtures = true` is in effect, per-example
-      # BEGIN/COMMIT fires `sql.active_record` inside the rspec-tracer
-      # bucket and attribution silently widens. Same shape as the
-      # boot-time warn shipped with M9.1 (RSpecTracer.start), surfaced
-      # here so users running `rspec-tracer doctor` see the issue
-      # without having to boot a full rspec run first.
+      # Surface the narrow-attribution precondition at diagnostic time.
+      # When `track_ar_schema_notifications` is enabled AND Rails is
+      # loaded AND the rspec-rails default `use_transactional_fixtures
+      # = true` is in effect, per-example BEGIN/COMMIT fires
+      # `sql.active_record` inside the rspec-tracer bucket and
+      # attribution silently widens. Same shape as the boot-time warn
+      # in RSpecTracer.start, surfaced here so users running
+      # `rspec-tracer doctor` see the issue without having to boot a
+      # full rspec run first.
       def self.ar_schema_narrow_attribution_check
         return 'INFO AR schema:   track_ar_schema_notifications not enabled' unless ar_schema_enabled?
         return 'INFO AR schema:   Rails not loaded' unless rails_loaded?

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -107,9 +107,9 @@ module RSpecTracer
 
           # Forward `**kwargs` too so DSL methods can accept Ruby 3+
           # keyword args (e.g. `track_rails_defaults except: [:views]`,
-          # M3.8's `storage_backend :json, serializer: :msgpack`).
-          # Before M4.1 this wrapper forwarded `*args, &block` only and
-          # silently stripped kwargs; see M3.4 handoff notes.
+          # `storage_backend :json, serializer: :msgpack`). Earlier
+          # forms of this wrapper forwarded `*args, &block` only and
+          # silently stripped kwargs.
           define_method method_name do |*args, **kwargs, &block|
             send(:"_#{method_name}", *args, **kwargs, &block)
           end
@@ -604,7 +604,7 @@ module RSpecTracer
                             end
     end
 
-    # M3.7 transitive-load attribution (closes the constants blind
+    # Transitive-load attribution (closes the constants blind
     # spot). Default `true` - the tracker observes files loaded during
     # the process and attributes them as transitive deps of every
     # subsequent example, so a change to a constants-defining file
@@ -629,7 +629,7 @@ module RSpecTracer
                                   end
     end
 
-    # M4.2 opt-in for narrow schema attribution. Default `false` - the
+    # Opt-in for narrow schema attribution. Default `false` - the
     # Preset `:schema` category already declared-glob-tracks db/schema.rb
     # + db/structure.sql as a safe over-approximation (any schema change
     # re-runs every example). Calling this method opts in to an
@@ -797,14 +797,14 @@ module RSpecTracer
       track_files(*globs)
     end
 
-    # One-way latch. Tracker.setup (M3.6) flips it so a stray
+    # One-way latch. Tracker.setup flips it so a stray
     # `track_files` later in the boot sequence raises instead of
     # silently accumulating into state that has already been read.
     def freeze_declared_globs!
       @declared_globs_frozen = true
     end
 
-    # M5.3 config-level env-tracking DSL. Accumulates names across
+    # Config-level env-tracking DSL. Accumulates names across
     # calls; bare entries flow into `Engine#setup`, are wildcard-
     # expanded via `Tracker::EnvMatcher`, and attach to every
     # previously-seen example (parallel to `track_files`'s "declared
@@ -856,7 +856,7 @@ module RSpecTracer
     EMPTY_TRACKED_ENV_NAMES = [].freeze
     private_constant :EMPTY_TRACKED_ENV_NAMES
 
-    # M5.1 per-spec-file exclusion (closes upstream #41). Accumulates
+    # Per-spec-file exclusion (closes upstream #41). Accumulates
     # glob patterns that match test files rspec-tracer should leave
     # alone: matching examples pass through RSpec unchanged, but the
     # tracer does not compute an identity hash, does not run
@@ -910,7 +910,7 @@ module RSpecTracer
       file_path[(@root.length + 1)..]
     end
 
-    # M3.8 local-cache run-id retention. Default 5 keeps enough
+    # Local-cache run-id retention. Default 5 keeps enough
     # history for rollback debugging without letting the cache grow
     # unbounded on long-lived machines (issue #20). 0 opts out (1.x
     # behavior - dirs accumulate forever). ENV
@@ -945,7 +945,7 @@ module RSpecTracer
     end
     # rubocop:enable Metrics/PerceivedComplexity
 
-    # M3.8 size budgets. Both return non-negative Integer MiB.
+    # Size budgets. Both return non-negative Integer MiB.
     # Shape identical to cache_retention_local_count:
     # defined-and-nil-arg returns memo, ENV wins, then DSL arg, then
     # module default. 0 disables the respective check.
@@ -1000,8 +1000,8 @@ module RSpecTracer
     end
     # rubocop:enable Metrics/PerceivedComplexity
 
-    # M3.4 storage backend selector, extended in M3.8 to accept a
-    # kwarg opts hash. Symbol form: `storage_backend :json` or
+    # Storage backend selector with optional kwarg opts hash.
+    # Symbol form: `storage_backend :json` or
     # `storage_backend :sqlite`. ENV `RSPEC_TRACER_STORAGE` wins over
     # the DSL argument, matching the `cache_dir` / `coverage_dir`
     # precedence convention so CI can swap backends without editing
@@ -1089,7 +1089,7 @@ module RSpecTracer
       { serializer: serializer }
     end
 
-    # M6.1 reporter DSL. Accumulates each call onto an internal list of
+    # Reporter DSL. Accumulates each call onto an internal list of
     # `[name_or_class, opts]` pairs that `Reporters::Registry` walks
     # at finalize-time. Matches the `track_files` accumulator shape.
     #
@@ -1099,7 +1099,7 @@ module RSpecTracer
     #   add_reporter MyCustomReporter, color: false
     #
     # Symbol names must match `Reporters::Registry::BUILT_INS.keys`
-    # (`:terminal`, `:json`; M6.2 adds `:html`). Class values are
+    # (`:terminal`, `:json`, `:html`). Class values are
     # trusted - they must subclass / duck-type `Reporters::Base` but
     # validation is deferred to initialize-time so custom reporters
     # defined in user code don't have to exist at DSL-validate time.

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -58,9 +58,9 @@ module RSpecTracer
   # Cache parity: `finalize` builds a Snapshot with file-name-keyed
   # dependency / reverse_dependency / all_files maps (matching the
   # 1.x on-disk convention - root-stripped file names with a leading
-  # "/") and hands it to Storage::JsonBackend. The schema bump to 3
-  # from M3.7 adds `boot_set`; everything else mirrors the 1.x
-  # cache layout byte-for-byte.
+  # "/") and hands it to Storage::JsonBackend. The 2.0 schema bump
+  # adds `boot_set`; everything else mirrors the 1.x cache layout
+  # byte-for-byte.
   # rubocop:disable Metrics/ClassLength
   class Engine
     EXAMPLE_RUN_REASON = {
@@ -104,7 +104,7 @@ module RSpecTracer
       @tracks_files = Hash.new { |h, id| h[id] = Set.new } # id => Set<abs_path>
       @tracks_env = Hash.new { |h, id| h[id] = Set.new }   # id => Set<env_name>
       @tracked_env_names = Set.new
-      @config_tracked_env_names = Set.new # M5.3 config-level subset (post-expansion)
+      @config_tracked_env_names = Set.new # config-level subset (post-expansion)
       @previous_snapshot = nil
       @run_id = nil
       @before_peek = nil
@@ -152,8 +152,8 @@ module RSpecTracer
       self
     end
 
-    # M5.2 per-example tracking DSL hook. Called from RunnerHook with
-    # the normalized `{files: Set<String>, env: Set<String>}` that
+    # Per-example tracking DSL hook. Called from RunnerHook with the
+    # normalized `{files: Set<String>, env: Set<String>}` that
     # `RSpec::Metadata.tracks_for(example)` produced. Resolves the
     # file globs against the project root once per distinct glob
     # string (memoized) and unions the matching Inputs into this
@@ -161,11 +161,11 @@ module RSpecTracer
     # `@tracked_env_names` so the finalize snapshot covers every key
     # the run cared about.
     #
-    # M5.3: per-example env entries may carry wildcard patterns
-    # (`tracks: { env: 'RAILS_*' }`). `EnvMatcher.expand` is the
-    # single funnel - literals pass through, wildcards expand against
-    # the live ENV, and unsupported syntax raises ArgumentError at
-    # this point (RunnerHook Pass 1, before any example body runs).
+    # Per-example env entries may carry wildcard patterns (`tracks:
+    # { env: 'RAILS_*' }`). `EnvMatcher.expand` is the single funnel
+    # - literals pass through, wildcards expand against the live ENV,
+    # and unsupported syntax raises ArgumentError at this point
+    # (RunnerHook Pass 1, before any example body runs).
     # rubocop:disable Metrics/PerceivedComplexity
     def register_tracks(example_id, tracks)
       files = tracks[:files] || tracks['files'] || Set.new
@@ -181,18 +181,17 @@ module RSpecTracer
     end
     # rubocop:enable Metrics/PerceivedComplexity
 
-    # M5.2 / M5.3. Called from RunnerHook AFTER the filter-decision
-    # pre-walk has populated `@tracks_env` / `@tracked_env_names` for
-    # every example. Compares each declared env key against the
-    # previous snapshot's `env_snapshot` via Tracker::EnvSnapshot;
-    # marks any example whose tracked-env set intersects the
-    # invalidated set as re-runnable. Strictly additive vs other
-    # filter reasons - if the example was already in
-    # `@filtered_examples` for a stronger reason (files_changed /
-    # whole_suite_invalidator / failed_example / ...), env_changed
-    # does NOT overwrite.
+    # Called from RunnerHook AFTER the filter-decision pre-walk has
+    # populated `@tracks_env` / `@tracked_env_names` for every
+    # example. Compares each declared env key against the previous
+    # snapshot's `env_snapshot` via Tracker::EnvSnapshot; marks any
+    # example whose tracked-env set intersects the invalidated set
+    # as re-runnable. Strictly additive vs other filter reasons - if
+    # the example was already in `@filtered_examples` for a stronger
+    # reason (files_changed / whole_suite_invalidator /
+    # failed_example / ...), env_changed does NOT overwrite.
     #
-    # M5.3 config-level path: when an invalidated key intersects
+    # Config-level path: when an invalidated key intersects
     # `@config_tracked_env_names` (the post-expansion config-level
     # set), every previously-seen example re-runs - mirrors the
     # `track_files` "declared globs attach to every example"
@@ -338,7 +337,7 @@ module RSpecTracer
 
     private
 
-    # M5.3. Read the config-level `track_env(*names)` accumulator,
+    # Read the config-level `track_env(*names)` accumulator,
     # expand any wildcard patterns against the live ENV via
     # EnvMatcher.expand (which raises ArgumentError on unsupported
     # syntax - intentionally surfaces config errors at run start),
@@ -355,7 +354,7 @@ module RSpecTracer
       @tracked_env_names.merge(expanded)
     end
 
-    # M5.3. Mark every previously-seen example for re-run. Called
+    # Mark every previously-seen example for re-run. Called
     # when a config-level env key flips between runs.
     def mark_all_prev_examples(reason)
       @previous_snapshot.all_examples.each_key do |example_id|
@@ -365,7 +364,7 @@ module RSpecTracer
       end
     end
 
-    # M5.2 / M5.3 per-example env-changed mark. Walks @tracks_env,
+    # Per-example env-changed mark. Walks @tracks_env,
     # marks examples whose declared env set intersects invalidated.
     # Additive vs other filter reasons (won't overwrite).
     def mark_per_example_intersections(invalidated, reason)
@@ -883,9 +882,9 @@ module RSpecTracer
       @env_snapshot.digest_snapshot(@tracked_env_names)
     end
 
-    # M6.1. Project the per-example `@tracks_env` map (Set<env_name>
-    # per example_id) into a JSON-friendly Hash[id => sorted Array]
-    # for persistence. Reporters consume this to render the env-
+    # Project the per-example `@tracks_env` map (Set<env_name> per
+    # example_id) into a JSON-friendly Hash[id => sorted Array] for
+    # persistence. Reporters consume this to render the env-
     # dependency view on the Examples Dependency report. Empty sets
     # drop out so the on-disk map stays narrow. Sort keeps the output
     # deterministic for downstream diffs and golden tests.

--- a/lib/rspec_tracer/rails/README.md
+++ b/lib/rspec_tracer/rails/README.md
@@ -66,14 +66,13 @@ Leaving `:schema` in `track_rails_defaults` while also enabling the
 subscriber is a no-op in terms of the re-run set - declared-glob
 dominates at graph registration.
 
-## Phase 4 scope split
+## Components
 
-- **M4.1**: preset + detection + Railtie scaffold.
-- **M4.2** (this file, shipped): Notifications + I18nTracking
-  observers, `track_ar_schema_notifications` opt-in DSL, and
-  Engine.setup wiring. Factory and fixture coverage ride the existing
-  LoadedFilesTracker / YAML.load_file hook surface; regression specs
-  verify both mechanically.
-- **M4.3**: integration test against the reference Rails app
-  (`spec/fixtures/rails_app/`) covering the full "change X -> Y re-runs"
-  behavior matrix.
+- **Preset + detection + Railtie scaffold.**
+- **Notifications + I18nTracking observers**, the
+  `track_ar_schema_notifications` opt-in DSL, and `Engine.setup`
+  wiring. Factory and fixture coverage ride the existing
+  `LoadedFilesTracker` / `YAML.load_file` hook surface.
+- **Integration coverage** against the reference Rails app
+  (`spec/fixtures/rails_app/`) verifying the full "change X -> Y
+  re-runs" behavior matrix.

--- a/lib/rspec_tracer/rails/i18n_tracking.rb
+++ b/lib/rspec_tracer/rails/i18n_tracking.rb
@@ -8,7 +8,7 @@ module RSpecTracer
   module Rails
     # I18n backend observer. Covers custom backends (Redis-backed,
     # DB-backed, Chain) that bypass YAML.load_file and would otherwise
-    # miss the M3.2 IOHooks YAML hook.
+    # miss the IOHooks YAML hook.
     #
     # Mechanism: Module#prepend onto ::I18n::Backend::Base - every
     # backend subclass's load_translations resolves through the hook,

--- a/lib/rspec_tracer/rails/railtie.rb
+++ b/lib/rspec_tracer/rails/railtie.rb
@@ -6,10 +6,11 @@ module RSpecTracer
     # when `defined?(::Rails::Railtie)` is true, so loading this file in
     # a non-Rails process is not expected and will raise NameError.
     #
-    # M4.1 scope: define the Railtie class + register one initializer
-    # that logs a single confirmation line. M4.2 fills in
-    # ActiveSupport::Notifications subscribers for ActionView template
-    # renders, I18n lookups, and schema/factory/fixture tracking.
+    # Defines the Railtie class + registers one initializer that logs
+    # a single confirmation line. The actual ActiveSupport::Notifications
+    # subscribers for ActionView template renders, I18n lookups, and
+    # schema/factory/fixture tracking live in `notifications.rb` and
+    # `i18n_tracking.rb` and are wired by `Engine.setup`.
     class Railtie < ::Rails::Railtie
       initializer 'rspec_tracer.setup' do
         RSpecTracer.logger.info 'rspec-tracer Rails integration loaded'

--- a/lib/rspec_tracer/remote_cache/Rakefile
+++ b/lib/rspec_tracer/remote_cache/Rakefile
@@ -9,8 +9,8 @@
 #
 # This file must remain at the same path and continue to define the
 # same two tasks. The `require 'rspec_tracer'` + `require
-# 'rspec_tracer/remote_cache'` pair lazy-loads the M7.1 backend tree
-# only when the user actually invokes a cache task.
+# 'rspec_tracer/remote_cache'` pair lazy-loads the backend tree only
+# when the user actually invokes a cache task.
 
 require 'rspec_tracer'
 require 'rspec_tracer/remote_cache'

--- a/lib/rspec_tracer/remote_cache/local_fs_backend.rb
+++ b/lib/rspec_tracer/remote_cache/local_fs_backend.rb
@@ -69,8 +69,8 @@ module RSpecTracer
       #
       # `tree_sha:` is accepted for protocol uniformity with S3Backend
       # but is currently a no-op: the tree-SHA secondary index is an
-      # S3-only feature (M8.4-B). Future enhancement may extend it
-      # here; the orchestrator already forwards the kwarg.
+      # S3-only feature. Future enhancement may extend it here; the
+      # orchestrator already forwards the kwarg.
       def download(ref, tree_sha: nil)
         _ = tree_sha
         return false if blank?(ref)

--- a/lib/rspec_tracer/remote_cache/redis_backend.rb
+++ b/lib/rspec_tracer/remote_cache/redis_backend.rb
@@ -89,8 +89,8 @@ module RSpecTracer
       #
       # `tree_sha:` is accepted for protocol uniformity with S3Backend
       # but is currently a no-op: the tree-SHA secondary index is an
-      # S3-only feature (M8.4-B). Future enhancement may extend it
-      # here; the orchestrator already forwards the kwarg.
+      # S3-only feature. Future enhancement may extend it here; the
+      # orchestrator already forwards the kwarg.
       def download(ref, tree_sha: nil)
         _ = tree_sha
         return false if blank?(ref)

--- a/lib/rspec_tracer/remote_cache/s3_backend.rb
+++ b/lib/rspec_tracer/remote_cache/s3_backend.rb
@@ -50,7 +50,7 @@ module RSpecTracer
     #     entirely (including its branch_refs.json) when no ref has
     #     been touched in X seconds. Applied at upload time in the
     #     backend's own branch only; cross-branch cleanup is a separate
-    #     Rake task (deferred to M7.2).
+    #     Rake task.
     #
     # Graceful-degradation contract:
     #   - `download` returns false and never raises on wire/validation
@@ -60,8 +60,8 @@ module RSpecTracer
     #   - `prune!` returns count removed, never raises.
     #
     # S3 shells out via `aws` CLI - a single class is the natural unit
-    # of composition here. M8.3 mutation-smoke addition may push this
-    # over the limit further; splitting would be cosmetic.
+    # of composition here. The class is large; splitting would be
+    # cosmetic.
     # rubocop:disable Metrics/ClassLength
     class S3Backend
       class S3BackendError < StandardError; end

--- a/lib/rspec_tracer/reporters/base.rb
+++ b/lib/rspec_tracer/reporters/base.rb
@@ -2,7 +2,7 @@
 
 module RSpecTracer
   module Reporters
-    # Abstract base for every reporter M6.1 / M6.2 ships. Takes the
+    # Abstract base for every reporter rspec-tracer ships. Takes the
     # finalized Storage::Snapshot + report_dir + run_metadata triplet
     # (architectural decision (b), Option X - raw Snapshot, no
     # projection struct) and exposes two lifecycle hooks:

--- a/lib/rspec_tracer/reporters/coverage_json_reporter.rb
+++ b/lib/rspec_tracer/reporters/coverage_json_reporter.rb
@@ -9,9 +9,9 @@ require_relative '../line_stub'
 
 module RSpecTracer
   module Reporters
-    # M8.0 owner of `coverage.json` emission. Replaces the legacy
-    # CoverageReporter + CoverageWriter + CoverageMerger + RubyCoverage
-    # quartet that 1.x carried. Output shape preserved byte-for-byte
+    # Single owner of `coverage.json` emission in 2.0. Replaces the
+    # legacy CoverageReporter + CoverageWriter + CoverageMerger +
+    # RubyCoverage quartet that 1.x carried. Output shape preserved byte-for-byte
     # for downstream consumers (user CI dashboards parse this):
     #
     #   { "RSpecTracer": {
@@ -33,7 +33,7 @@ module RSpecTracer
     # NOT write coverage.json. Instead it installs a small inner module
     # via `::Coverage.singleton_class.prepend` so SimpleCov's at_exit
     # result-merge sees rspec-tracer's filtered coverage. Matches 1.x
-    # behavior + the M4.3 integration matrix convention.
+    # behavior + the integration matrix convention.
     #
     # Parallel_tests: per-worker emit happens through the Registry
     # like every other reporter (each worker writes its own
@@ -287,7 +287,7 @@ module RSpecTracer
       # SimpleCov calls `::Coverage.result` at its at_exit time, this
       # prepended `result` method returns rspec-tracer's filtered
       # cumulative coverage so SimpleCov's result-merge sees exactly
-      # what rspec-tracer saw. Matches the 1.x behavior the M4.3
+      # what rspec-tracer saw. Matches the 1.x behavior the
       # integration matrix relies on.
       module SimpleCovInterop
         class << self

--- a/lib/rspec_tracer/reporters/terminal_reporter.rb
+++ b/lib/rspec_tracer/reporters/terminal_reporter.rb
@@ -7,8 +7,8 @@ module RSpecTracer
     # Concise stdout summary printed at finalize-time. Output is
     # capped at 4 lines for a typical run (5 when duplicate /
     # interrupted / flaky / pending counters are non-zero). Kind-less
-    # taxonomy per M6.1 decision - the in-memory Input#kind enum does
-    # not survive Storage::Snapshot persistence, so breaking down
+    # taxonomy by design - the in-memory Input#kind enum does not
+    # survive Storage::Snapshot persistence, so breaking down
     # "Changed files: Templates / Locales / Ruby" would require a
     # schema bump (deferred).
     #
@@ -31,7 +31,7 @@ module RSpecTracer
       # "\u00B7" = U+00B7 MIDDLE DOT. Written as the ASCII escape form
       # so mutant's US-ASCII-defaulted parser doesn't choke on
       # non-ASCII bytes in the source file. Same discipline as the
-      # dependency_graph.rb fix (M3.5).
+      # dependency_graph.rb workaround.
       SEPARATOR = " \u00B7 "
       private_constant :SEPARATOR
 

--- a/lib/rspec_tracer/rspec/README.md
+++ b/lib/rspec_tracer/rspec/README.md
@@ -44,7 +44,7 @@ Installation module logs a warn-level line. Users are still free to
 ignore it - the tracer degrades to "attribute whatever we can observe
 from now on".
 
-## Per-example metadata DSL (M5.2)
+## Per-example metadata DSL
 
 Annotate a describe / context / example with `tracks: { files: ..., env: ... }`
 to declare additional dependencies that Coverage + IO observation cannot see:

--- a/lib/rspec_tracer/rspec/installation.rb
+++ b/lib/rspec_tracer/rspec/installation.rb
@@ -13,7 +13,7 @@ module RSpecTracer
     # 1.x used `ObjectSpace.each_object(::RSpec::Core::Runner)` to find
     # the already-instantiated runner and prepend onto its singleton
     # class - forcing start-time ordering (RSpec had to be mid-boot).
-    # M5.1 prepends onto the class itself at require time, so the hooks
+    # 2.0 prepends onto the class itself at require time, so the hooks
     # apply to every subsequent Runner / Reporter instance.
     #
     # Consequence: `RSpecTracer.start` no longer requires RSpec to be

--- a/lib/rspec_tracer/rspec/metadata.rb
+++ b/lib/rspec_tracer/rspec/metadata.rb
@@ -4,7 +4,7 @@ require 'set'
 
 module RSpecTracer
   module RSpec
-    # M5.2 per-example tracking DSL. Reads the `tracks:` metadata key
+    # Per-example tracking DSL. Reads the `tracks:` metadata key
     # off an example and its ancestor example groups and emits a
     # normalized union of declared file globs + env-var names.
     #

--- a/lib/rspec_tracer/rspec/parallel_tests.rb
+++ b/lib/rspec_tracer/rspec/parallel_tests.rb
@@ -10,9 +10,9 @@ module RSpecTracer
     # 1.x scattered the parallel-worker glue across `lib/rspec_tracer.rb`
     # (`parallel_tests_setup`, `track_parallel_tests_test_env_number`,
     # `run_parallel_tests_exit_tasks`, `merge_parallel_tests_reports`,
-    # `parallel_tests_last_process?`, etc). M5.1 collapses them here and
+    # `parallel_tests_last_process?`, etc). 2.0 collapses them here and
     # rewires the snapshot merge onto `Storage::JsonBackend#merge_from_peers`
-    # so any storage backend (M3.8 SQLite) gets the merge for free.
+    # so any storage backend (including SQLite) gets the merge for free.
     #
     # Responsibilities:
     #   - Detect `TEST_ENV_NUMBER` + `PARALLEL_TEST_GROUPS` env vars.
@@ -157,12 +157,12 @@ module RSpecTracer
 
         merge_snapshot!
         merge_coverage! unless RSpecTracer.simplecov?
-        # M8.10: emit terminal/JSON/HTML reporters ONCE at the merged
-        # top-level location BEFORE purge_worker_dirs! removes the
-        # per-worker `parallel_tests_N` dirs. Pre-M8.10 each worker
-        # emitted reports into its `rspec_tracer_report/parallel_tests_N`
-        # dir and the purge then deleted them, leaving the user with
-        # zero usable output. Now reporters consume the just-merged
+        # Emit terminal/JSON/HTML reporters ONCE at the merged top-level
+        # location BEFORE purge_worker_dirs! removes the per-worker
+        # `parallel_tests_N` dirs. Earlier behavior had each worker emit
+        # reports into its `rspec_tracer_report/parallel_tests_N` dir
+        # and the purge then deleted them, leaving the user with zero
+        # usable output. Now reporters consume the just-merged
         # top-level snapshot.
         emit_merged_reporters!
         purge_worker_dirs!
@@ -241,7 +241,7 @@ module RSpecTracer
         paths.map { |path| ::File.dirname(path) }
       end
 
-      # M8.10: Emit reporters against the merged top-level snapshot
+      # Emit reporters against the merged top-level snapshot
       # so the user gets one terminal summary + one JSON report + one
       # HTML report at the canonical (non-`parallel_tests_N`) path.
       # Wrapped in its own rescue so a failed reporter never blocks
@@ -400,7 +400,7 @@ module RSpecTracer
       end
 
       # Merge per-worker coverage.json files into a top-level coverage.json.
-      # M8.0 routes through Reporters::CoverageJsonReporter.merge_parallel
+      # Routed through Reporters::CoverageJsonReporter.merge_parallel
       # (replaces the legacy CoverageMerger + CoverageWriter pair).
       def self.merge_coverage!
         base_dir = ::File.dirname(RSpecTracer.coverage_path)

--- a/lib/rspec_tracer/rspec/reporter_hook.rb
+++ b/lib/rspec_tracer/rspec/reporter_hook.rb
@@ -15,7 +15,7 @@ module RSpecTracer
     #
     # The per-example coverage peek+diff sequence (peek before, peek
     # after) runs through Engine#example_started + Engine#example_finished
-    # only. M8.0 retired the legacy CoverageReporter that previously
+    # only. 2.0 retired the legacy CoverageReporter that previously
     # peeked a second time per example; coverage.json emission now
     # consumes the Engine's per-example deltas + a single finalize-time
     # peek through Tracker::CoverageAdapter#peek_unfiltered.

--- a/lib/rspec_tracer/source_file.rb
+++ b/lib/rspec_tracer/source_file.rb
@@ -2,8 +2,8 @@
 
 module RSpecTracer
   # Path manipulation helpers used by Example.location_file_name.
-  # Post-M8.0 retirement, the only caller is example.rb (the legacy
-  # CoverageReporter that previously used these is gone).
+  # Post-coverage-stack retirement, the only caller is example.rb
+  # (the legacy CoverageReporter that previously used these is gone).
   #
   # All methods declared `def self.x` per
   # feedback_mutation_friendly_modules so mutant observes mutations

--- a/lib/rspec_tracer/storage/README.md
+++ b/lib/rspec_tracer/storage/README.md
@@ -30,6 +30,6 @@ end
 
 ## Status
 
-Placeholder for 2.0. Legacy 1.x persistence lives in
-`lib/rspec_tracer/cache.rb`, `report_writer.rb`, and `coverage_writer.rb`
-and migrates here during Phase 3 (session M3.4).
+Shipping in 2.0. The legacy 1.x persistence files
+(`lib/rspec_tracer/cache.rb`, `report_writer.rb`, `coverage_writer.rb`)
+were retired and replaced by this storage subsystem.

--- a/lib/rspec_tracer/storage/backend.rb
+++ b/lib/rspec_tracer/storage/backend.rb
@@ -3,9 +3,9 @@
 module RSpecTracer
   module Storage
     # Protocol every storage backend must satisfy. JsonBackend is the
-    # only shipping implementation in 2.0; SqliteBackend arrives in
-    # M3.8. The `spec/contracts/storage_backend.rb` shared-examples
-    # group asserts the full contract on every implementation.
+    # default; SqliteBackend is an opt-in alternative on MRI. The
+    # `spec/contracts/storage_backend.rb` shared-examples group asserts
+    # the full contract on every implementation.
     #
     # Rationale for the method set (from ARCHITECTURE.md, Contracts
     # between layers):

--- a/lib/rspec_tracer/storage/json_backend.rb
+++ b/lib/rspec_tracer/storage/json_backend.rb
@@ -42,9 +42,9 @@ module RSpecTracer
     # asserts across 1000 iterations.
     #
     # Encoding: every read and write passes `encoding: 'UTF-8'`.
-    # This fixes the M3.1-flagged `Encoding::InvalidByteSequenceError`
-    # that bit the dogfood path when an example title contained a
-    # non-ASCII byte on a US-ASCII-defaulted filesystem.
+    # Fixes the `Encoding::InvalidByteSequenceError` that bit the
+    # dogfood path when an example title contained a non-ASCII byte on
+    # a US-ASCII-defaulted filesystem.
     # rubocop:disable Metrics/ClassLength
     class JsonBackend
       # On-disk filenames under the default `:json` serializer. This
@@ -57,20 +57,20 @@ module RSpecTracer
       # boot_set.json lands at the end of the list - additive w.r.t.
       # 1.x and v2 readers that walked this enumeration. It carries
       # the project's transitive boot-load set (schema_version 3).
-      # wsi_snapshot.json (M4.3) persists the WholeSuiteInvalidators
+      # wsi_snapshot.json persists the WholeSuiteInvalidators
       # digest_snapshot so warm runs can tell whether Gemfile.lock /
       # .ruby-version / .rspec-tracer / tracer-gem identity changed
       # since the previous run. Without it, warm runs always saw a
       # nil previous and treated every run as a cold first run.
-      # Missing file deserializes to `{}` so pre-M4.3 caches still
-      # load - the fallback path fires one full re-run (safe).
-      # env_snapshot.json (M5.2) persists the `Tracker::EnvSnapshot`
-      # digest map for env-var values the per-example `tracks:
-      # { env: ... }` DSL declares. Same missing-coerces-to-`{}`
-      # fallback as wsi_snapshot - no schema bump.
-      # env_dependency.json (M6.1) persists the per-example tracked-env
+      # Missing file deserializes to `{}` so older caches still load -
+      # the fallback path fires one full re-run (safe).
+      # env_snapshot.json persists the `Tracker::EnvSnapshot` digest
+      # map for env-var values the per-example `tracks: { env: ... }`
+      # DSL declares. Same missing-coerces-to-`{}` fallback as
+      # wsi_snapshot - no schema bump.
+      # env_dependency.json persists the per-example tracked-env
       # attribution map that reporters need for the Examples Dependency
-      # report. Missing file coerces to `{}`; pre-M6.1 caches load
+      # report. Missing file coerces to `{}`; older caches load
       # without a cold re-run.
       FILENAMES = %w[
         all_examples.json

--- a/lib/rspec_tracer/storage/schema.rb
+++ b/lib/rspec_tracer/storage/schema.rb
@@ -19,11 +19,11 @@ module RSpecTracer
     # caller pays one cold run on upgrade - the deal 1.x users already
     # expect for any rspec-tracer version bump.
     module Schema
-      # schema_version 2 shipped with M3.4 (first versioned schema;
-      # 1.x was unstamped). M3.7 introduces `Snapshot.boot_set` -
-      # breaking for any reader that assumed the v2 field list - so
-      # CURRENT bumps to 3 and SUPPORTED narrows to only the new
-      # version. Pre-release: no v2 caches are persisted in user land.
+      # schema_version 2 was the first versioned schema (1.x was
+      # unstamped). 2.0 adds `Snapshot.boot_set` - breaking for any
+      # reader that assumed the v2 field list - so CURRENT bumps to 3
+      # and SUPPORTED narrows to only the new version. No v2 caches
+      # were ever persisted in user land.
       CURRENT = 3
       SUPPORTED = [CURRENT].freeze
 

--- a/lib/rspec_tracer/storage/serializer/json.rb
+++ b/lib/rspec_tracer/storage/serializer/json.rb
@@ -7,8 +7,8 @@ module RSpecTracer
     module Serializer
       # Default serializer for JsonBackend. Produces pretty-printed
       # JSON strings; reads tolerate binary-mode bytes by forcing
-      # UTF-8 on decode (preserves the M3.1 fix for example titles
-      # with non-ASCII bytes on US-ASCII-defaulted filesystems).
+      # UTF-8 on decode (preserves the fix for example titles with
+      # non-ASCII bytes on US-ASCII-defaulted filesystems).
       #
       # Class-level methods (not module_function) so mutant-rspec can
       # observe mutations through the call path; see the mutation-

--- a/lib/rspec_tracer/storage/serializer/msgpack.rb
+++ b/lib/rspec_tracer/storage/serializer/msgpack.rb
@@ -9,7 +9,7 @@ module RSpecTracer
       # is not in the user's bundle. JsonBackend rescues at construct
       # time + falls back to the Json serializer with a warn line,
       # same optional-dep pattern the RedisBackend uses for the redis
-      # gem (see M7.2 handoff notes).
+      # gem.
       class MsgpackGemNotInstalled < StandardError; end
 
       # MessagePack + zlib serializer. msgpack encode is ~2x smaller
@@ -51,9 +51,7 @@ module RSpecTracer
         # post-load constant. The previous @msgpack_loaded ivar memo
         # was load-bearing for mutation observability: once any prior
         # test tripped the memo, mutations on the require line were
-        # observably equivalent (M8.3-A retro: ~25 pp local-vs-CI
-        # variance on this subject; memory:
-        # feedback_mutant_local_vs_ci_variance).
+        # observably equivalent.
         def self.available?
           ensure_available!
           true

--- a/lib/rspec_tracer/storage/snapshot.rb
+++ b/lib/rspec_tracer/storage/snapshot.rb
@@ -15,34 +15,33 @@ module RSpecTracer
     # into struct internals.
     #
     # `examples_coverage` may be `nil` when a caller explicitly loads
-    # the cheap header only (M3.6 will wire that path). The default
-    # load is eager - `nil` vs `{}` distinguishes "not yet loaded"
-    # from "loaded and empty."
+    # the cheap header only. The default load is eager - `nil` vs `{}`
+    # distinguishes "not yet loaded" from "loaded and empty."
     #
     # Methods are defined on the reopened class body (not inside the
     # Struct.new block) so mutant can introspect them - same pattern
     # as Tracker::Input.
     #
-    # M3.7 adds `boot_set` - Hash[relative_path => sha256_hex] of every
-    # project file loaded before any example runs (spec_helper
-    # requires, gem boot, eager autoload). Backs the constants-
-    # blind-spot fix: the M3.6 caller compares this against the
-    # previous run's boot_set and ORs any mismatch with
-    # WholeSuiteInvalidators when computing the whole_suite_invalidated
-    # bool. Per-example loaded-set attribution folds into `dependency`
-    # via the existing graph registration path - no separate field.
+    # `boot_set` - Hash[relative_path => sha256_hex] of every project
+    # file loaded before any example runs (spec_helper requires, gem
+    # boot, eager autoload). Backs the constants-blind-spot fix: the
+    # engine compares this against the previous run's boot_set and ORs
+    # any mismatch with WholeSuiteInvalidators when computing the
+    # whole_suite_invalidated bool. Per-example loaded-set attribution
+    # folds into `dependency` via the existing graph registration path
+    # - no separate field.
     #
-    # M4.3 adds `wsi_snapshot` - Hash[watch_name => sha256_hex] produced
-    # by `WholeSuiteInvalidators#digest_snapshot`. Without it, a warm
-    # run can't tell whether Gemfile.lock / .ruby-version / .rspec-tracer
+    # `wsi_snapshot` - Hash[watch_name => sha256_hex] produced by
+    # `WholeSuiteInvalidators#digest_snapshot`. Without it, a warm run
+    # can't tell whether Gemfile.lock / .ruby-version / .rspec-tracer
     # (or the tracer gem identity) changed since the previous run, and
     # the engine falls back to "first run = invalidate everything" on
-    # every warm run. The field is optional in the JSON layout so caches
-    # saved before M4.3 continue to load (missing wsi.json coerces to
-    # `{}`, which compares unequal and triggers one cold re-run - safe
-    # fallback, same cost as any other cache miss).
+    # every warm run. The field is optional in the JSON layout so older
+    # caches continue to load (missing wsi.json coerces to `{}`, which
+    # compares unequal and triggers one cold re-run - safe fallback,
+    # same cost as any other cache miss).
     #
-    # M5.2 adds `env_snapshot` - Hash[env_name => md5_hex] produced by
+    # `env_snapshot` - Hash[env_name => md5_hex] produced by
     # `Tracker::EnvSnapshot#digest_snapshot`. Covers env-var values
     # declared via the per-example `tracks: { env: ... }` DSL.
     # Without it, a warm run can't tell whether an env-gated example
@@ -50,13 +49,13 @@ module RSpecTracer
     # treatment as wsi_snapshot: missing file coerces to `{}`, no
     # schema_version bump, one cold re-run on upgrade.
     #
-    # M6.1 adds `env_dependency` - Hash[example_id => Array<env_name>]
-    # capturing which env keys each tracked example declared. The
-    # per-run `env_snapshot` stores the digest of each key; this map
-    # stores the example-to-key attribution that the reporter layer
-    # needs to render "which env vars does this example depend on."
-    # Without it, reports can't surface env dependencies - Engine's
-    # per-run `@tracks_env` map would otherwise be lost at finalize.
+    # `env_dependency` - Hash[example_id => Array<env_name>] capturing
+    # which env keys each tracked example declared. The per-run
+    # `env_snapshot` stores the digest of each key; this map stores
+    # the example-to-key attribution that the reporter layer needs to
+    # render "which env vars does this example depend on." Without it,
+    # reports can't surface env dependencies - Engine's per-run
+    # `@tracks_env` map would otherwise be lost at finalize.
     # Same optional-in-JSON treatment as wsi_snapshot / env_snapshot:
     # missing file coerces to `{}`, no schema_version bump.
     #

--- a/lib/rspec_tracer/storage/sqlite_backend.rb
+++ b/lib/rspec_tracer/storage/sqlite_backend.rb
@@ -43,7 +43,7 @@ module RSpecTracer
       # Raised when the sqlite3 gem cannot be loaded. Engine's
       # build_storage_backend dispatch rescues + falls back to
       # `:json` with a warn line - same optional-dep posture as
-      # RedisBackend (M7.2) uses for the redis gem.
+      # RedisBackend uses for the redis gem.
       class SqliteBackendError < StandardError; end
 
       DB_FILENAME = 'rspec_tracer.sqlite3'
@@ -57,8 +57,7 @@ module RSpecTracer
       # ms gives ~5x margin over a worst-case 1 s save on large caches
       # (cache_load benchmark p50 ~0.6 s at 500 examples), preserving
       # the storage layer's "concurrent writers serialize cleanly"
-      # contract verified in spec/edge_cases/concurrent_write_spec.rb
-      # (M8.2).
+      # contract verified in spec/edge_cases/concurrent_write_spec.rb.
       BUSY_TIMEOUT_MS = 5_000
 
       # SQLite's on-disk file format starts with the literal bytes
@@ -71,7 +70,7 @@ module RSpecTracer
       # Database.new + ensure_schema! sequence writes a fresh db.
       # Without this, configure_connection's PRAGMA raises
       # SQLite3::NotADatabaseException and the user is stuck unless
-      # they manually rm the cache. M8.2's cache_loader_fuzz harness
+      # they manually rm the cache. The `cache_loader_fuzz` harness
       # surfaced this gap.
       SQLITE_MAGIC_BYTES = "SQLite format 3\x00".b.freeze
       private_constant :SQLITE_MAGIC_BYTES
@@ -264,7 +263,7 @@ module RSpecTracer
         # the file's write lock to switch modes; if another connection is
         # mid-transaction (BEGIN IMMEDIATE held), the PRAGMA contends on
         # that lock and raises SQLite3::BusyException unless busy_timeout
-        # has been configured. M8.2's CI run on Ruby 3.3 caught this: the
+        # has been configured. CI on Ruby 3.3 surfaced this: the
         # losing concurrent writer never reached its BEGIN IMMEDIATE
         # because configure_connection's PRAGMA failed first.
         db.busy_timeout = BUSY_TIMEOUT_MS

--- a/lib/rspec_tracer/tracker/declared_globs.rb
+++ b/lib/rspec_tracer/tracker/declared_globs.rb
@@ -56,10 +56,11 @@ module RSpecTracer
         @globs.any? { |glob| File.fnmatch?(glob, rel, FNMATCH_FLAGS) }
       end
 
-      # Per-example attribution. Declared inputs attach to every example
-      # in the suite - the per-example DSL arrives in M5.2. Each example
-      # gets its own Set copy so downstream mutation of one example's
-      # input set does not leak into siblings.
+      # Per-example attribution. Declared inputs attach to every
+      # example in the suite (per-example narrowing is available via
+      # the per-example `tracks:` DSL). Each example gets its own Set
+      # copy so downstream mutation of one example's input set does
+      # not leak into siblings.
       def attribute_to(example_ids)
         inputs = walk
         example_ids.to_h { |id| [id, Set.new(inputs)] }

--- a/lib/rspec_tracer/tracker/dependency_graph.rb
+++ b/lib/rspec_tracer/tracker/dependency_graph.rb
@@ -17,7 +17,7 @@ module RSpecTracer
     #
     # Keyed by file path, not Input identity
     # -------------------------------------
-    # M3.5's brief described the inverse as "input_identity -> Set<example_id>",
+    # An earlier design framed the inverse as "input_identity -> Set<example_id>",
     # which embeds the Input#kind (e.g. "ruby:lib/foo.rb" vs
     # "declared:lib/foo.rb"). In practice the change-set that drives
     # filtering comes from diffing Snapshot.all_files digests, which

--- a/lib/rspec_tracer/tracker/env_matcher.rb
+++ b/lib/rspec_tracer/tracker/env_matcher.rb
@@ -2,7 +2,7 @@
 
 module RSpecTracer
   module Tracker
-    # M5.3 wildcard env matching helper.
+    # Wildcard env matching helper.
     #
     # Lives outside Configuration so configure's alias loop does not
     # leak its private helpers as public _name DSL surface

--- a/lib/rspec_tracer/tracker/env_snapshot.rb
+++ b/lib/rspec_tracer/tracker/env_snapshot.rb
@@ -7,7 +7,7 @@ module RSpecTracer
   module Tracker
     # Observer #5 in the 2.0 tracker pipeline (WholeSuiteInvalidators
     # is #4). Owns the per-run snapshot of environment-variable
-    # values that M5.2's `tracks: { env: ... }` metadata declares.
+    # values that the per-example `tracks: { env: ... }` metadata declares.
     #
     # Watch list is caller-provided - unlike WholeSuiteInvalidators,
     # which hard-codes Gemfile.lock / .ruby-version / .rspec-tracer,

--- a/lib/rspec_tracer/tracker/example_registry.rb
+++ b/lib/rspec_tracer/tracker/example_registry.rb
@@ -10,10 +10,10 @@ module RSpecTracer
     # detection via RSpec's identity-hash surface (the same hash 1.x
     # uses for `fail_on_duplicates`).
     #
-    # M3.5 owns the data structure only. `update_status` is called by
-    # M5.1 (RSpec integration hooks) on example-finished events and
-    # by signal handlers on interruption; M3.6 passes the registry
-    # instance through Tracker.setup. The registry itself has no
+    # This module owns the data structure only. `update_status` is
+    # called by the RSpec integration hooks on example-finished events
+    # and by signal handlers on interruption; `Tracker.setup` passes
+    # the registry instance through. The registry itself has no
     # opinion about where status comes from.
     #
     # Statuses
@@ -22,8 +22,8 @@ module RSpecTracer
     #   :failed       - example assertion failed
     #   :pending      - RSpec `pending`
     #   :interrupted  - RSpec was killed mid-example (SIGINT / SIGTERM)
-    #   :flaky        - passed this run but previously failed (M5.1
-    #                   detects via retry semantics)
+    #   :flaky        - passed this run but previously failed
+    #                   (detected via retry semantics)
     #   :skipped      - skipped via `skip` or `:skip` metadata; tracked
     #                   for coverage attribution but NOT auto-re-run
     #

--- a/lib/rspec_tracer/tracker/file_digest.rb
+++ b/lib/rspec_tracer/tracker/file_digest.rb
@@ -21,9 +21,9 @@ module RSpecTracer
     # this module centralized them.
     #
     # Thread-safety: rspec example execution is single-threaded
-    # (M5.1 cold-subprocess contract); the cache uses a plain Hash
-    # without locking. Multi-threaded callers are unsupported
-    # (consistent with the rest of the tracer's threading model).
+    # (cold-subprocess contract); the cache uses a plain Hash without
+    # locking. Multi-threaded callers are unsupported (consistent
+    # with the rest of the tracer's threading model).
     module FileDigest
       class << self
         # Returns the SHA256 hex digest of `path`, or nil when the

--- a/lib/rspec_tracer/tracker/input.rb
+++ b/lib/rspec_tracer/tracker/input.rb
@@ -4,11 +4,13 @@ require 'set'
 
 module RSpecTracer
   module Tracker
-    # Closed taxonomy of input sources. M3.1 only produces :ruby
-    # (Coverage-observed source). The other kinds are the surface for
-    # M3.2 (:data via I/O hooks), M3.3 (:declared, :lockfile), M3.7
-    # (:env) and later sessions. Adding a new kind is a one-line change
-    # here plus a test; shrinking the set is a schema_version bump.
+    # Closed taxonomy of input sources. The kinds correspond to the
+    # observation surface: `:ruby` (Coverage-observed source), `:data`
+    # (I/O hooks), `:declared` / `:lockfile` (declared globs), `:env`
+    # (env_snapshot), `:notification` (Rails notifications),
+    # `:template` / `:schema` (Rails subscribers). Adding a new kind
+    # is a one-line change here plus a test; shrinking the set is a
+    # schema_version bump.
     ALLOWED_INPUT_KINDS = %i[
       ruby template data schema lockfile declared env notification
     ].to_set.freeze

--- a/lib/rspec_tracer/tracker/io_hooks.rb
+++ b/lib/rspec_tracer/tracker/io_hooks.rb
@@ -25,8 +25,8 @@ module RSpecTracer
     #
     # Lifecycle:
     #   1. IOHooks.install(root:, filter:, extensions:) - called once
-    #      at Tracker.setup time (wired in M3.6). Prepends hook modules
-    #      onto File/IO/YAML/JSON/Kernel singleton classes.
+    #      at Tracker.setup time. Prepends hook modules onto
+    #      File/IO/YAML/JSON/Kernel singleton classes.
     #   2. Example execution runs inside IOHooks.with_bucket(bucket)
     #      {...}. Hooks push Inputs into the thread-local bucket;
     #      outside a with_bucket call every hook fast-rejects.
@@ -137,8 +137,8 @@ module RSpecTracer
 
         # Record a :ruby input (Kernel#load hook). Belt-and-suspenders
         # for dynamically-constructed load paths that might bypass the
-        # Coverage module's require-graph observation. M3.5's registry
-        # dedupes overlap with CoverageAdapter.
+        # Coverage module's require-graph observation. The example
+        # registry dedupes overlap with CoverageAdapter.
         def record_ruby_load(path)
           _record(path, :ruby) { |p| p.end_with?('.rb') }
         end

--- a/lib/rspec_tracer/tracker/io_hooks/file.rb
+++ b/lib/rspec_tracer/tracker/io_hooks/file.rb
@@ -16,8 +16,7 @@ module RSpecTracer
       # `@root_prefix` nil-check before the inner bucket check could
       # bail. With the guard, the bucket check happens at FileReads
       # so the reject path skips IOHooks.record entirely. Cuts the
-      # M2 Max reject overhead from ~530 ns/call to ~300 ns/call
-      # (M3.1-M3.2 absorbed orphan).
+      # M2 Max reject overhead from ~530 ns/call to ~300 ns/call.
       module FileReads
         def read(path, ...)
           IOHooks.record(path) if Thread.current[BUCKET_KEY]

--- a/lib/rspec_tracer/tracker/io_hooks/kernel.rb
+++ b/lib/rspec_tracer/tracker/io_hooks/kernel.rb
@@ -8,7 +8,7 @@ module RSpecTracer
       # chain) and explicit `Kernel.load('x.rb')` (singleton dispatch)
       # fire the hook. Records as :ruby - CoverageAdapter also sees
       # these files through the Coverage module's load-path
-      # instrumentation; M3.5's registry dedupes the overlap.
+      # instrumentation; the example registry dedupes the overlap.
       module KernelReads
         def load(path, ...)
           IOHooks.record_ruby_load(path) if Thread.current[BUCKET_KEY]

--- a/lib/rspec_tracer/tracker/loaded_files_tracker.rb
+++ b/lib/rspec_tracer/tracker/loaded_files_tracker.rb
@@ -131,9 +131,9 @@ module RSpecTracer
       end
 
       # Hash[relative_path => sha256_hex] for every file in the boot
-      # set. Used by the M3.6 caller to compare against the previous
-      # run's stored `Snapshot.boot_set` - any inequality is a
-      # whole-suite invalidator.
+      # set. The engine compares this against the previous run's
+      # stored `Snapshot.boot_set` - any inequality is a whole-suite
+      # invalidator.
       #
       # Invariant (enforced by capture_boot_set!): every path in
       # `@boot_set` has a matching `@input_cache` entry, so the fetch
@@ -150,9 +150,9 @@ module RSpecTracer
       # cache) is treated as "not invalidated by this signal" - first
       # run is already a cold run for unrelated reasons.
       #
-      # Disabled tracker never invalidates - M3.6's caller ORs this
-      # with WholeSuiteInvalidators.invalidated?, so returning false
-      # keeps the tracker silent when the feature is off.
+      # Disabled tracker never invalidates - the engine ORs this with
+      # WholeSuiteInvalidators.invalidated?, so returning false keeps
+      # the tracker silent when the feature is off.
       def boot_set_invalidated?(previous_snapshot)
         return false unless @enabled
         return false if previous_snapshot.nil?
@@ -229,9 +229,9 @@ module RSpecTracer
       # the cached length from the previous call no new project paths
       # can have appeared. Returns [] without iterating - cuts the
       # per-call cost from ~70 us (full filter loop over ~500 paths) to
-      # one Array#length comparison. M8.4-A profile pass identified
-      # this loop as the dominant per-example cost in the engine
-      # microbench (16% TOTAL); the fast-path drops it to <1%.
+      # one Array#length comparison. A profile pass identified this
+      # loop as the dominant per-example cost in the engine microbench
+      # (16% TOTAL); the fast-path drops it to <1%.
       def new_filtered_paths
         paths = @peek.call
         return [] if @last_peek_length == paths.length

--- a/lib/rspec_tracer/tracker/new_file_detector.rb
+++ b/lib/rspec_tracer/tracker/new_file_detector.rb
@@ -14,15 +14,15 @@ module RSpecTracer
     # The fix: at boot, walk the union of user-declared globs and a
     # pure-Ruby default set (lib/**/*.rb). Every match on disk that is
     # not in the loaded cache's known_paths emits an Input, which the
-    # filter engine (M3.5) treats as "added" and re-runs any example
-    # whose dependency graph could plausibly include it.
+    # filter engine treats as "added" and re-runs any example whose
+    # dependency graph could plausibly include it.
     #
     # Kind is :declared for every emission. The pure-Ruby default is
     # logically a pre-declared glob on the user's behalf - the
     # attribution semantics are identical to an explicit
     # `track_files 'lib/**/*.rb'`.
     #
-    # Rails preset (app/**/*.rb) arrives in M4.1 through
+    # The Rails preset (app/**/*.rb) flows through
     # Configuration#track_rails_defaults; the default list here stays
     # framework-agnostic.
     class NewFileDetector

--- a/lib/rspec_tracer/tracker/whole_suite_invalidators.rb
+++ b/lib/rspec_tracer/tracker/whole_suite_invalidators.rb
@@ -10,7 +10,7 @@ module RSpecTracer
     # Observer #4 in the 2.0 tracker pipeline. Emits the binary
     # "blow it all up" signal that runs before any per-example
     # filtering - when any watched file changes, the filter engine
-    # (M3.5) treats every example as affected.
+    # treats every example as affected.
     #
     # Watch list is deliberately hard-coded (not config-overridable):
     # these are the files whose semantics are universal across any
@@ -43,7 +43,7 @@ module RSpecTracer
 
       # Fresh snapshot on every call - callers typically take one at
       # boot (stored as the "current" snapshot) and compare against a
-      # previously-loaded snapshot (returned by storage in M3.4).
+      # previously-loaded snapshot (returned by the storage backend).
       # Unlike DeclaredGlobs.walk, this is not memoized: the caller
       # chooses when to sample.
       def digest_snapshot


### PR DESCRIPTION
## Summary

- Pure comment / YARD-prose edits across 41 files in `lib/`. Drops the maintainer's internal milestone identifiers (M3.4, M5.1, M8.0, M9.1, etc.) and the local-only `docs/revamp/` planning-tree references that had accumulated in inline comments during 2.0 development.
- Pre-tag hygiene for the upcoming `2.0.0.pre.1` release: the built gem (`gem unpack`) must not ship internal IDs to RubyGems users. Each comment now either omits the prefix entirely (\"M8.9: SimpleCov ...\" → \"SimpleCov ...\") or rephrases with version context where load-bearing (\"M8.0 retired ...\" → \"2.0 retired ...\").
- No behavior change. Pure prose / comment edits.

## Verification

After this PR:

```
$ git ls-files lib/ | xargs grep -nE 'M[0-9]+\.[0-9]+|docs/revamp'
(0 hits)
```

Pre-PR parity green locally:

- `task check` — 1887 examples / 0 failures
- `task lint:ruby` / `task lint:actions` / `task lint:yaml` — clean
- `task check:bundle` — Gemfile dependencies satisfied
- `task security:bundle-audit` — no vulnerabilities
- `task test:property` — 25 / 0
- `task test:dogfood` — 1 / 1
- `task test:mutation:smoke` — 93.18% (≥ 90% gate)
- `task docs:yard:check` — 56.87% (informational; no regression — comments edited, not `@param` / `@return`)

## Test plan

- [ ] CI: full matrix green on this branch
- [ ] After merge: `gem build rspec-tracer.gemspec` then `gem unpack rspec-tracer-*.gem -d /tmp/check && grep -rnE 'M[0-9]+\.[0-9]+|docs/revamp' /tmp/check/` → zero hits