### PR TITLE
chore(release): tighten tag-trigger patterns + extend prerelease flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,28 @@ name: release
 
 on:
   push:
+    # Tag triggers use GitHub Actions extended-glob (extglob) syntax,
+    # NOT regex. `*` matches zero+ chars except `/`; `+([0-9])` matches
+    # one+ digits. The looser `v*.*.*` form is intentionally NOT used —
+    # `*` will greedy-match dots, so `v*.*.*` accidentally matches
+    # `v2.0.0.rc.1` (third `*` eats `0.rc.1`). Each shape gets its own
+    # explicit pattern so a future flavor rename or addition is a
+    # one-line edit and so unintended pre-release tags don't fire the
+    # final-release path.
     tags:
-      - 'v*.*.*'
-      - 'v*.*.*.pre.*'
+      # Final release: vMAJOR.MINOR.PATCH only. `+([0-9])` rejects
+      # any non-digit segment, so `v2.0.0.rc.1` does not match here.
+      - 'v+([0-9]).+([0-9]).+([0-9])'
+      # Pre-release flavors: vMAJOR.MINOR.PATCH.<flavor>.N. The
+      # rspec-tracer.gemspec version constant convention is the dotted
+      # form (e.g. `2.0.0.pre.1`); RubyGems treats any non-numeric
+      # segment as a pre-release version, so `gem install rspec-tracer`
+      # without `--pre` skips these. One pattern per flavor; add new
+      # flavors here as separate lines if ever needed.
+      - 'v+([0-9]).+([0-9]).+([0-9]).pre.+([0-9])'
+      - 'v+([0-9]).+([0-9]).+([0-9]).rc.+([0-9])'
+      - 'v+([0-9]).+([0-9]).+([0-9]).beta.+([0-9])'
+      - 'v+([0-9]).+([0-9]).+([0-9]).alpha.+([0-9])'
 
 permissions:
   contents: write  # required to create the GitHub release
@@ -31,6 +50,19 @@ jobs:
             exit 1
           fi
           echo "tag ${GITHUB_REF_NAME} matches RSpecTracer::VERSION ${gem_version}"
+
+      - name: Determine prerelease flag for the GitHub release UI
+        id: prerelease
+        # Mirrors the flavor list in `on.push.tags` above. RubyGems
+        # treats any non-numeric segment as a pre-release for `gem
+        # install` purposes regardless of this flag; this is purely
+        # the GitHub release UI marker (Latest vs Pre-release badge).
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ \.(pre|rc|beta|alpha)\. ]]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -66,5 +98,5 @@ jobs:
             gem install rspec-tracer -v ${{ github.ref_name }}
             ```
           draft: false
-          prerelease: ${{ contains(github.ref_name, '.pre.') }}
+          prerelease: ${{ steps.prerelease.outputs.value }}
           generate_release_notes: false


### PR DESCRIPTION
## Summary

Two related hardenings to [`.github/workflows/release.yml`](.github/workflows/release.yml) so the published artifacts on RubyGems and the GitHub release UI stay consistent across the whole 2.0 ramp (`pre.1` → `rc.1` → `2.0.0`) and any future release flavors.

### 1. Tag-trigger patterns are now strict

GitHub Actions tag triggers use **extended-glob** (extglob), not regex — and the previous `'v*.*.*'` glob accepted anything with at least three dotted segments. `*` matches zero+ chars including dots, so `v2.0.0.rc.1` matched the final-release pattern (the third `*` greedy-matched `0.rc.1`).

Replaced with `'v+([0-9]).+([0-9]).+([0-9])'` — `+([0-9])` matches one or more digits, with NO support for non-digit characters per segment. Only `vMAJOR.MINOR.PATCH` fires the final-release path now.

Pre-release flavors get their own explicit patterns:

```yaml
- 'v+([0-9]).+([0-9]).+([0-9])'                  # final
- 'v+([0-9]).+([0-9]).+([0-9]).pre.+([0-9])'     # vX.Y.Z.pre.N
- 'v+([0-9]).+([0-9]).+([0-9]).rc.+([0-9])'      # vX.Y.Z.rc.N
- 'v+([0-9]).+([0-9]).+([0-9]).beta.+([0-9])'    # vX.Y.Z.beta.N
- 'v+([0-9]).+([0-9]).+([0-9]).alpha.+([0-9])'   # vX.Y.Z.alpha.N
```

One pattern per flavor — adding (or removing) a flavor is a one-line edit, and unintended pre-release tags can no longer accidentally fire the final-release path.

### 2. Prerelease flag now covers every flavor

The old expression `prerelease: \${{ contains(github.ref_name, '.pre.') }}` resolved to `false` for `v2.0.0.rc.1`, so the GitHub release UI would mark an rc tag as **Latest** instead of **Pre-release**.

Replaced with a dedicated step that mirrors the trigger flavor list:

```yaml
- name: Determine prerelease flag for the GitHub release UI
  id: prerelease
  run: |
    if [[ "\$GITHUB_REF_NAME" =~ \.(pre|rc|beta|alpha)\. ]]; then
      echo "value=true" >> "\$GITHUB_OUTPUT"
    else
      echo "value=false" >> "\$GITHUB_OUTPUT"
    fi
```

Then: `prerelease: \${{ steps.prerelease.outputs.value }}`.

RubyGems already treats any non-numeric segment as a pre-release for `gem install` purposes regardless of this flag — this fix is purely the GitHub release UI badge.

## Verification

Local extglob case-statement test against ten candidate tag shapes:

| Tag | Result | Expected |
|---|---|---|
| `v2.0.0` | FINAL | ✓ |
| `v10.20.30` | FINAL | ✓ multi-digit segments |
| `v2.0.0.pre.1` | PRE | ✓ |
| `v2.0.0.rc.1` | RC | ✓ |
| `v2.0.0.beta.2` | BETA | ✓ |
| `v2.0.0.alpha.1` | ALPHA | ✓ |
| `v2.0.0.pre` | MISS | ✓ no trailing `.N` |
| `v2.0.0.preview.1` | MISS | ✓ `preview` ≠ `pre` |
| `v2.0.0-pre.1` | MISS | ✓ hyphen ≠ dot |
| `v2.0.0.dev.1` | MISS | ✓ unsupported flavor |

`task lint:actions` (actionlint) + `task lint:yaml` (yamllint --strict) clean.

## Test plan

- [ ] CI green on this PR (lint + actions paths only — no test changes).
- [ ] After merge, before tagging `v2.0.0.pre.1`: confirm the `release.yml` workflow's `on.push.tags` patterns still match the intended tag shape.