### PR TITLE
docs: pin install instructions to 2.0.0.pre.1 in README + COOKBOOK

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -31,7 +31,8 @@ Goal: skip already-passing examples on subsequent runs.
 
 ```ruby
 # Gemfile
-gem 'rspec-tracer', '~> 2.0', group: :test, require: false
+# 2.0 is in pre-release; switch to '~> 2.0' once 2.0.0 final ships.
+gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
 ```
 
 ```sh
@@ -74,7 +75,8 @@ with views, locales, fixtures, schema, and per-example AR queries.
 
 ```ruby
 # Gemfile (test group)
-gem 'rspec-tracer', '~> 2.0', group: :test, require: false
+# 2.0 is in pre-release; switch to '~> 2.0' once 2.0.0 final ships.
+gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
 ```
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ Rails 8.0 needs Ruby 3.2+. JRuby 9.4 is supported.
 1. Add the gem:
 
    ```ruby
-   gem 'rspec-tracer', '~> 2.0', group: :test, require: false
+   # 2.0 is in pre-release. Pin to the pre-release version explicitly;
+   # switch to '~> 2.0' once 2.0.0 final ships.
+   gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
    ```
+
+   `bundle install` will resolve the pre-release version. You can
+   also install ad-hoc with `gem install rspec-tracer --pre`.
 
 2. Add the canonical directories to your `.gitignore`:
 


### PR DESCRIPTION
## Summary

The Quick start in [README.md](README.md) and the first two recipes in [COOKBOOK.md](COOKBOOK.md) showed `gem 'rspec-tracer', '~> 2.0'`. That pin won't resolve until `2.0.0` final ships — Bundler excludes pre-release versions from `~>` constraints by default, so users following the README before final would hit "no version found."

Flipped all 3 install instructions to an explicit pre-release pin with an inline comment for the post-final flip:

```ruby
# 2.0 is in pre-release. Pin to the pre-release version explicitly;
# switch to '~> 2.0' once 2.0.0 final ships.
gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
```

README also picks up a one-line note that `gem install rspec-tracer --pre` is the ad-hoc equivalent.

## Forward path

The pin flip-forward is now scoped into the upcoming release sessions (in the local-only `docs/revamp/sessions/` briefs):

- **M9.3 (rc.1):** flip `'= 2.0.0.pre.1'` → `'= 2.0.0.rc.1'`. Inline comment stays.
- **M9.4 (final):** flip to `'~> 2.0'` and drop the inline comment.

## Diff stats

```
2 files changed, 10 insertions(+), 3 deletions(-)
```

Pure docs change. No code, no specs, no workflow yaml.