### PR TITLE
chore(release): fix tag-trigger patterns to use [0-9]+ (not bash extglob)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,28 +2,39 @@ name: release
 
 on:
   push:
-    # Tag triggers use GitHub Actions extended-glob (extglob) syntax,
-    # NOT regex. `*` matches zero+ chars except `/`; `+([0-9])` matches
-    # one+ digits. The looser `v*.*.*` form is intentionally NOT used —
-    # `*` will greedy-match dots, so `v*.*.*` accidentally matches
+    # Tag triggers use GitHub Actions filter-pattern syntax, NOT bash
+    # extended-glob and NOT POSIX regex. Per
+    # docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax:
+    # `*` = zero+ chars except `/` (greedy; matches dots); `+` = one+
+    # of the *preceding* character / character class; `[0-9]` is a
+    # character class. So "one or more digits" is `[0-9]+`. The
+    # bash-extglob form `+([0-9])` is NOT recognized — actionlint
+    # accepts it as syntactically valid YAML but the runtime treats
+    # `+(`, `)` as literal characters that no real tag contains.
+    #
+    # The looser `v*.*.*` form is intentionally NOT used — `*`
+    # greedy-matches dots, so `v*.*.*` accidentally matches
     # `v2.0.0.rc.1` (third `*` eats `0.rc.1`). Each shape gets its own
     # explicit pattern so a future flavor rename or addition is a
     # one-line edit and so unintended pre-release tags don't fire the
     # final-release path.
+    #
+    # Patterns are YAML-quoted because the cheat sheet warns: "always
+    # quote patterns containing brackets to avoid YAML parsing errors."
     tags:
-      # Final release: vMAJOR.MINOR.PATCH only. `+([0-9])` rejects
-      # any non-digit segment, so `v2.0.0.rc.1` does not match here.
-      - 'v+([0-9]).+([0-9]).+([0-9])'
+      # Final release: vMAJOR.MINOR.PATCH only. `[0-9]+` per segment
+      # rejects any non-digit, so `v2.0.0.rc.1` does not match here.
+      - 'v[0-9]+.[0-9]+.[0-9]+'
       # Pre-release flavors: vMAJOR.MINOR.PATCH.<flavor>.N. The
       # rspec-tracer.gemspec version constant convention is the dotted
       # form (e.g. `2.0.0.pre.1`); RubyGems treats any non-numeric
       # segment as a pre-release version, so `gem install rspec-tracer`
       # without `--pre` skips these. One pattern per flavor; add new
       # flavors here as separate lines if ever needed.
-      - 'v+([0-9]).+([0-9]).+([0-9]).pre.+([0-9])'
-      - 'v+([0-9]).+([0-9]).+([0-9]).rc.+([0-9])'
-      - 'v+([0-9]).+([0-9]).+([0-9]).beta.+([0-9])'
-      - 'v+([0-9]).+([0-9]).+([0-9]).alpha.+([0-9])'
+      - 'v[0-9]+.[0-9]+.[0-9]+.pre.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.rc.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.beta.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.alpha.[0-9]+'
 
 permissions:
   contents: write  # required to create the GitHub release


### PR DESCRIPTION
## Critical follow-up to PR #176

The patterns shipped in #176 used `+([0-9])` — **bash extended-glob** syntax that only works inside shell scripts after `shopt -s extglob`. GitHub Actions tag-pattern filtering uses a different glob flavor where `+` means "one or more of the **preceding character**" (regex-quantifier semantics, not extglob). The bash-extglob form is treated as literal `+(`, `)` characters that no real tag contains, so the patterns matched nothing.

## Symptom

Tag `v2.0.0.pre.1` was pushed against `e73a41c` (the post-#178 HEAD) to trigger the 2.0.0.pre.1 release.

- ✅ `docs-publish.yml` (uses simple `'v*'`) fired correctly and deployed `/v2.0.0.pre.1/yard/` + `/demo/`.
- ❌ `release.yml` did **NOT** fire — confirmed by absence in `gh run list --workflow release.yml`. The gem was never published to RubyGems and no GitHub release was created.

## Recovery

Tag `v2.0.0.pre.1` deleted from local + origin. After this PR merges, re-tag will fire correctly.

## The fix

Per [GitHub Actions filter-pattern docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax) and production examples ([Discussion #13226](https://github.com/orgs/community/discussions/13226)), `+` quantifies the **preceding character** and `[0-9]` is a character class, so `[0-9]+` means "one or more digits":

```yaml
# before — bash extglob, never matched
- 'v+([0-9]).+([0-9]).+([0-9])'
- 'v+([0-9]).+([0-9]).+([0-9]).pre.+([0-9])'
- 'v+([0-9]).+([0-9]).+([0-9]).rc.+([0-9])'
- 'v+([0-9]).+([0-9]).+([0-9]).beta.+([0-9])'
- 'v+([0-9]).+([0-9]).+([0-9]).alpha.+([0-9])'

# after — GitHub Actions filter-pattern syntax
- 'v[0-9]+.[0-9]+.[0-9]+'
- 'v[0-9]+.[0-9]+.[0-9]+.pre.[0-9]+'
- 'v[0-9]+.[0-9]+.[0-9]+.rc.[0-9]+'
- 'v[0-9]+.[0-9]+.[0-9]+.beta.[0-9]+'
- 'v[0-9]+.[0-9]+.[0-9]+.alpha.[0-9]+'
```

The workflow comment block is also rewritten to explain the actual semantics (bash-extglob vs GHA filter-pattern, the `*`-greedy-matches-dots trap, why patterns are YAML-quoted) so the next reader doesn't fall into the same trap.

## Verification

Manual mental-trace against 10 candidate tag shapes:

| Tag | Pattern that matches | Notes |
|---|---|---|
| `v2.0.0` | final | strict digit-only |
| `v10.20.30` | final | multi-digit segments |
| `v2.0.0.pre.1` | pre | |
| `v2.0.0.rc.1` | rc | |
| `v2.0.0.beta.2` | beta | |
| `v2.0.0.alpha.1` | alpha | |
| `v2.0.0.pre` | NONE | missing `.N` correctly rejected |
| `v2.0.0.preview.1` | NONE | `preview` not `pre` |
| `v2.0.0-pre.1` | NONE | hyphen separator |
| `v2.0.0.dev.1` | NONE | unsupported flavor |

`task lint:actions` (actionlint) + `task lint:yaml` (yamllint `--strict`) clean. No code or test changes — workflow YAML only.

## Why this slipped past actionlint + my local test

- `actionlint` only validates YAML syntax + workflow shape, not filter-pattern flavor. `+([0-9])` is syntactically valid YAML, so actionlint passed.
- My local pattern test used `bash -c 'shopt -s extglob; case ...'` which **does** support `+(...)` extglob. Bash extglob and GHA filter-pattern syntax are different glob flavors; the local test was misleading.
- Empirical signal: tag pushed, release.yml didn't fire. That's the test that caught it.

## Test plan

- [ ] CI green on this PR (lint paths only).
- [ ] After merge: re-tag `v2.0.0.pre.1` on the new HEAD. Confirm `release.yml` fires this time → gem published to RubyGems → GH release created.