### PR TITLE
fix(serializer): msgpack Time + Symbol type extension

### DIFF
--- a/lib/rspec_tracer/storage/serializer/msgpack.rb
+++ b/lib/rspec_tracer/storage/serializer/msgpack.rb
@@ -31,7 +31,34 @@ module RSpecTracer
       # The require is lazy so pure-Ruby suites that stay on :json
       # do not pay the msgpack load cost and so the LoadError path
       # is exercisable in unit specs (hide_const-based).
+      #
+      # Type extensions: Ruby `Time` and `Symbol` values surface in
+      # example metadata (RSpec's `execution_result.started_at` is a
+      # Time; status values like `:passed` / `:failed` / `:flaky` are
+      # Symbols on the in-memory snapshot). The bare msgpack default
+      # registry has no `Time` packer (crashes
+      # `NoMethodError: undefined method 'to_msgpack'`) and silently
+      # coerces `Symbol` to `String` (lossy round-trip). Both
+      # behaviors broke the cache on the first run a user followed
+      # the 50 MiB warning's `:msgpack` recommendation. Registering
+      # `Factory` type extensions for `Time` (ID 0x00, 12-byte
+      # seconds+nanoseconds payload) and `Symbol` (ID 0x01, UTF-8
+      # string payload) gives lossless round-trip. The factory is
+      # memoized so the extension registration is one-shot per
+      # process.
       class Msgpack
+        # Internal constant — `MessagePack::Factory#register_type`
+        # ID for Ruby `Time`. Codepoint chosen from the user-space
+        # range (0x00–0x7F per msgpack ext spec); collision-safe with
+        # the built-in timestamp ext (ID -1 / 0xFF) since IDs are
+        # disjoint.
+        # @api private
+        TIME_EXTENSION_TYPE = 0x00
+        # Internal constant — `MessagePack::Factory#register_type` ID
+        # for Ruby `Symbol`. See {TIME_EXTENSION_TYPE} rationale.
+        # @api private
+        SYMBOL_EXTENSION_TYPE = 0x01
+
         # Internal helper for the tracer pipeline.
         # @api private
         def self.extension
@@ -41,15 +68,13 @@ module RSpecTracer
         # Internal helper for the tracer pipeline.
         # @api private
         def self.encode(payload)
-          ensure_available!
-          ::Zlib::Deflate.deflate(::MessagePack.pack(payload))
+          ::Zlib::Deflate.deflate(factory.pack(payload))
         end
 
         # Internal helper for the tracer pipeline.
         # @api private
         def self.decode(bytes)
-          ensure_available!
-          ::MessagePack.unpack(::Zlib::Inflate.inflate(bytes))
+          factory.unpack(::Zlib::Inflate.inflate(bytes))
         end
 
         # Probe used by JsonBackend#initialize to decide whether to
@@ -71,6 +96,58 @@ module RSpecTracer
 
         class << self
           private
+
+          # `MessagePack::Factory` with `Time` and `Symbol` type
+          # extensions registered. Memoized for the process lifetime;
+          # the factory's `register_type` calls are not idempotent
+          # (re-registering would double-register the codepoint), so
+          # one-shot construction is the simplest correctness
+          # contract.
+          def factory
+            return @factory if defined?(@factory) && @factory
+
+            ensure_available!
+            @factory = build_factory
+          end
+
+          # `Time` and `Symbol` packers / unpackers. Packers are
+          # called by `factory.pack` whenever a Ruby `Time` /
+          # `Symbol` appears at any depth in the payload (top-level
+          # value, nested Hash value, Array element). Unpackers are
+          # called by `factory.unpack` on the ext-typed bytes.
+          # Symbol pack/unpack maps to `to_s` / `to_sym` directly
+          # via `Symbol#to_proc`; Time is more involved so it gets
+          # named `pack_time` / `unpack_time` helpers below.
+          def build_factory
+            f = ::MessagePack::Factory.new
+            f.register_type(
+              TIME_EXTENSION_TYPE, ::Time,
+              packer: method(:pack_time),
+              unpacker: method(:unpack_time)
+            )
+            f.register_type(
+              SYMBOL_EXTENSION_TYPE, ::Symbol,
+              packer: :to_s.to_proc,
+              unpacker: :to_sym.to_proc
+            )
+            f
+          end
+
+          # Time encoding: 64-bit signed seconds (`tv_sec`) + 32-bit
+          # signed nanoseconds (`tv_nsec`), little-endian, 12 bytes
+          # total. Round-trip canonicalizes to UTC — rspec-tracer
+          # never re-uses the Time as a user-facing wall-clock value
+          # (cache entries are compared, not displayed), and UTC
+          # makes the on-disk bytes timezone-independent so a cache
+          # built in one tz reads back identically in another.
+          def pack_time(time)
+            [time.tv_sec, time.tv_nsec].pack('q<l<')
+          end
+
+          def unpack_time(data)
+            sec, nsec = data.unpack('q<l<')
+            ::Time.at(sec, nsec, :nanosecond).utc
+          end
 
           # Internal method on the tracer pipeline.
           # @api private

--- a/spec/storage/json_backend_msgpack_spec.rb
+++ b/spec/storage/json_backend_msgpack_spec.rb
@@ -90,6 +90,41 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       end
     end
 
+    describe 'Time + Symbol round-trip via Snapshot (regression for #182)' do
+      # Inner Hash keys are Symbols (Ruby `key:` shorthand), matching
+      # how RSpec example metadata gets populated on the in-memory
+      # snapshot. The Symbol type extension preserves both keys and
+      # values across the cache boundary.
+      it 'round-trips a Snapshot containing Time values losslessly' do
+        snap_with_time = build_sample_snapshot('run-time')
+        snap_with_time.all_examples = {
+          'ex1' => {
+            id: 'ex1',
+            description: 'desc',
+            recorded_at: Time.utc(2026, 5, 13, 12, 0, 0)
+          }
+        }
+        backend.save_graph(snap_with_time, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+        loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+        expect(loaded.all_examples['ex1'][:recorded_at]).to eq(Time.utc(2026, 5, 13, 12, 0, 0))
+      end
+
+      it 'round-trips a Snapshot containing Symbol values losslessly' do
+        snap_with_symbols = build_sample_snapshot('run-sym')
+        snap_with_symbols.all_examples = {
+          'ex1' => { id: 'ex1', status: :flaky, tags: %i[slow integration] }
+        }
+        backend.save_graph(snap_with_symbols, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+        loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+        expect(loaded.all_examples['ex1'][:status]).to eq(:flaky)
+        expect(loaded.all_examples['ex1'][:tags]).to eq(%i[slow integration])
+      end
+    end
+
     describe 'disk size reduction' do
       it 'is noticeably smaller than the :json equivalent on a path-repetitive cache' do
         fat_snap = build_sample_snapshot('run-fat')

--- a/spec/storage/serializer/json_spec.rb
+++ b/spec/storage/serializer/json_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'rspec_tracer/storage/serializer/json'
+
+# Direct unit-level spec for the Json serializer. Lives in this
+# subdirectory so mutant-rspec's Selector::Expression attributes
+# these tests to the Storage::Serializer::Json subject at its own
+# level (not via Storage::* fallthrough, which would otherwise be
+# shadowed once Storage::Serializer::Msgpack got a direct
+# describe of its own in msgpack_spec.rb).
+# rubocop:disable RSpec/MultipleExpectations
+RSpec.describe RSpecTracer::Storage::Serializer::Json do
+  describe '.extension' do
+    it 'returns the literal string "json" (drives the on-disk file shape)' do
+      expect(described_class.extension).to eq('json')
+    end
+
+    it 'is a String, not a Symbol or nil' do
+      expect(described_class.extension).to be_a(String)
+    end
+  end
+
+  describe '.encode' do
+    it 'returns a String' do
+      expect(described_class.encode('a' => 1)).to be_a(String)
+    end
+
+    it 'returns valid JSON parseable back to the input Hash' do
+      payload = { 'a' => 1, 'b' => [2, 3, 'four'], 'c' => { 'nested' => true } }
+
+      encoded = described_class.encode(payload)
+
+      expect(JSON.parse(encoded)).to eq(payload)
+    end
+
+    it 'produces pretty-printed JSON with newlines + indentation (mutant kills `JSON.generate` swap)' do
+      encoded = described_class.encode('a' => 1, 'b' => 2)
+
+      expect(encoded).to include("\n")
+      expect(encoded).to match(/^\s+"[ab]"/m)
+    end
+
+    it 'produces output that round-trips through .decode losslessly' do
+      payload = { 'roundtrip' => 'value', 'count' => 42 }
+
+      decoded = described_class.decode(described_class.encode(payload))
+
+      expect(decoded).to eq(payload)
+    end
+
+    it 'encodes nil values' do
+      expect(JSON.parse(described_class.encode('key' => nil))).to eq('key' => nil)
+    end
+
+    it 'encodes Array values' do
+      expect(JSON.parse(described_class.encode('list' => [1, 2, 3]))).to eq('list' => [1, 2, 3])
+    end
+
+    it 'encodes empty Hash' do
+      expect(described_class.encode({})).to eq('{}')
+    end
+  end
+
+  describe '.decode' do
+    it 'parses a JSON string into the corresponding Ruby Hash' do
+      expect(described_class.decode('{"a":1,"b":"two"}')).to eq('a' => 1, 'b' => 'two')
+    end
+
+    it 'parses an Array-rooted JSON document' do
+      expect(described_class.decode('[1,2,3]')).to eq([1, 2, 3])
+    end
+
+    it 'returns String values as UTF-8 (mutant kills `force_encoding` arg swap)' do
+      result = described_class.decode('{"k":"value"}')
+
+      expect(result['k'].encoding).to eq(Encoding::UTF_8)
+    end
+
+    it 'handles binary-encoded input by force-encoding to UTF-8 (mutant kills `force_encoding` drop)' do
+      bytes = String.new('{"k":"value"}', encoding: Encoding::ASCII_8BIT)
+
+      expect(described_class.decode(bytes)).to eq('k' => 'value')
+    end
+
+    it 'preserves the input bytes string encoding (mutant kills `.dup` drop)' do
+      bytes = String.new('{"k":"value"}', encoding: Encoding::ASCII_8BIT)
+
+      described_class.decode(bytes)
+
+      expect(bytes.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it 'parses non-ASCII characters correctly (the user-issue-fix that the UTF-8 force protects)' do
+      json = '{"name":"café"}'
+
+      result = described_class.decode(json)
+
+      expect(result['name']).to eq('café')
+    end
+
+    it 'raises JSON::ParserError on malformed input' do
+      expect { described_class.decode('{not json}') }.to raise_error(JSON::ParserError)
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleExpectations

--- a/spec/storage/serializer/msgpack_spec.rb
+++ b/spec/storage/serializer/msgpack_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rspec_tracer/storage/serializer/msgpack'
+
+# Unit-level round-trip + type-extension contract for the Msgpack
+# serializer. JsonBackend-level coverage at
+# spec/storage/json_backend_msgpack_spec.rb exercises the full
+# Snapshot pipeline; this spec pins the serializer's own behavior
+# so a future refactor that drops the Time / Symbol extensions
+# fails here loudly rather than only at the
+# "NoMethodError: undefined method 'to_msgpack' for an instance of
+# Time" / "Symbol -> String coercion" symptom level.
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe RSpecTracer::Storage::Serializer::Msgpack do
+  describe 'round-trip' do
+    it 'preserves String values' do
+      bytes = described_class.encode('id_1' => 'value')
+
+      expect(described_class.decode(bytes)).to eq('id_1' => 'value')
+    end
+
+    it 'preserves Integer values' do
+      bytes = described_class.encode('count' => 42)
+
+      expect(described_class.decode(bytes)).to eq('count' => 42)
+    end
+
+    it 'preserves nested Hash + Array structure' do
+      payload = { 'deps' => { 'ex_1' => ['/a.rb', '/b.rb'] } }
+      bytes = described_class.encode(payload)
+
+      expect(described_class.decode(bytes)).to eq(payload)
+    end
+
+    it 'preserves Time values losslessly (the bug at the heart of #182)' do
+      time = Time.utc(2026, 5, 13, 12, 34, 56, 789_012)
+      bytes = described_class.encode('started_at' => time)
+      result = described_class.decode(bytes)
+
+      expect(result['started_at']).to eq(time)
+    end
+
+    it 'preserves Time nanosecond precision' do
+      time = Time.at(1_715_000_000, 123_456_789, :nanosecond).utc
+      bytes = described_class.encode('ts' => time)
+      result = described_class.decode(bytes)
+
+      aggregate_failures do
+        expect(result['ts']).to eq(time)
+        expect(result['ts'].tv_nsec).to eq(123_456_789)
+      end
+    end
+
+    it 'canonicalizes Time round-trip to UTC (timezone-independent on-disk bytes)' do
+      local = Time.utc(2026, 5, 13, 12, 0, 0).getlocal('+05:00')
+      bytes = described_class.encode('ts' => local)
+      result = described_class.decode(bytes)
+
+      aggregate_failures do
+        expect(result['ts']).to be_utc
+        expect(result['ts']).to eq(local)
+      end
+    end
+
+    it 'preserves Symbol values (msgpack default coerces to String)' do
+      bytes = described_class.encode('status' => :passed)
+      result = described_class.decode(bytes)
+
+      aggregate_failures do
+        expect(result['status']).to eq(:passed)
+        expect(result['status']).to be_a(Symbol)
+      end
+    end
+
+    it 'preserves Symbol inside nested Hash + Array' do
+      payload = { 'examples' => { 'ex_1' => { 'status' => :flaky, 'tags' => %i[slow integration] } } }
+      bytes = described_class.encode(payload)
+      result = described_class.decode(bytes)
+
+      aggregate_failures do
+        expect(result['examples']['ex_1']['status']).to eq(:flaky)
+        expect(result['examples']['ex_1']['tags']).to eq(%i[slow integration])
+      end
+    end
+
+    it 'preserves a representative cache payload mixing Time + Symbol values' do
+      payload = representative_cache_payload
+      bytes = described_class.encode(payload)
+
+      expect(described_class.decode(bytes)).to eq(payload)
+    end
+  end
+
+  describe 'on-disk encoding' do
+    it 'emits zlib-deflated msgpack bytes (caller inflates + decodes)' do
+      bytes = described_class.encode('any' => 'payload')
+
+      expect { Zlib::Inflate.inflate(bytes) }.not_to raise_error
+    end
+
+    it 'reports the .msgpack.gz extension for JsonBackend layout' do
+      expect(described_class.extension).to eq('msgpack.gz')
+    end
+  end
+
+  describe '.available?' do
+    it 'is true when the msgpack gem loads cleanly' do
+      expect(described_class.available?).to be(true)
+    end
+  end
+
+  # Helper kept out of the example body so RSpec/ExampleLength does
+  # not flag the realistic-shape regression test. Mirrors a
+  # last_run-style payload with Time started_at + Symbol status.
+  def representative_cache_payload
+    {
+      'run_id' => 'abc123',
+      'recorded_at' => Time.utc(2026, 5, 13, 0, 0, 0),
+      'examples' => {
+        'ex_1' => {
+          'status' => :passed,
+          'execution_result' => {
+            'started_at' => Time.utc(2026, 5, 13, 12, 0, 0),
+            'run_time' => 0.012
+          }
+        }
+      }
+    }
+  end
+end
+# rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
## Summary

Fix the `:msgpack` serializer to handle Ruby `Time` and `Symbol` values losslessly via `MessagePack::Factory` type extensions.

Before:
- Time values crashed (`NoMethodError: undefined method 'to_msgpack' for an instance of Time`).
- Symbol values silently coerced to Strings.
- Users who followed the gem's own 50 MiB warning — which recommends `:msgpack` — bricked their cache on the first run that wrote a Time (RSpec's `execution_result.started_at` is a Time).

After:
- `MessagePack::Factory` with a Time extension (codepoint `0x00`, 12-byte `tv_sec + tv_nsec` little-endian, UTC-canonicalized on decode) and a Symbol extension (codepoint `0x01`, UTF-8 string body).
- Factory memoized per process.
- 50 MiB warning text in `json_backend.rb` keeps its `:msgpack` recommendation — the type extensions make the recommendation accurate.

Closes #182.

## Test plan

- [x] Unit round-trip spec at `spec/storage/serializer/msgpack_spec.rb` covering: String/Integer/nested Hash + Array baselines, Time loss-free round-trip (nanosecond precision, UTC canonicalization), Symbol round-trip at top + nested + Array positions, mixed Time + Symbol representative cache payload, zlib-deflated bytes, `.available?` happy-path.
- [x] Integration spec extension at `spec/storage/json_backend_msgpack_spec.rb` exercising Time + Symbol round-trip through the full `Snapshot` pipeline.
- [x] `bundle exec rspec spec/storage` — 215 examples, 0 failures.
- [x] `task test:unit` — 1901 examples, 0 failures.
- [x] `task test:dogfood` — green.
- [x] `task test:property` — 25 examples, 0 failures.
- [x] `task benchmark:smoke` — `cold_ruby` 0.32s + `warm_noop` 0.29s, both within thresholds.
- [x] `task docs:yard:check` — 100% documented.
- [x] `task security:bundle-audit` — no vulnerabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)