### PR TITLE
fix(cli + docs): doctor probes Gem.loaded_specs; flip to bundle exec rspec-tracer

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -359,10 +359,10 @@ falls back to `:json` automatically.
 
 ## 10. Debug "why did this test re-run?"
 
-Use `bin/rspec-tracer explain <example_id_or_substring>`:
+Use `bundle exec rspec-tracer explain <example_id_or_substring>`:
 
 ```sh
-bin/rspec-tracer explain 'AdminController#create'
+bundle exec rspec-tracer explain 'AdminController#create'
 ```
 
 Prints the example's last-run status, dependency set, and the run-
@@ -378,7 +378,7 @@ rspec-tracer: 1,820 examples · 42 re-run · 1,778 skipped (97% cached)
 by reason: 38 Files changed · 4 Failed previously
 ```
 
-For deeper config-level debugging, `bin/rspec-tracer doctor`
+For deeper config-level debugging, `bundle exec rspec-tracer doctor`
 diagnoses the boot-time state of every contract (SimpleCov load
 order, schema version, remote-cache reachability, AR-schema config).
 

--- a/README.md
+++ b/README.md
@@ -365,19 +365,23 @@ Or override per-run via env: `RSPEC_TRACER_STORAGE=sqlite`.
 
 ## Command-line tools
 
-`bin/rspec-tracer` exposes five sub-commands:
+`rspec-tracer` exposes five sub-commands. Run them via Bundler so the
+gem's executable resolves cleanly without needing `bundle binstubs
+rspec-tracer` first:
 
 ```sh
-bin/rspec-tracer doctor         # diagnose config + environment
-bin/rspec-tracer cache:info     # size, last run, invalidation stats
-bin/rspec-tracer cache:clear    # rm cache dirs
-bin/rspec-tracer report:open    # open the HTML report
-bin/rspec-tracer explain <id>   # why is <example_id> scheduled to (re-)run?
+bundle exec rspec-tracer doctor         # diagnose config + environment
+bundle exec rspec-tracer cache:info     # size, last run, invalidation stats
+bundle exec rspec-tracer cache:clear    # rm cache dirs
+bundle exec rspec-tracer report:open    # open the HTML report
+bundle exec rspec-tracer explain <id>   # why is <example_id> scheduled to (re-)run?
 ```
 
-The CLI is opt-in for local-dev convenience. The
-`rake rspec_tracer:remote_cache:*` tasks remain first-class for CI
-integration — nothing in the CLI replaces them.
+Generated binstubs (`bin/rspec-tracer …`) work too once you've run
+`bundle binstubs rspec-tracer` in your project. The CLI is opt-in for
+local-dev convenience; the `rake rspec_tracer:remote_cache:*` tasks
+remain first-class for CI integration — nothing in the CLI replaces
+them.
 
 ## SimpleCov interop
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -206,8 +206,8 @@ These are additive — your existing config keeps working without them.
 - **`storage_backend :sqlite`** — single-file SQLite database instead
   of the 10-file JSON layout. Faster on cold reads when you have
   >5,000 examples. JRuby falls back to `:json` automatically.
-- **`bin/rspec-tracer`** — opt-in CLI: `bin/rspec-tracer doctor`
-  diagnoses config issues; `bin/rspec-tracer explain <example_id>`
+- **`rspec-tracer` CLI** — opt-in: `bundle exec rspec-tracer doctor`
+  diagnoses config issues; `bundle exec rspec-tracer explain <example_id>`
   answers "why did this test (re-)run?" The rake-task flow remains
   first-class for CI.
 

--- a/lib/rspec_tracer/cli/doctor.rb
+++ b/lib/rspec_tracer/cli/doctor.rb
@@ -109,24 +109,33 @@ module RSpecTracer
         end
       end
 
-      # Internal helper for the tracer pipeline.
-      # @api private
+      # `bundle exec rspec-tracer doctor` runs in its own process via
+      # the gem's `bin/rspec-tracer` binstub, NOT inside the user's
+      # rspec boot — so app code never loads here and a bare
+      # `defined?(::SimpleCov)` check would falsely report "not
+      # loaded" on projects that DO have SimpleCov in their
+      # Gemfile. Probe `Gem.loaded_specs` first to surface the
+      # "installed but not loaded in doctor's process" case
+      # separately from "actually not installed."
       def self.simplecov_check
-        if defined?(::SimpleCov)
-          'OK   SimpleCov:   loaded (interop active)'
-        else
-          'INFO SimpleCov:   not loaded (this is fine; SimpleCov is optional)'
-        end
+        return 'OK   SimpleCov:   loaded (interop active)' if defined?(::SimpleCov)
+
+        spec = Gem.loaded_specs['simplecov']
+        return "INFO SimpleCov:   installed (v#{spec.version}; not loaded in doctor's process)" if spec
+
+        'INFO SimpleCov:   not installed (this is fine; SimpleCov is optional)'
       end
 
-      # Internal helper for the tracer pipeline.
-      # @api private
+      # See {.simplecov_check} for the doctor-runs-in-its-own-
+      # process rationale. Same three-state probe shape: loaded in
+      # this process / installed but not loaded / not installed.
       def self.rails_check
-        if defined?(::Rails::VERSION) && !::Rails::VERSION.nil?
-          "OK   Rails:       #{::Rails::VERSION::STRING}"
-        else
-          'INFO Rails:       not loaded (this is fine for non-Rails projects)'
-        end
+        return "OK   Rails:       #{::Rails::VERSION::STRING}" if defined?(::Rails::VERSION) && !::Rails::VERSION.nil?
+
+        spec = Gem.loaded_specs['rails']
+        return "INFO Rails:       installed (v#{spec.version}; not loaded in doctor's process)" if spec
+
+        'INFO Rails:       not installed (this is fine for non-Rails projects)'
       end
 
       # Surface a 1.x->2.0 cache mismatch BEFORE the user runs

--- a/spec/cli/doctor_spec.rb
+++ b/spec/cli/doctor_spec.rb
@@ -169,26 +169,54 @@ RSpec.describe RSpecTracer::CLI::Doctor do
   end
 
   describe '.simplecov_check / .rails_check' do
-    it 'reports SimpleCov as INFO when not loaded' do
-      hide_const('::SimpleCov')
-      expect(described_class.simplecov_check).to start_with('INFO SimpleCov:')
-    end
-
-    it 'reports SimpleCov as OK when loaded' do
+    it 'reports SimpleCov as OK when loaded in this process' do
       stub_const('::SimpleCov', Module.new)
       expect(described_class.simplecov_check).to start_with('OK   SimpleCov:')
     end
 
-    it 'reports Rails as INFO when not loaded' do
-      hide_const('::Rails')
-      expect(described_class.rails_check).to start_with('INFO Rails:')
+    # Regression for #184: doctor runs in its own process via the
+    # binstub, so a project that DOES have SimpleCov in its Gemfile
+    # but isn't loading it inside doctor's boot used to get a
+    # false "not loaded" line. Probe Gem.loaded_specs first.
+    it 'reports SimpleCov as installed-but-not-loaded when its gem spec is present' do
+      hide_const('::SimpleCov')
+      sim_spec = instance_double(Gem::Specification, version: Gem::Version.new('0.22.0'))
+      allow(Gem.loaded_specs).to receive(:[]).and_call_original
+      allow(Gem.loaded_specs).to receive(:[]).with('simplecov').and_return(sim_spec)
+
+      expect(described_class.simplecov_check).to include('installed (v0.22.0')
     end
 
-    it 'reports Rails version when loaded' do
+    it 'reports SimpleCov as not-installed only when its gem spec is absent' do
+      hide_const('::SimpleCov')
+      allow(Gem.loaded_specs).to receive(:[]).and_call_original
+      allow(Gem.loaded_specs).to receive(:[]).with('simplecov').and_return(nil)
+
+      expect(described_class.simplecov_check).to include('not installed')
+    end
+
+    it 'reports Rails version when loaded in this process' do
       stub_const('::Rails', Module.new)
       stub_const('::Rails::VERSION', Module.new)
       stub_const('::Rails::VERSION::STRING', '8.0.1')
       expect(described_class.rails_check).to include('8.0.1')
+    end
+
+    it 'reports Rails as installed-but-not-loaded when its gem spec is present' do
+      hide_const('::Rails')
+      rails_spec = instance_double(Gem::Specification, version: Gem::Version.new('8.0.1'))
+      allow(Gem.loaded_specs).to receive(:[]).and_call_original
+      allow(Gem.loaded_specs).to receive(:[]).with('rails').and_return(rails_spec)
+
+      expect(described_class.rails_check).to include('installed (v8.0.1')
+    end
+
+    it 'reports Rails as not-installed only when its gem spec is absent' do
+      hide_const('::Rails')
+      allow(Gem.loaded_specs).to receive(:[]).and_call_original
+      allow(Gem.loaded_specs).to receive(:[]).with('rails').and_return(nil)
+
+      expect(described_class.rails_check).to include('not installed')
     end
   end
 end


### PR DESCRIPTION
## Summary

Two related user-trust fixes for the new `rspec-tracer` CLI:

**#184 — `doctor` false-INFO**: `rspec-tracer doctor` runs in its own process via the gem's `bin/rspec-tracer` binstub. App code never loads there, so the previous `defined?(::SimpleCov)` / `defined?(::Rails::VERSION)` probes returned false on every project — emitting "SimpleCov: not loaded" / "Rails: not loaded" even when those gems were in the user's Gemfile. Now also probes `Gem.loaded_specs['simplecov']` / `['rails']` and distinguishes three states:

| State | Probe shape |
|---|---|
| Loaded in this process | `OK   SimpleCov:   loaded (interop active)` |
| Installed but not loaded in doctor's process | `INFO SimpleCov:   installed (v0.22.0; not loaded in doctor's process)` |
| Not installed at all | `INFO SimpleCov:   not installed (this is fine; SimpleCov is optional)` |

Same shape for Rails. Closes #184.

**#185 — README/COOKBOOK/UPGRADING binstub instruction**: documented commands as `bin/rspec-tracer …`, but a fresh user install has no binstub at that path until `bundle binstubs rspec-tracer` is run. Flipped the canonical form to `bundle exec rspec-tracer …` across README §"Command-line tools", COOKBOOK §10, and UPGRADING §"What's new." README explicitly mentions the generated-binstub form still works for users who want it. Closes #185.

## Test plan

- [x] `spec/cli/doctor_spec.rb` — adds three-state probe tests for both `simplecov_check` and `rails_check` (loaded / installed-but-not-loaded / not-installed). 25 examples, 0 failures.
- [x] All `bin/rspec-tracer <sub>` references in user-facing docs flipped to `bundle exec rspec-tracer <sub>`; gem-author / architecture-diagram references in `ARCHITECTURE.md` + `ROADMAP.md` + the new README binstub-alternative paragraph intentionally retain `bin/rspec-tracer …` because they describe the gem's own binstub from the gem-author perspective.
- [x] `task lint:ruby` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)