### PR TITLE
fix(engine): persist correct run_reason on warm runs across all reason paths

### DIFF
--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -154,12 +154,24 @@ module RSpecTracer
       @filtered_examples[example_id] || EXAMPLE_RUN_REASON[:no_cache]
     end
 
-    # Internal method on the tracer pipeline.
+    # Records one example registration into the engine's per-run
+    # state. Overwrites any prior `@all_examples[id]` entry on
+    # purpose: on warm runs, `seed_all_examples_from_previous` seeds
+    # `@all_examples` with the prior snapshot's metadata (including
+    # the prior `:run_reason`), and the RunnerHook's per-example
+    # call here carries this run's freshly-tagged value. Preserving
+    # the seeded entry via `||=` would persist the stale prior
+    # reason and surface "No cache" in `report.json#run_reason` for
+    # examples re-run because they failed / pended / were
+    # interrupted / had files change / had env change. Duplicate
+    # detection is unaffected: duplicates accumulate in
+    # `@duplicate_examples`, and `deregister_duplicate_examples`
+    # drops them from `@all_examples` outright.
     # @api private
     def register_example(example)
       example_id = example[:example_id]
       @registry.register(example_id, metadata: example, identity_hash: example_id)
-      @all_examples[example_id] ||= example
+      @all_examples[example_id] = example
       @duplicate_examples[example_id] ||= []
       @duplicate_examples[example_id] << example
       self

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -972,5 +972,57 @@ RSpec.describe RSpecTracer::Engine do
       expect(file_names).to include('/lib/keep.rb', '/excluded_dir/old.rb')
     end
   end
+
+  # On warm runs, seed_all_examples_from_previous populates @all_examples
+  # with the prior snapshot's metadata (including the prior run_reason).
+  # When the RunnerHook later calls register_example with a freshly-tagged
+  # tracer_example carrying this run's run_reason, register_example must
+  # overwrite the seeded entry; otherwise the persisted snapshot keeps
+  # carrying forward the stale prior reason and `report.json#run_reason`
+  # reads "No cache" for examples re-run because they failed / pended /
+  # were interrupted / had files change / had env change. Confirmed via
+  # field testing across all five reason paths.
+  describe 'register_example overwrites prior-run metadata on warm runs' do
+    let(:previous_snapshot) do
+      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |snap|
+        snap.all_examples = {
+          'ex_failed' => build_example('ex_failed').merge(run_reason: 'No cache')
+        }
+        snap.failed_examples = Set.new(['ex_failed'])
+      end
+    end
+
+    def prime_previous_cache
+      backend = RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
+      backend.save_graph(previous_snapshot, schema_version: 3)
+    end
+
+    it "replaces the seeded run_reason with this run's freshly-tagged value" do
+      prime_previous_cache
+      tracker = build_tracker.tap(&:setup)
+      # Sanity: setup seeded the prior metadata into @all_examples.
+      expect(tracker.all_examples['ex_failed'][:run_reason]).to eq('No cache')
+
+      fresh_example = build_example('ex_failed').merge(run_reason: 'Failed previously')
+      tracker.register_example(fresh_example)
+
+      expect(tracker.all_examples['ex_failed'][:run_reason]).to eq('Failed previously')
+    end
+
+    it 'persists the fresh run_reason through finalize' do
+      prime_previous_cache
+      tracker = build_tracker.tap(&:setup)
+      fresh_example = build_example('ex_failed').merge(run_reason: 'Failed previously')
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+
+      tracker.register_example(fresh_example)
+      tracker.example_started
+      tracker.example_finished('ex_failed')
+      tracker.on_example_passed('ex_failed', build_execution_result(status: :passed))
+      snapshot = tracker.finalize
+
+      expect(snapshot.all_examples['ex_failed'][:run_reason]).to eq('Failed previously')
+    end
+  end
 end
 # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/MultipleMemoizedHelpers

--- a/spec/integration/run_reason_persistence_spec.rb
+++ b/spec/integration/run_reason_persistence_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# End-to-end regression for #186 (and the field-test-2 widened scope):
+# on warm runs, report.json#run_reason must surface the actual reason
+# this run's filter classified the example with (Failed previously /
+# Pending previously / Files changed / Environment changed / Interrupted
+# previously), not the seeded prior-snapshot reason. The fix lives at
+# RSpecTracer::Engine#register_example, which now overwrites the seeded
+# entry in @all_examples instead of preserving it via `||=`.
+#
+# Drives the ruby_app fixture with a temp spec file containing a
+# deliberately failing example. The around block guarantees the temp
+# file is removed even when the test fails partway.
+
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'report.json#run_reason persistence on warm runs' do
+  let(:fixture_root) { File.expand_path('../../benchmark/fixtures/ruby_app', __dir__) }
+  let(:cache_dir)    { File.join(fixture_root, 'rspec_tracer_cache') }
+  let(:report_dir)   { File.join(fixture_root, 'rspec_tracer_report') }
+  let(:coverage_dir) { File.join(fixture_root, 'rspec_tracer_coverage') }
+  let(:temp_spec)    { File.join(fixture_root, 'spec', 'run_reason_regression_spec.rb') }
+
+  around do |example|
+    Bundler.with_unbundled_env do
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+      example.run
+    ensure
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+      FileUtils.rm_f(temp_spec)
+    end
+  end
+
+  def run_rspec
+    Open3.capture2e('bundle', 'exec', 'rspec', '--no-color', chdir: fixture_root)
+  end
+
+  def report_payload
+    JSON.parse(File.read(File.join(report_dir, 'report.json'), encoding: 'UTF-8'))
+  end
+
+  def find_example(description_substring)
+    report_payload['reports']['all_examples'].find do |e|
+      e['description']&.include?(description_substring)
+    end
+  end
+
+  def ensure_bundle_installed!
+    Dir.chdir(fixture_root) do
+      next if system('bundle check > /dev/null 2>&1')
+
+      install_out, install_status = Open3.capture2e('bundle', 'install', '--quiet')
+      raise "bundle install failed in #{fixture_root}:\n#{install_out}" unless install_status.success?
+    end
+  end
+
+  before { ensure_bundle_installed! }
+
+  it "tags 'Failed previously' on the warm re-run of a deliberately failing example" do
+    File.write(temp_spec, <<~RUBY)
+      RSpec.describe 'run_reason regression fixture' do
+        it 'deliberately fails to exercise the failed_example reason path' do
+          expect(true).to be(false)
+        end
+      end
+    RUBY
+
+    # Cold run: example is new — Filter classifies it as :no_cache.
+    _, cold_status = run_rspec
+    expect(cold_status.exitstatus).not_to eq(0), 'cold run should fail (deliberately)'
+    cold_example = find_example('deliberately fails to exercise')
+    expect(cold_example).not_to be_nil
+    expect(cold_example['run_reason']).to eq('No cache')
+
+    # Warm run: same spec file (digest unchanged); the failing example
+    # is in failed_examples from the prev snapshot, so Filter classifies
+    # it as :failed_example. Before the fix, the seeded "No cache" from
+    # @all_examples leaked through unchanged.
+    _, warm_status = run_rspec
+    expect(warm_status.exitstatus).not_to eq(0), 'warm run should still fail (same example)'
+    warm_example = find_example('deliberately fails to exercise')
+    expect(warm_example).not_to be_nil
+    expect(warm_example['run_reason']).to eq('Failed previously')
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength


### PR DESCRIPTION
## Summary

`Engine#register_example` preserved seeded prior-snapshot metadata via `||=`, so on warm runs the prior run's `run_reason` (typically `"No cache"` from the cold first run) leaked through unchanged into the persisted snapshot. `report.json#run_reason` then read `"No cache"` for examples re-run because they failed previously / pended previously / had files change / had env change / were interrupted — even though the engine's `Filter` classified each correctly and the `RunnerHook` tagged the fresh `tracer_example` with the right reason.

Trace of the broken warm-run path on `main`:

1. `setup` → `seed_state_from_previous` seeds `@all_examples[id]` with the prior snapshot's metadata (including the prior `:run_reason`).
2. `compute_filter_decisions` populates `@filtered_examples[id]` with the correct value (e.g. `"Failed previously"`).
3. `RunnerHook` ([runner_hook.rb:126](https://github.com/avmnu-sng/rspec-tracer/blob/main/lib/rspec_tracer/rspec/runner_hook.rb#L126)) sets `tracer_example[:run_reason] = engine.run_example_reason(id)` — correct here.
4. `RunnerHook` ([runner_hook.rb:132](https://github.com/avmnu-sng/rspec-tracer/blob/main/lib/rspec_tracer/rspec/runner_hook.rb#L132)) calls `engine.register_example(tracer_example)`.
5. `register_example`: `@all_examples[example_id] ||= example` is a NO-OP because `@all_examples[id]` is already the seeded prior meta. The new run_reason is discarded.
6. `finalize` → `build_snapshot` persists the stale `"No cache"` value.

The fix is one character at [engine.rb:162](https://github.com/avmnu-sng/rspec-tracer/blob/main/lib/rspec_tracer/engine.rb#L162): `||=` becomes `=`. The new `tracer_example` overwrites the seeded prior-run entry, so the `run_reason` set by `RunnerHook` persists through `finalize`. Same single write site closes the broader scope — all five reason paths (failed_example / pending_example / interrupted / files_changed / env_changed) route through this one `register_example` call.

Duplicate detection is unaffected: duplicates accumulate in `@duplicate_examples`, and `deregister_duplicate_examples` drops them from `@all_examples` outright.

## New coverage

- **`spec/engine_spec.rb`** — new `'register_example overwrites prior-run metadata on warm runs'` describe with two cases. The first asserts that calling `register_example` with a freshly-tagged `tracer_example` replaces the seeded prior `:run_reason`; the second drives the full `setup → register → example_started → example_finished → on_example_passed → finalize` lifecycle and asserts the persisted snapshot carries the fresh value.
- **`spec/integration/run_reason_persistence_spec.rb`** (new) — exercises the full cold-then-warm cycle against the `ruby_app` fixture with an injected deliberately-failing example. Asserts `report.json#run_reason == "Failed previously"` on the warm re-run. The `around` block guarantees temp-spec cleanup even on test failure.

Closes #186.

## Test plan

- [x] `task lint:ruby` (only pre-existing `Gemspec/RequireMFA` warning on `rspec-tracer.gemspec:7`, not introduced here)
- [x] `task lint:actions`, `task lint:yaml`, `task check:bundle`
- [x] `task security:bundle-audit`
- [x] `task test:unit` (1937 examples, 0 failures)
- [x] `task test:property` (rantly, 0 failures)
- [x] `task test:dogfood`
- [x] `task test:mutation:smoke` (Tracker::EnvMatcher 93.18%)
- [x] `task test:mutation:rspec` (RunnerHook + ReporterHook + Installation + ParallelTests + Metadata — 100% on ReporterHook reported; all 5 gates passed)
- [x] `task benchmark:smoke` (within ratchet)
- [x] `task docs:yard:check` (100%)
- [x] New unit test verified red pre-fix (`got: "No cache"`), green post-fix (`got: "Failed previously"`)
- [x] New integration spec passes end-to-end against the `ruby_app` fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)