### PR TITLE
fix(remote_cache): gate reports_s3_path probe + emit INFO on download/upload/prune_all

### DIFF
--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -554,6 +554,25 @@ module RSpecTracer
       @reports_s3_path = path if valid_s3_path?(path)
     end
 
+    # Probe-path predicate. True when the user explicitly set
+    # `reports_s3_path` via the DSL OR the `RSPEC_TRACER_REPORTS_S3_PATH`
+    # environment variable. Distinct from {#reports_s3_path} (the
+    # getter), which fires a one-time deprecation warning on every
+    # call from an unconfigured state — including the
+    # `RemoteCache::UserTasks#derive_from_legacy_dsl` probe that runs
+    # whenever any `rake rspec_tracer:remote_cache:*` task fires.
+    # Callers that need to detect whether the legacy DSL was actually
+    # used (vs probing) should read this predicate first.
+    #
+    # @return [Boolean]
+    def reports_s3_path_set?
+      return true if defined?(@reports_s3_path) && @reports_s3_path
+      return false unless ENV.key?('RSPEC_TRACER_REPORTS_S3_PATH')
+
+      env_value = ENV.fetch('RSPEC_TRACER_REPORTS_S3_PATH', nil)
+      !env_value.nil? && !env_value.empty?
+    end
+
     # Deprecated in 2.0. Migration: `remote_cache_backend :s3, ...,
     # local: true`. Kept for backward compat; UserTasks derives the
     # `local:` opt from this when `remote_cache_backend` is absent.

--- a/lib/rspec_tracer/remote_cache/user_tasks.rb
+++ b/lib/rspec_tracer/remote_cache/user_tasks.rb
@@ -117,9 +117,12 @@ module RSpecTracer
         end
 
         tree_sha = head_tree_sha
-        refs.each do |ref|
+        refs.each do |ref, origin|
           @logger.debug "rspec-tracer remote_cache: trying ref #{ref}"
-          return true if backend.download(ref, tree_sha: tree_sha)
+          next unless backend.download(ref, tree_sha: tree_sha)
+
+          log_download_success(ref, origin, ancestry)
+          return true
         end
 
         @logger.warn 'rspec-tracer remote_cache: no suitable cache found; cold run'
@@ -148,6 +151,7 @@ module RSpecTracer
         backend = build_backend(ancestry)
 
         backend.upload(ancestry.branch_ref, tree_sha: head_tree_sha)
+        @logger.info "rspec-tracer remote_cache: uploaded cache to #{ancestry.branch_ref}"
         maybe_update_branch_refs(backend, ancestry)
         maybe_prune(backend, ancestry)
         maybe_warn_unbounded(backend)
@@ -174,7 +178,7 @@ module RSpecTracer
 
         backend = build_backend(build_admin_ancestry)
         removed = backend.prune_all!(pr_branch_ttl_seconds: ttl)
-        @logger.debug "rspec-tracer remote_cache: prune_all removed #{removed} refs"
+        @logger.info "rspec-tracer remote_cache: prune_all removed #{removed} refs"
         removed
       rescue StandardError => e
         @logger.warn "rspec-tracer remote_cache: prune_all failed (#{e.class}: #{e.message})"
@@ -235,9 +239,15 @@ module RSpecTracer
         derive_from_legacy_dsl
       end
 
-      # Internal method on the tracer pipeline.
+      # Probe the legacy `reports_s3_path` DSL when no explicit
+      # `remote_cache_backend` is configured. Gated on
+      # {Configuration#reports_s3_path_set?} so the deprecation
+      # warning fires only when the user actually set the DSL or its
+      # env var — never on the probe path when neither is configured.
       # @api private
       def derive_from_legacy_dsl
+        return nil unless safe_config(:reports_s3_path_set?)
+
         s3_uri = safe_config(:reports_s3_path)
         return nil if s3_uri.nil? || s3_uri.to_s.empty?
 
@@ -285,13 +295,42 @@ module RSpecTracer
         runtime.merge(user_opts)
       end
 
-      # Internal method on the tracer pipeline.
+      # Returns a timestamp-sorted (newest first) list of
+      # `[ref, origin]` tuples where origin is `:branch` (PR-tier
+      # branch_refs upload) or `:ancestry` (commit-ancestry fallback,
+      # which on PR builds means a cross-branch hit on the
+      # default-branch tier). Same merge order as before — on PR
+      # builds branch_refs come first, ancestry refs second; on
+      # collision ancestry wins, so the origin reflects the winning
+      # source. The info-log shape in {#download!} reads the origin
+      # tag to qualify cross-branch fallback hits in the INFO line.
       # @api private
       def candidate_refs(ancestry, backend)
         refs = {}
-        refs.merge!(backend.branch_refs(ancestry.branch_name)) if ancestry.pr_build?
-        refs.merge!(ancestry.ancestry_refs)
-        refs.sort_by { |_, ts| -ts }.map(&:first)
+        origins = {}
+        if ancestry.pr_build?
+          backend.branch_refs(ancestry.branch_name).each do |sha, ts|
+            refs[sha] = ts
+            origins[sha] = :branch
+          end
+        end
+        ancestry.ancestry_refs.each do |sha, ts|
+          refs[sha] = ts
+          origins[sha] = :ancestry
+        end
+        refs.sort_by { |_, ts| -ts }.map { |sha, _| [sha, origins[sha]] }
+      end
+
+      # Emit an INFO log line on a successful download. Distinguishes
+      # PR-tier branch_refs hits ("restored cache from <ref>") from
+      # ancestry-fallback hits on PR builds, which get the explicit
+      # "(cross-branch fallback)" qualifier so the user can tell at
+      # a glance whether the PR-tier cache existed or whether the
+      # restore traversed the default branch.
+      # @api private
+      def log_download_success(ref, origin, ancestry)
+        qualifier = origin == :ancestry && ancestry.pr_build? ? ' (cross-branch fallback)' : ''
+        @logger.info "rspec-tracer remote_cache: restored cache from #{ref}#{qualifier}"
       end
 
       # Internal method on the tracer pipeline.

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1008,6 +1008,36 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
+  describe '#reports_s3_path_set? (probe-path predicate)' do
+    it 'returns false when neither the DSL nor the env var is set' do
+      stub_const('ENV', ENV.to_hash.except('RSPEC_TRACER_REPORTS_S3_PATH'))
+
+      expect(config.reports_s3_path_set?).to be(false)
+    end
+
+    it 'returns true after the DSL set a valid s3:// URI' do
+      allow(config.logger).to receive(:warn)
+      config.reports_s3_path('s3://bucket/prefix')
+
+      expect(config.reports_s3_path_set?).to be(true)
+    end
+
+    it 'returns true when only the env var is set (no DSL call yet)' do
+      stub_const('ENV', ENV.to_hash.merge('RSPEC_TRACER_REPORTS_S3_PATH' => 's3://env-bucket/env-prefix'))
+
+      expect(config.reports_s3_path_set?).to be(true)
+    end
+
+    it 'does not emit a deprecation warning when probed' do
+      stub_const('ENV', ENV.to_hash.except('RSPEC_TRACER_REPORTS_S3_PATH'))
+      allow(config.logger).to receive(:warn)
+
+      config.reports_s3_path_set?
+
+      expect(config.logger).not_to have_received(:warn)
+    end
+  end
+
   describe '#use_local_aws (deprecated)' do
     it 'still stores a boolean' do
       allow(config.logger).to receive(:warn)

--- a/spec/remote_cache/user_tasks_spec.rb
+++ b/spec/remote_cache/user_tasks_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       cache_path: cache_path,
       remote_cache_backend_entry: nil,
       reports_s3_path: nil,
+      reports_s3_path_set?: false,
       use_local_aws: false,
       upload_non_ci_reports: false,
       cache_retention_count: nil,
@@ -269,6 +270,80 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       _ = ancestry
     end
 
+    it 'emits an INFO log line naming the ref on a successful main-tier download' do
+      config = build_config(remote_cache_backend_entry: backend_entry)
+      stub_ancestry(branch: 'main', default_branch: 'main', ancestry_refs: { 'main-sha' => 100 })
+      allow(fake_backend_class).to receive(:new).and_wrap_original do |original, **opts|
+        instance = original.call(**opts)
+        instance.stub_downloads('main-sha' => true)
+      end
+
+      described_class.new(configuration: config, env: build_env).download!
+
+      info_messages = captured_logs.select { |(level, _)| level == :info }.map(&:last)
+      expect(info_messages).to include('rspec-tracer remote_cache: restored cache from main-sha')
+    end
+
+    it 'qualifies the INFO log with "(cross-branch fallback)" when a PR build hits an ancestry ref' do
+      config = build_config(remote_cache_backend_entry: backend_entry)
+      # PR build with NO branch_refs (so a hit goes through the ancestry path).
+      stub_ancestry(branch: 'feat', default_branch: 'main', ancestry_refs: { 'main-sha' => 100 })
+      allow(fake_backend_class).to receive(:new).and_wrap_original do |original, **opts|
+        instance = original.call(**opts)
+        instance.stub_branch_refs({}).stub_downloads('main-sha' => true)
+      end
+
+      described_class.new(configuration: config, env: build_env(branch: 'feat')).download!
+
+      info_messages = captured_logs.select { |(level, _)| level == :info }.map(&:last)
+      expect(info_messages).to include(
+        'rspec-tracer remote_cache: restored cache from main-sha (cross-branch fallback)'
+      )
+    end
+
+    it 'omits the cross-branch qualifier when a PR build hits its own branch_refs' do
+      config = build_config(remote_cache_backend_entry: backend_entry)
+      stub_ancestry(branch: 'feat', default_branch: 'main', ancestry_refs: { 'anc1' => 100 })
+      allow(fake_backend_class).to receive(:new).and_wrap_original do |original, **opts|
+        instance = original.call(**opts)
+        # br1 has the newest ts so it's tried first and hits — PR-tier (branch_refs) origin.
+        instance.stub_branch_refs('br1' => 200).stub_downloads('br1' => true)
+      end
+
+      described_class.new(configuration: config, env: build_env(branch: 'feat')).download!
+
+      info_messages = captured_logs.select { |(level, _)| level == :info }.map(&:last)
+      expect(info_messages).to include('rspec-tracer remote_cache: restored cache from br1')
+      expect(info_messages).not_to(include(a_string_including('cross-branch fallback')))
+    end
+
+    it 'does not probe the deprecated reports_s3_path when reports_s3_path_set? is false' do
+      config = build_config(remote_cache_backend_entry: nil, reports_s3_path_set?: false)
+      stub_ancestry
+
+      described_class.new(configuration: config, env: build_env).download!
+
+      expect(config).not_to have_received(:reports_s3_path)
+    end
+
+    it 'returns nil from the legacy probe when the getter yields a nil/empty value' do
+      # Edge case: reports_s3_path_set? returns true (env was set), but the
+      # getter returns nil (the env value failed valid_s3_path? in Configuration
+      # and never populated @reports_s3_path). The probe defensively bails out.
+      config = build_config(
+        remote_cache_backend_entry: nil,
+        reports_s3_path: nil,
+        reports_s3_path_set?: true
+      )
+      stub_ancestry
+
+      result = described_class.new(configuration: config, env: build_env).download!
+
+      expect(result).to be(false)
+      warns = captured_logs.select { |(level, _)| level == :warn }.map(&:last)
+      expect(warns).to include(a_string_including('no remote_cache_backend configured'))
+    end
+
     it 'merges branch_refs with ancestry on PR builds' do
       config = build_config(remote_cache_backend_entry: backend_entry)
       stub_ancestry(branch: 'feat', default_branch: 'main', ancestry_refs: { 'anc1' => 100 })
@@ -289,6 +364,7 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       config = build_config(
         remote_cache_backend_entry: nil,
         reports_s3_path: 's3://legacy-bucket/legacy-prefix',
+        reports_s3_path_set?: true,
         use_local_aws: true
       )
       stub_ancestry(ancestry_refs: { 'sha1' => 100 })
@@ -305,7 +381,8 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
     it 'rejects a legacy reports_s3_path with a non-s3 scheme (returns nil → unconfigured)' do
       config = build_config(
         remote_cache_backend_entry: nil,
-        reports_s3_path: 'http://example.com/cache'
+        reports_s3_path: 'http://example.com/cache',
+        reports_s3_path_set?: true
       )
       stub_ancestry
 
@@ -340,6 +417,16 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       backend = fake_backend_class.all_instances.last
       expect(backend.calls[:upload]).to eq(['main-sha'])
       expect(backend.calls[:write_branch_refs]).to be_empty
+    end
+
+    it 'emits an INFO log line naming the ref on successful upload' do
+      config = build_config(remote_cache_backend_entry: backend_entry)
+      stub_ancestry(branch: 'main', default_branch: 'main', branch_ref: 'main-sha')
+
+      described_class.new(configuration: config, env: build_env).upload!
+
+      info_messages = captured_logs.select { |(level, _)| level == :info }.map(&:last)
+      expect(info_messages).to include('rspec-tracer remote_cache: uploaded cache to main-sha')
     end
 
     it 'uploads and updates branch_refs on pr tier' do
@@ -655,6 +742,19 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
       allow_any_instance_of(fake_backend_class).to receive(:prune_all!).and_return(5) # rubocop:disable RSpec/AnyInstance
 
       expect(tasks.prune_all!).to eq(5)
+    end
+
+    it 'emits an INFO log line with the removed count on a successful run' do
+      config = build_config(remote_cache_backend_entry: backend_entry,
+                            cache_retention_pr_branch_ttl_seconds: 7200)
+      stub_ancestry
+      tasks = described_class.new(configuration: config, env: build_env)
+      allow_any_instance_of(fake_backend_class).to receive(:prune_all!).and_return(3) # rubocop:disable RSpec/AnyInstance
+
+      tasks.prune_all!
+
+      info_messages = captured_logs.select { |(level, _)| level == :info }.map(&:last)
+      expect(info_messages).to include('rspec-tracer remote_cache: prune_all removed 3 refs')
     end
 
     it 'returns 0 and logs on StandardError from the backend' do


### PR DESCRIPTION
## Summary

Two related fixes for the user-facing `rspec_tracer:remote_cache:*` rake tasks.

### `reports_s3_path` deprecation false positive

`RemoteCache::UserTasks#derive_from_legacy_dsl` unconditionally called `safe_config(:reports_s3_path)`, which routes through `Configuration#reports_s3_path` — the deprecated getter that fires `warn_once_deprecation` on every uninitialized read. Users running `bundle exec rake rspec_tracer:remote_cache:download` **without** either `remote_cache_backend` / `remote_cache_uri` set saw a deprecation warning about a DSL they never used, on top of the genuine `no remote_cache_backend configured` failure message.

Adds `Configuration#reports_s3_path_set?` — a non-warning predicate returning true when the user set the DSL via Ruby OR via `RSPEC_TRACER_REPORTS_S3_PATH`. Gates `derive_from_legacy_dsl` on it: the probe returns `nil` without ever calling the getter when the user is not using the deprecated config. The warning still fires on legitimate use (DSL call or env var set) — deprecation semantics preserved.

### Silent success on `download!` / `upload!` / `prune_all!`

The success path on each was silent at the default log level — only the `debug`-level `trying ref X` / `pruned N refs` lines emitted. A successful `rake rspec_tracer:remote_cache:download` produced zero output, and users couldn't tell whether the cache came from their branch, fell back to the default-branch tier, or whether the run was cold. Same gap for upload and prune_all (the latter is the cron-driven cross-tier admin task).

Three new `@logger.info` lines:

- **`download!`**: `restored cache from <ref>` on every successful download. PR builds that hit an ancestry ref (rather than their own `branch_refs`) get an explicit ` (cross-branch fallback)` qualifier — users see at a glance whether the PR-tier cache existed or whether the restore traversed the default branch. Implementation refactors `candidate_refs` to return `[ref, origin]` tuples (`:branch` for PR-tier `branch_refs`, `:ancestry` for ancestry-fallback). One fix covers s3 / redis / file backends — they share this orchestrator.
- **`upload!`**: `uploaded cache to <ref>` after the backend's upload returns successfully.
- **`prune_all!`**: flips the existing `@logger.debug` line to `info` so the cron / workflow operator sees the prune count in standard logs.

The per-upload `maybe_prune` debug stays as-is — the upload INFO line already announces the upload; per-tier retention pruning is incidental detail.

Closes #187.
Closes #188.

## Test plan

- [x] `task lint:ruby` (only pre-existing `Gemspec/RequireMFA` warning on `rspec-tracer.gemspec:7`)
- [x] `task lint:actions`, `task lint:yaml`, `task check:bundle`, `task security:bundle-audit`
- [x] `task test:unit` (1945 examples, 0 failures)
- [x] `task test:property`, `task test:dogfood`, `task benchmark:smoke`, `task docs:yard:check` (100%)
- [x] `task test:mutation:smoke` (`Tracker::EnvMatcher` 93.18%)
- [x] `task test:mutation:remote-cache` — passes all 8 subjects (final `S3Backend` 72.02% above 65% gate)
- [x] Targeted `mutant run 'RSpecTracer::RemoteCache::UserTasks*'` — 81.72% above the carve-out gate
- [x] New tests verified red pre-fix on the probe predicate, green post-fix
- [x] User-tasks branch coverage hits 100% post these tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)