### PR TITLE
docs(rails-engine): cover lib/ boot-set behavior + dummy-app sub-rspec summaries

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -111,6 +111,50 @@ recover per-example precision, set `config.eager_load = false` in
 `config/environments/test.rb`. See README "How it works" for the
 full rationale.
 
+### Rails engines: `lib/` always lands in the boot set
+
+A gem-loaded engine's own `lib/` files are `require`d at gem load
+time (via the Gemfile.lock cascade) and land in the boot set
+**regardless of `eager_load`**. Editing any `lib/<engine_name>/...`
+file re-runs every example in the engine's spec suite. This is
+**safe** (never misses a dep) but **coarser** than per-example
+attribution. The behavior is deliberate: it closes the
+constants-lookup blind spot that pure coverage-diff tracking
+misses (an example that references a constant defined in a loaded
+file produces no coverage delta against that file, even though the
+example depends on it).
+
+If your engine's `lib/`-edit cycle is bottlenecked by whole-suite
+re-runs and you've audited that your suite doesn't exercise the
+constants-lookup pattern, opt out with:
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  transitive_load_tracking false
+end
+```
+
+Trade-off: this restores 1.x's pure coverage-diff behavior. The
+constants-lookup blind spot returns — an example that only
+references a constant from a loaded file (without exercising any
+of its lines) will not be tagged as depending on that file, so
+editing the file may not re-run the example. Most suites are
+unaffected (any line execution against the file already attributes
+the dep correctly); audit yours before flipping. The 2.1
+`track_class_attribution` work will close this gap more precisely.
+
+### Sub-rspec summaries (engine + dummy-app)
+
+If your engine fixture does sub-process rspec invocations — e.g.,
+acceptance specs that `chdir` into a generated dummy app and run
+a nested `rspec` — you'll see two rspec summary totals in the
+same `bundle exec rspec` invocation (one from the inner sub-rspec,
+one from the outer). rspec-tracer tracks the **outer** process
+and is the authoritative example count for your cache; the inner
+summary belongs to the dummy-app sub-process and is not visible
+to the tracer.
+
 ---
 
 ## 3. Migrate a 1.x project to 2.0

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ eager-loaded test environments — see
 [`CHANGELOG.md`](CHANGELOG.md) "Deferred to 2.1" for the planned
 contract.
 
+**Rails engines:** a gem-loaded engine's own `lib/` files are
+`require`d at gem-load time via the Gemfile.lock cascade and land
+in the boot set **regardless of `eager_load`**. Editing them
+re-runs every example — same SAFE-but-coarser shape as the
+`eager_load = true` case above. The rationale (closing the
+constants-lookup blind spot) lives in
+[`lib/rspec_tracer/tracker/loaded_files_tracker.rb`](lib/rspec_tracer/tracker/loaded_files_tracker.rb).
+Teams that want tighter per-example precision and accept the blind
+spot can set `transitive_load_tracking false` — see
+[`COOKBOOK.md`](COOKBOOK.md) recipe 2 for the trade-off.
+
 ## Per-example `tracks:` DSL
 
 Annotate any describe / context / example with extra inputs the

--- a/lib/rspec_tracer/reporters/html/package.json
+++ b/lib/rspec_tracer/reporters/html/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "description": "Frontend bundle for RSpec-Tracer's HTML reporter (M6.2). Built output is committed to dist/; users never run npm.",
+  "description": "Frontend bundle for RSpec-Tracer's HTML reporter. Built output is committed to dist/; users never run npm.",
   "scripts": {
     "build": "vite build",
     "dev": "vite",


### PR DESCRIPTION
## Summary

Three docs / surface-hygiene additions surfaced during the field-test pass.

### README per-example-precision section

Adds a **Rails engines** paragraph at the end of the existing "Per-example precision under Rails `config.eager_load`" section. An engine's own `lib/` files are `require`d at gem-load time via the Gemfile.lock cascade and land in the boot set **regardless of `eager_load`**, so editing them re-runs every example. Same SAFE-but-coarser shape as the `eager_load = true` Rails-app case; the rationale (closing the constants-lookup blind spot) lives in `Tracker::LoadedFilesTracker`. Points readers at `transitive_load_tracking false` for the opt-out.

Closes #189.

### COOKBOOK recipe 2 sub-sections

Two new sub-sections under "Add to an existing Rails app":

1. **Rails engines: `lib/` always lands in the boot set** — concrete `.rspec-tracer` snippet showing the `transitive_load_tracking false` opt-out, plus audit guidance (most suites don't exercise the constants-lookup pattern; verify yours first; the 2.1 `track_class_attribution` work will close the gap more precisely).
2. **Sub-rspec summaries (engine + dummy-app)** — one-paragraph explainer for engine fixtures that do nested `bundle exec rspec` invocations against a generated dummy app (e.g. `clearance`'s `spec/acceptance/clearance_installation_spec.rb` pattern). rspec-tracer tracks the outer process; the inner summary belongs to the dummy-app sub-process and is invisible to the tracer.

Closes #190.

### `package.json` description hygiene

Strips a stale internal milestone-ID reference from `lib/rspec_tracer/reporters/html/package.json`'s `description` field. Self-descriptive for npm-time consumers who happen to inspect the bundled frontend's metadata.

## Test plan

- [x] `task lint:ruby` (no offenses in `lib/` + `spec/`; pre-existing gemspec warning unchanged)
- [x] `task test:unit` (1934 examples, 0 failures — docs-only change doesn't affect tests)
- [x] `task docs:yard:check` (100% documented)
- [x] `ruby -rjson -e 'JSON.parse(...)'` against the modified `package.json` — valid
- [x] `git ls-files ... | xargs grep -nE "M[0-9]+\\.[0-9]+|docs/revamp"` returns zero matches post-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)