### PR TITLE
fix(engine): late-bind Rails observer install when Rails loads after RSpecTracer.start

### DIFF
--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -451,11 +451,39 @@ module RSpecTracer
 
     # Install the Rails-observer family (ActionView notifications +
     # I18n backend prepend) when Rails is detected in the process.
-    # Runs at setup time so the subscribers are attached before the
-    # first example fires. Errors here never propagate - the tracer
-    # gracefully degrades to IOHooks-only behavior.
+    # Errors here never propagate - the tracer gracefully degrades to
+    # IOHooks-only behavior.
+    #
+    # Two-mode dispatch handles the canonical README setup order
+    # (RSpecTracer.start BEFORE `require_relative '../config/environment'`,
+    # so Rails is not yet loaded at engine.setup time):
+    #
+    # - **Eager** (Rails already loaded): install subscribers + arm the
+    #   AR-schema warn directly.
+    # - **Late-bind** (Rails not yet loaded): register a `before(:suite)`
+    #   hook that re-checks `defined?(::Rails::VERSION)` after Rails has
+    #   loaded (typically via the user's `rails_helper.rb` requiring
+    #   `config/environment` later in the boot chain). The hook installs
+    #   subscribers + the inline AR-schema warn at suite time.
+    #
+    # Without the late-bind path, `track_ar_schema_notifications` was
+    # silently inert under the canonical README setup -- the documented
+    # `use_transactional_fixtures` warn never fired and the
+    # `sql.active_record` subscriber never attached.
     def install_rails_observers
-      return unless @configuration.rails?
+      if @configuration.rails?
+        do_install_rails_observers
+        arm_ar_schema_setup_warn if ar_schema_notifications_enabled?
+      else
+        arm_rails_late_bind_install
+      end
+    end
+
+    # Subscriber-install body. Idempotent via `@rails_observers_installed`
+    # so a re-call (e.g. eager path then late-bind firing on a slow Rails
+    # load) is a no-op. Shared between the eager and late-bind paths.
+    def do_install_rails_observers
+      return if rails_observers_installed?
 
       require_relative 'rails/notifications'
       require_relative 'rails/i18n_tracking'
@@ -471,14 +499,46 @@ module RSpecTracer
         root: @configuration.root, filter: filter
       )
 
-      arm_ar_schema_setup_warn if ar_schema_notifications_enabled?
-
       @rails_observers_installed = true
     rescue StandardError => e
       @configuration.logger.warn(
         "rspec-tracer: Rails observer install failed (#{e.class}: #{e.message})"
       )
       @rails_observers_installed = false
+    end
+
+    # Late-bind: at engine.setup `defined?(::Rails::VERSION)` was false,
+    # so register a `before(:suite)` hook that re-checks Rails-loaded
+    # state at suite time. By that point the user's `rails_helper.rb`
+    # has typically required `config/environment` and Rails IS loaded.
+    # Installs subscribers + inline-fires the AR-schema warn so the
+    # documented behavior holds end-to-end under the canonical README
+    # setup order. No-op when Rails still hasn't loaded by suite start.
+    def arm_rails_late_bind_install
+      return unless defined?(::RSpec) && ::RSpec.respond_to?(:configure)
+
+      engine = self
+      ::RSpec.configure do |config|
+        config.before(:suite) { engine.send(:rails_late_bind_install_hook) }
+      end
+    rescue StandardError => e
+      @configuration.logger.warn(
+        "rspec-tracer: rails late-bind install failed (#{e.class}: #{e.message})"
+      )
+    end
+
+    # Body of the late-bind `before(:suite)` hook. Extracted so the
+    # registration shape stays flat and the per-fire logic is testable
+    # without invoking RSpec's suite machinery.
+    def rails_late_bind_install_hook
+      return unless defined?(::Rails::VERSION) && !::Rails::VERSION.nil?
+      return if rails_observers_installed?
+
+      do_install_rails_observers
+      return unless rails_observers_installed?
+      return unless ar_schema_notifications_enabled?
+
+      emit_ar_schema_setup_warn_if_needed
     end
 
     # `track_ar_schema_notifications` promises per-example attribution
@@ -494,33 +554,46 @@ module RSpecTracer
     #   - DatabaseCleaner :truncation / :deletion / :transaction in
     #     around hooks: same outcome.
     #
-    # Defer the check to before(:suite): at engine.setup the user has
-    # not run their RSpec.configure block yet, so
-    # `use_transactional_fixtures` is unset.
+    # Eager path: defer the check to before(:suite) -- at engine.setup
+    # the user has not run their RSpec.configure block yet, so
+    # `use_transactional_fixtures` is unset. The late-bind path
+    # short-circuits this method and inline-fires
+    # `emit_ar_schema_setup_warn_if_needed` from inside its own
+    # before(:suite) hook (no nested registration).
     def arm_ar_schema_setup_warn
       return unless defined?(::RSpec) && ::RSpec.respond_to?(:configure)
 
-      logger = @configuration.logger
+      engine = self
       ::RSpec.configure do |config|
         config.before(:suite) do
-          next unless ::RSpec.configuration.respond_to?(:use_transactional_fixtures)
-          next if ::RSpec.configuration.use_transactional_fixtures == false
-
-          logger.warn(
-            'rspec-tracer: track_ar_schema_notifications is enabled but ' \
-            'use_transactional_fixtures defaults to true; per-example ' \
-            'BEGIN/COMMIT fires sql.active_record so db/schema.rb gets ' \
-            'attributed to every AR-touching example (safe, but widens ' \
-            'invalidation). For narrow attribution, set ' \
-            'use_transactional_fixtures = false and use sequence-based ' \
-            'factories (or another non-AR cleanup mechanism). See ' \
-            'README section "Narrow AR-schema attribution".'
-          )
+          engine.send(:emit_ar_schema_setup_warn_if_needed)
         end
       end
     rescue StandardError => e
       @configuration.logger.warn(
         "rspec-tracer: ar-schema warn install failed (#{e.class}: #{e.message})"
+      )
+    end
+
+    # Inline check for the AR-schema attribution-widening precondition.
+    # Reused by `arm_ar_schema_setup_warn` (registered from engine.setup
+    # under the eager path) and `arm_rails_late_bind_install` (fired
+    # from inside its own before(:suite) hook). The shared helper
+    # avoids registering a nested before(:suite) under the late-bind
+    # path, which is unsafe across RSpec versions.
+    def emit_ar_schema_setup_warn_if_needed
+      return unless ::RSpec.configuration.respond_to?(:use_transactional_fixtures)
+      return if ::RSpec.configuration.use_transactional_fixtures == false
+
+      @configuration.logger.warn(
+        'rspec-tracer: track_ar_schema_notifications is enabled but ' \
+        'use_transactional_fixtures defaults to true; per-example ' \
+        'BEGIN/COMMIT fires sql.active_record so db/schema.rb gets ' \
+        'attributed to every AR-touching example (safe, but widens ' \
+        'invalidation). For narrow attribution, set ' \
+        'use_transactional_fixtures = false and use sequence-based ' \
+        'factories (or another non-AR cleanup mechanism). See ' \
+        'README section "Narrow AR-schema attribution".'
       )
     end
 

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -876,6 +876,154 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
+  # Late-bind path (#192): when the user follows the canonical
+  # README setup order -- RSpecTracer.start before
+  # `require_relative '../config/environment'` -- Rails is not yet
+  # loaded at engine.setup time. arm_rails_late_bind_install
+  # registers a before(:suite) hook that re-checks
+  # defined?(::Rails::VERSION) once Rails has had a chance to load,
+  # then installs subscribers + emits the AR-schema warn inline.
+  # Without this, track_ar_schema_notifications was silently inert
+  # under the documented setup order.
+  describe 'Rails late-bind when rails? is false at setup' do
+    let(:captured_suite_blocks) { [] }
+    let(:fake_rspec_config) do
+      blocks = captured_suite_blocks
+      cfg = Object.new
+      cfg.define_singleton_method(:before) do |scope, &block|
+        blocks << block if scope == :suite
+      end
+      cfg
+    end
+
+    let(:fake_as_notifications) do
+      Class.new do
+        def initialize
+          @subscribers = {}
+        end
+
+        def subscribe(event_name, &block)
+          handle = Object.new
+          (@subscribers[event_name] ||= {})[handle] = block
+          handle
+        end
+
+        def unsubscribe(handle)
+          @subscribers.each_value { |blocks| blocks.delete(handle) }
+        end
+
+        attr_reader :subscribers
+      end.new
+    end
+
+    before do
+      allow(RSpec).to receive(:configure).and_yield(fake_rspec_config)
+      stub_const('ActiveSupport', Module.new)
+      stub_const('ActiveSupport::Notifications', fake_as_notifications)
+    end
+
+    after do
+      if defined?(RSpecTracer::Rails::Notifications) && RSpecTracer::Rails::Notifications.installed?
+        RSpecTracer::Rails::Notifications.uninstall
+      end
+      if defined?(RSpecTracer::Rails::I18nTracking) && RSpecTracer::Rails::I18nTracking.installed?
+        RSpecTracer::Rails::I18nTracking.uninstall
+      end
+    end
+
+    it 'registers a before(:suite) hook instead of installing eagerly' do
+      build_tracker(stub_configuration(rails?: false)).tap(&:setup)
+
+      expect(captured_suite_blocks.size).to eq(1)
+      expect(
+        defined?(RSpecTracer::Rails::Notifications) &&
+          RSpecTracer::Rails::Notifications.installed?
+      ).to be_falsey
+    end
+
+    it 'installs Rails observers when the hook fires after Rails has loaded' do
+      tracker = build_tracker(stub_configuration(rails?: false)).tap(&:setup)
+      hook = captured_suite_blocks.first
+
+      stub_const('Rails', Module.new) unless defined?(Rails)
+      stub_const('Rails::VERSION', Module.new)
+      stub_const('Rails::VERSION::STRING', '7.2.3.1')
+
+      hook.call
+
+      expect(RSpecTracer::Rails::Notifications).to be_installed
+      expect(tracker.send(:rails_observers_installed?)).to be(true)
+    end
+
+    it 'is a no-op when Rails still has not loaded by suite-start time' do
+      build_tracker(stub_configuration(rails?: false)).tap(&:setup)
+      hook = captured_suite_blocks.first
+      # Intentionally do NOT stub Rails::VERSION -- the hook fires
+      # before Rails was ever required (rare but possible in pure-Ruby
+      # suites that opt into track_ar_schema_notifications by mistake).
+      hide_const('Rails::VERSION') if defined?(Rails::VERSION)
+
+      hook.call
+
+      expect(
+        defined?(RSpecTracer::Rails::Notifications) &&
+          RSpecTracer::Rails::Notifications.installed?
+      ).to be_falsey
+    end
+
+    it 'fires the AR-schema warn inline when track_ar_schema_notifications is enabled' do
+      configuration = stub_configuration(rails?: false, track_ar_schema_notifications?: true)
+      tracker = build_tracker(configuration).tap(&:setup)
+      hook = captured_suite_blocks.first
+
+      stub_const('Rails', Module.new) unless defined?(Rails)
+      stub_const('Rails::VERSION', Module.new)
+      stub_const('Rails::VERSION::STRING', '7.2.3.1')
+      allow(RSpec.configuration).to receive_messages(respond_to?: true, use_transactional_fixtures: true)
+
+      hook.call
+
+      expect(logger).to have_received(:warn).with(
+        a_string_including('track_ar_schema_notifications is enabled')
+          .and(a_string_including('use_transactional_fixtures defaults to true'))
+      )
+      _ = tracker
+    end
+
+    it 'does not fire the AR-schema warn when use_transactional_fixtures is false' do
+      configuration = stub_configuration(rails?: false, track_ar_schema_notifications?: true)
+      build_tracker(configuration).tap(&:setup)
+      hook = captured_suite_blocks.first
+
+      stub_const('Rails', Module.new) unless defined?(Rails)
+      stub_const('Rails::VERSION', Module.new)
+      stub_const('Rails::VERSION::STRING', '7.2.3.1')
+      allow(RSpec.configuration).to receive_messages(respond_to?: true, use_transactional_fixtures: false)
+
+      hook.call
+
+      expect(logger).not_to have_received(:warn).with(
+        a_string_including('use_transactional_fixtures defaults to true')
+      )
+    end
+
+    it 'is idempotent: re-firing the hook after a successful install does not double-install' do
+      build_tracker(stub_configuration(rails?: false)).tap(&:setup)
+      hook = captured_suite_blocks.first
+
+      stub_const('Rails', Module.new) unless defined?(Rails)
+      stub_const('Rails::VERSION', Module.new)
+      stub_const('Rails::VERSION::STRING', '7.2.3.1')
+
+      hook.call
+      installed_first = RSpecTracer::Rails::Notifications.installed?
+      expect { hook.call }.not_to raise_error
+      installed_second = RSpecTracer::Rails::Notifications.installed?
+
+      expect([installed_first, installed_second]).to eq([true, true])
+    end
+  end
+
   # M8.0 acceptance criterion #4: per-example hot path invokes
   # ::Coverage.peek_result exactly twice (once at example_started for
   # the baseline, once at example_finished for the diff). The legacy

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -1022,6 +1022,87 @@ RSpec.describe RSpecTracer::Engine do
 
       expect([installed_first, installed_second]).to eq([true, true])
     end
+
+    it 'rescues StandardError raised by RSpec.configure during the late-bind install' do
+      allow(RSpec).to receive(:configure).and_raise(StandardError, 'rspec wedge')
+
+      expect { build_tracker(stub_configuration(rails?: false)).tap(&:setup) }.not_to raise_error
+      expect(logger).to have_received(:warn).with(a_string_including('rails late-bind install failed'))
+    end
+  end
+
+  # Eager-path arm_ar_schema_setup_warn registers a `before(:suite)`
+  # hook that fires `emit_ar_schema_setup_warn_if_needed` at suite-
+  # start time. The captured-block pattern from the late-bind tests
+  # exercises the registered hook body so the body-line and the
+  # graceful-degradation rescue both have coverage.
+  describe 'arm_ar_schema_setup_warn (eager path) hook body + rescue' do
+    let(:captured_suite_blocks) { [] }
+    let(:fake_rspec_config) do
+      blocks = captured_suite_blocks
+      cfg = Object.new
+      cfg.define_singleton_method(:before) do |scope, &block|
+        blocks << block if scope == :suite
+      end
+      cfg
+    end
+
+    let(:fake_as_notifications) do
+      Class.new do
+        def initialize
+          @subscribers = {}
+        end
+
+        def subscribe(event_name, &block)
+          handle = Object.new
+          (@subscribers[event_name] ||= {})[handle] = block
+          handle
+        end
+
+        def unsubscribe(handle)
+          @subscribers.each_value { |blocks| blocks.delete(handle) }
+        end
+      end.new
+    end
+
+    before do
+      stub_const('ActiveSupport', Module.new)
+      stub_const('ActiveSupport::Notifications', fake_as_notifications)
+      stub_const('Rails', Module.new) unless defined?(Rails)
+      stub_const('Rails::VERSION', Module.new)
+      stub_const('Rails::VERSION::STRING', '7.2.3.1')
+    end
+
+    after do
+      if defined?(RSpecTracer::Rails::Notifications) && RSpecTracer::Rails::Notifications.installed?
+        RSpecTracer::Rails::Notifications.uninstall
+      end
+      if defined?(RSpecTracer::Rails::I18nTracking) && RSpecTracer::Rails::I18nTracking.installed?
+        RSpecTracer::Rails::I18nTracking.uninstall
+      end
+    end
+
+    it 'fires emit_ar_schema_setup_warn_if_needed when the registered hook runs' do
+      allow(RSpec).to receive(:configure).and_yield(fake_rspec_config)
+      configuration = stub_configuration(rails?: true, track_ar_schema_notifications?: true)
+      build_tracker(configuration).tap(&:setup)
+      hook = captured_suite_blocks.first
+      allow(RSpec.configuration).to receive_messages(respond_to?: true, use_transactional_fixtures: true)
+
+      hook.call
+
+      expect(logger).to have_received(:warn).with(
+        a_string_including('use_transactional_fixtures defaults to true')
+      )
+    end
+
+    it 'rescues StandardError raised by RSpec.configure during the warn install' do
+      allow(RSpec).to receive(:configure).and_raise(StandardError, 'rspec wedge')
+      configuration = stub_configuration(rails?: true, track_ar_schema_notifications?: true)
+
+      expect { build_tracker(configuration).tap(&:setup) }.not_to raise_error
+      expect(logger).to have_received(:warn).with(a_string_including('ar-schema warn install failed'))
+    end
   end
 
   # M8.0 acceptance criterion #4: per-example hot path invokes


### PR DESCRIPTION
## Summary

Under the canonical README setup order — `RSpecTracer.start` **before** `require_relative '../config/environment'` (the Coverage-friendly order that puts coverage hooks in place before Rails loads its own files) — `defined?(::Rails::VERSION)` returned false at engine.setup time. `setup_rails` cached `@rails = false`, the configuration's `rails?` predicate stayed false forever in the process, and `install_rails_observers` short-circuited at its first line.

Result: the `sql.active_record` subscriber never attached, **and** `arm_ar_schema_setup_warn`'s documented `use_transactional_fixtures` warn never fired — both promises of `track_ar_schema_notifications` silently broken on the documented setup path.

## The fix

Refactor `install_rails_observers` into a two-mode dispatch:

- **Eager path** (Rails already loaded at engine.setup): `do_install_rails_observers` attaches subscribers immediately; `arm_ar_schema_setup_warn` defers the `use_transactional_fixtures` check to `before(:suite)` (Rails-side config has not run yet at engine.setup).
- **Late-bind path** (Rails not yet loaded at engine.setup): `arm_rails_late_bind_install` registers a `before(:suite)` hook that fires after `rails_helper.rb` has had a chance to require `config/environment`. The hook re-checks `defined?(::Rails::VERSION)`, calls `do_install_rails_observers` if Rails IS now loaded, and inline-fires `emit_ar_schema_setup_warn_if_needed` when `track_ar_schema_notifications` is enabled.

Three invariants worth calling out:

1. `do_install_rails_observers` is idempotent via `@rails_observers_installed`. A re-call (eager path + a spurious late-bind fire) is a no-op.
2. The shared `emit_ar_schema_setup_warn_if_needed` helper is used by both paths. The eager path defers it via `arm_ar_schema_setup_warn`'s `before(:suite)` registration (user's `RSpec.configure` has not run at engine.setup). The late-bind path calls it inline (already inside `before(:suite)`; registering a nested `before(:suite)` is unsafe across RSpec versions).
3. The late-bind hook is a no-op when Rails **still** has not loaded by suite-start time. Conservative on a per-fire basis — avoids forcing the user to require rspec-tracer after Rails.

Closes #192.

## Test coverage

`spec/engine_spec.rb` gains a `'Rails late-bind when rails? is false at setup'` describe (6 cases) that captures the registered `before(:suite)` block via a stubbed `RSpec.configure`, then invokes it under different stubbed Rails-loaded states:

- registers a `before(:suite)` hook instead of installing eagerly
- installs Rails observers when the hook fires after Rails loads
- is a no-op when Rails still has not loaded by suite-start
- fires the AR-schema warn inline when `track_ar_schema_notifications` is enabled + `use_transactional_fixtures` defaults to true
- does NOT fire the warn when `use_transactional_fixtures` is false
- is idempotent: re-firing the hook does not double-install

The existing `'Rails observer wiring'` describe (6 cases) keeps passing post-refactor — the eager path's external behavior is unchanged.

## Test plan

- [x] `task lint:ruby` (no offenses in `lib/` + `spec/`; pre-existing gemspec warning unchanged)
- [x] `task lint:actions`, `task lint:yaml`, `task check:bundle`, `task security:bundle-audit`
- [x] `task test:unit` (1940 examples, 0 failures)
- [x] `task test:property` (25 examples, 0 failures), `task test:dogfood` (1 example, 0 failures)
- [x] `task benchmark:smoke` (cold_ruby 0.68x / warm_noop 0.74x of threshold)
- [x] `task docs:yard:check` (100% documented)
- [x] `task test:mutation:smoke` (Tracker::EnvMatcher 93.18%)
- [x] `task test:mutation:rspec` (engine.rb path-gated; 100% on ReporterHook, all 5 subjects PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)