### PR TITLE
feat(cli): accept --force / -f as a synonym for --yes / -y on cache:clear

### DIFF
--- a/lib/rspec_tracer/cli/cache_clear.rb
+++ b/lib/rspec_tracer/cli/cache_clear.rb
@@ -23,14 +23,26 @@ module RSpecTracer
         return nothing_to_remove(stdout) if existing.empty?
 
         announce(stdout, existing)
-        force = args.include?('--yes') || args.include?('-y')
-        return aborted(stdout) unless force || confirm?(stdout)
+        return aborted(stdout) unless skip_confirmation?(args) || confirm?(stdout)
 
         remove_each(stdout, existing)
         0
       rescue StandardError => e
         stderr.puts "cache:clear: #{e.class}: #{e.message}"
         1
+      end
+
+      # Returns true when any of the documented skip-confirmation
+      # flags is present. `--yes` / `-y` is the canonical form;
+      # `--force` / `-f` is the Unix-conventional synonym accepted
+      # so users' muscle memory works. Either form skips the
+      # interactive `Proceed? [y/N]` prompt.
+      # @api private
+      SKIP_CONFIRMATION_FLAGS = %w[--yes -y --force -f].freeze
+
+      # @api private
+      def self.skip_confirmation?(args)
+        args.any? { |arg| SKIP_CONFIRMATION_FLAGS.include?(arg) }
       end
 
       # Internal helper for the tracer pipeline.
@@ -83,13 +95,14 @@ module RSpecTracer
       # @api private
       def self.print_help(stdout)
         stdout.puts <<~HELP
-          Usage: rspec-tracer cache:clear [--yes]
+          Usage: rspec-tracer cache:clear [--yes | --force]
 
           Remove cache, coverage, and report directories. The next rspec
           run will be a cold run (full re-execution + cache rebuild).
 
           Options:
-            -y, --yes   Skip the confirmation prompt.
+            -y, --yes     Skip the confirmation prompt.
+            -f, --force   Synonym for --yes.
         HELP
         0
       end

--- a/spec/cli/cache_clear_spec.rb
+++ b/spec/cli/cache_clear_spec.rb
@@ -47,6 +47,32 @@ RSpec.describe RSpecTracer::CLI::CacheClear do
       end
     end
 
+    it 'accepts every documented skip-confirmation flag form' do
+      %w[--yes -y --force -f].each do |flag|
+        Dir.mktmpdir do |dir|
+          cache = File.join(dir, 'cache')
+          coverage = File.join(dir, 'coverage')
+          report = File.join(dir, 'report')
+          [cache, coverage, report].each { |p| FileUtils.mkdir_p(p) }
+          allow(RSpecTracer).to receive_messages(
+            cache_path: cache, coverage_path: coverage, report_path: report
+          )
+          out = StringIO.new
+
+          message = "flag #{flag.inspect} should skip the prompt"
+          expect(described_class.run([flag], stdout: out, stderr: stderr)).to eq(0), message
+          expect(File.directory?(cache)).to be(false), "flag #{flag.inspect} should remove cache"
+        end
+      end
+    end
+
+    it 'documents both --yes and --force in the help output' do
+      out = StringIO.new
+      described_class.run(['--help'], stdout: out, stderr: stderr)
+
+      expect(out.string).to include('--yes').and(include('--force'))
+    end
+
     it 'aborts when user declines the confirmation prompt' do
       Dir.mktmpdir do |dir|
         cache = File.join(dir, 'cache')


### PR DESCRIPTION
## Summary

Users following standard Unix CLI conventions reached for `rspec-tracer cache:clear --force` (and `-f`) and got silently dropped back to the interactive `Proceed? [y/N]` prompt — the flag was ignored, no actionable error, no documentation pointing at the canonical `--yes`.

Extend the skip-confirmation flag set to include both forms. Extract a `SKIP_CONFIRMATION_FLAGS` constant + a `skip_confirmation?(args)` helper so the matched flag set is visible at one site and the disjunction stays a single Array membership check.

`print_help` documents both forms (`--yes` stays the canonical spelling; `--force` is documented as the synonym).

Closes #191.

## Test coverage

- **`accepts every documented skip-confirmation flag form`** — iterates `[--yes, -y, --force, -f]` and asserts each one skips the prompt + removes the cache directories. Per-iteration failure messages identify which flag broke if a future regression slips through.
- **`documents both --yes and --force in the help output`** — guards against the `print_help` text drifting silently.

## Test plan

- [x] `task lint:ruby` (no offenses in `lib/` + `spec/`)
- [x] `task test:unit` (1936 examples, 0 failures)
- [x] `task test:mutation:smoke` (`Tracker::EnvMatcher` 93.18% PASS)
- [x] `task benchmark:smoke` (cold_ruby 0.77x, warm_noop 0.78x of threshold)
- [x] `task docs:yard:check` (100% — `Methods: 340`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)