### PR TITLE
fix(storage): merge filtered_examples by id then re-tally cache_hit_reason

### DIFF
--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -975,7 +975,8 @@ module RSpecTracer
         wsi_snapshot: @whole_suite_invalidators.digest_snapshot,
         env_snapshot: env_snapshot_for_persistence,
         env_dependency: env_dependency_for_persistence,
-        cache_hit_reason: @filtered_examples.values.tally
+        cache_hit_reason: @filtered_examples.values.tally,
+        filtered_examples: @filtered_examples
       )
     end
 

--- a/lib/rspec_tracer/storage/json_backend.rb
+++ b/lib/rspec_tracer/storage/json_backend.rb
@@ -91,6 +91,7 @@ module RSpecTracer
         env_snapshot.json
         env_dependency.json
         cache_hit_reason.json
+        filtered_examples.json
       ].freeze
 
       # Internal constant.
@@ -126,6 +127,7 @@ module RSpecTracer
         env_snapshot
         env_dependency
         cache_hit_reason
+        filtered_examples
       ].freeze
 
       # Binds a backend + run directory so `LazySnapshot` readers
@@ -161,6 +163,7 @@ module RSpecTracer
       HASH_FIELDS = %w[
         all_examples duplicate_examples all_files examples_coverage
         boot_set wsi_snapshot env_snapshot env_dependency cache_hit_reason
+        filtered_examples
       ].freeze
       # Internal constant.
       # @api private
@@ -193,7 +196,8 @@ module RSpecTracer
         wsi_snapshot: :plain_hash,
         env_snapshot: :plain_hash,
         env_dependency: :plain_hash,
-        cache_hit_reason: :plain_hash
+        cache_hit_reason: :plain_hash,
+        filtered_examples: :plain_hash
       }.freeze
 
       # Internal attribute.
@@ -392,7 +396,14 @@ module RSpecTracer
 
           state[:reverse_dependency] = reverse_of(state[:dependency])
           state[:run_id] = Digest::MD5.hexdigest(state[:all_examples].keys.sort.to_json)
+          state[:cache_hit_reason] = state[:filtered_examples].values.tally
 
+          build_merged_snapshot(state, schema_version: schema_version)
+        end
+
+        # Internal helper for the tracer pipeline.
+        # @api private
+        def self.build_merged_snapshot(state, schema_version:)
           Snapshot.new(
             schema_version: schema_version,
             run_id: state[:run_id],
@@ -411,7 +422,8 @@ module RSpecTracer
             wsi_snapshot: state[:wsi_snapshot],
             env_snapshot: state[:env_snapshot],
             env_dependency: state[:env_dependency],
-            cache_hit_reason: state[:cache_hit_reason]
+            cache_hit_reason: state[:cache_hit_reason],
+            filtered_examples: state[:filtered_examples]
           )
         end
 
@@ -433,7 +445,7 @@ module RSpecTracer
             wsi_snapshot: {},
             env_snapshot: {},
             env_dependency: {},
-            cache_hit_reason: Hash.new(0)
+            filtered_examples: {}
           }
         end
 
@@ -462,7 +474,7 @@ module RSpecTracer
           state[:wsi_snapshot].merge!(snapshot.wsi_snapshot || {})
           state[:env_snapshot].merge!(snapshot.env_snapshot || {})
           merge_env_dependency!(state[:env_dependency], snapshot.env_dependency || {})
-          merge_cache_hit_reason!(state[:cache_hit_reason], snapshot.cache_hit_reason || {})
+          merge_filtered_examples!(state[:filtered_examples], snapshot.filtered_examples || {})
         end
         # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
@@ -477,14 +489,20 @@ module RSpecTracer
           end
         end
 
-        # Sum per-worker reason counts. parallel_tests partitions
-        # examples across workers; each worker's filtered_examples
-        # tally is disjoint by example_id, so sum is the right combine
-        # rule (a "Files changed" count from worker A plus the same
-        # reason's count from worker B = total examples that ran for
-        # that reason across the suite).
-        def self.merge_cache_hit_reason!(target, source)
-          source.each { |reason, count| target[reason] += count }
+        # Merge per-worker filtered_examples by example_id. Every
+        # parallel_tests worker independently runs Filter.select
+        # against the same global previous-run snapshot
+        # (Engine#compute_filter_decisions walks the registry seeded
+        # from `prev` and the filter intersects against
+        # `prev.all_examples.keys`), so every worker's filtered_examples
+        # hash is IDENTICAL. First-write-wins collapses the duplicate
+        # ids; `Merger.call` re-derives `cache_hit_reason` as the
+        # values-tally of the merged hash so the merged
+        # cache_hit_reason is the per-id-correct count (not the
+        # N-fold-inflated sum of identical per-worker tallies that
+        # the pre-#193 merge produced).
+        def self.merge_filtered_examples!(target, source)
+          source.each { |id, reason| target[id] ||= reason }
         end
 
         # Internal helper for the tracer pipeline.

--- a/lib/rspec_tracer/storage/snapshot.rb
+++ b/lib/rspec_tracer/storage/snapshot.rb
@@ -71,6 +71,18 @@ module RSpecTracer
     # require a meta-table column / schema bump); SqliteBackend users
     # see the field as `{}` on read until a future enhancement
     # extends the meta table.
+    #
+    # `filtered_examples` is the PER-EXAMPLE source-of-truth that
+    # backs `cache_hit_reason`: a Hash[example_id => reason_string]
+    # ("ex_abc" => "Failed previously"). The engine writes this at
+    # finalize; `cache_hit_reason` is the values-tally. Persisting
+    # both lets the parallel-tests merge collapse per-worker
+    # duplicates by id (every worker computes the same hash because
+    # the filter walks the global previous-run snapshot) and re-tally
+    # at merge time, instead of sum-merging identical per-worker
+    # tallies and inflating counts N-fold. Same optional-in-JSON
+    # treatment as cache_hit_reason: missing file coerces to `{}`,
+    # no schema_version bump, JSON-backend-only surface.
     Snapshot = Struct.new(
       :schema_version,
       :run_id,
@@ -90,6 +102,7 @@ module RSpecTracer
       :env_snapshot,
       :env_dependency,
       :cache_hit_reason,
+      :filtered_examples,
       keyword_init: true
     )
 
@@ -119,7 +132,8 @@ module RSpecTracer
           wsi_snapshot: {},
           env_snapshot: {},
           env_dependency: {},
-          cache_hit_reason: {}
+          cache_hit_reason: {},
+          filtered_examples: {}
         )
       end
     end

--- a/lib/rspec_tracer/storage/sqlite_backend.rb
+++ b/lib/rspec_tracer/storage/sqlite_backend.rb
@@ -107,7 +107,8 @@ module RSpecTracer
       # DB. Kept in step with Snapshot.members minus the envelope.
       READABLE_FIELDS = (
         %i[all_examples duplicate_examples all_files dependency
-           reverse_dependency examples_coverage env_dependency cache_hit_reason] +
+           reverse_dependency examples_coverage env_dependency cache_hit_reason
+           filtered_examples] +
           STATUS_FIELDS.keys + DIGEST_MAP_KINDS.keys
       ).freeze
 
@@ -532,10 +533,16 @@ module RSpecTracer
         when :reverse_dependency then read_reverse_dependency(db)
         when :examples_coverage then read_examples_coverage(db)
         when :env_dependency    then read_env_dependency(db)
-        when :cache_hit_reason  then {} # JSON-backend-only surface; sqlite no-op
-        # ^^ SqliteBackend does not persist the cache_hit_reason aggregate; future
-        # enhancement may add a meta-table column. Empty default mirrors the
-        # missing-file-coerces-to-{} contract used by JsonBackend's per-field reads.
+        when :cache_hit_reason, :filtered_examples
+          # JSON-backend-only surfaces; sqlite no-op. SqliteBackend
+          # does not persist these aggregates (would require meta-
+          # table columns / schema bump). SqliteBackend also has no
+          # parallel-tests peer-merge path (M5.1 / M5.5 are
+          # JsonBackend-only), so the per-id filtered_examples that
+          # backs cache_hit_reason isn't needed either. Empty default
+          # mirrors the missing-file-coerces-to-{} contract used by
+          # JsonBackend's per-field reads.
+          {}
         else                    dispatch_read_grouped(db, field)
         end
       end

--- a/spec/storage/json_backend_spec.rb
+++ b/spec/storage/json_backend_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       wsi_snapshot: { 'Gemfile.lock' => 'feedc0de', '.ruby-version' => 'b16b00b5' },
       env_snapshot: { 'API_KEY' => 'facade1', 'ROLE_CONFIG' => 'baadf00d' },
       env_dependency: { 'ex1' => ['API_KEY'], 'ex2' => %w[ROLE_CONFIG API_KEY] },
-      cache_hit_reason: { 'Files changed' => 3, 'No cache' => 1 }
+      cache_hit_reason: { 'Files changed' => 3, 'No cache' => 1 },
+      filtered_examples: { 'ex1' => 'Files changed', 'ex2' => 'No cache' }
     )
   end
 
@@ -57,7 +58,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(described_class::FILENAMES).to be_frozen
     end
 
-    it 'lists exactly the 16 per-run files (cache_hit_reason added alongside the existing 15)' do
+    it 'lists exactly the 17 per-run files (filtered_examples added alongside the existing 16)' do
       expect(described_class::FILENAMES).to eq(expected_filenames)
     end
 
@@ -68,7 +69,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
         pending_examples.json skipped_examples.json
         all_files.json dependency.json reverse_dependency.json examples_coverage.json
         boot_set.json wsi_snapshot.json env_snapshot.json env_dependency.json
-        cache_hit_reason.json
+        cache_hit_reason.json filtered_examples.json
       ]
     end
   end
@@ -103,6 +104,39 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
 
       expect(loaded.cache_hit_reason).to eq({})
+    end
+  end
+
+  describe 'filtered_examples round-trip' do
+    it 'persists and reloads the per-example reason hash' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.filtered_examples).to eq('ex1' => 'Files changed', 'ex2' => 'No cache')
+    end
+
+    it 'writes filtered_examples.json with a plain Hash[example_id => reason_string] body' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'filtered_examples.json')
+
+      expect(JSON.parse(File.read(path))).to eq('ex1' => 'Files changed', 'ex2' => 'No cache')
+    end
+
+    it 'coerces a missing filtered_examples.json to {} (load tolerant of pre-#193 caches)' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      File.delete(File.join(cache_path, sample_snapshot.run_id, 'filtered_examples.json'))
+      loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.filtered_examples).to eq({})
+    end
+
+    it 'tolerates a malformed filtered_examples.json (returns {})' do
+      backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
+      path = File.join(cache_path, sample_snapshot.run_id, 'filtered_examples.json')
+      File.binwrite(path, "\x00 garbage".b)
+      loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
+
+      expect(loaded.filtered_examples).to eq({})
     end
   end
 
@@ -789,7 +823,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
   end
   # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations, RSpec/ExampleLength
 
-  # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations
+  # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations, RSpec/ExampleLength
   describe RSpecTracer::Storage::JsonBackend::Merger do
     let(:schema) { RSpecTracer::Storage::Schema::CURRENT }
 
@@ -824,6 +858,65 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
 
       expect(merged.duplicate_examples['ex']).to eq([{ a: 1 }, { a: 2 }])
     end
+
+    # Regression: every parallel_tests worker independently runs
+    # Filter.select against the SAME global previous-run snapshot,
+    # producing IDENTICAL @filtered_examples hashes — failed /
+    # pending / interrupted ids are seeded from the same `prev`
+    # snapshot on every worker. Pre-fix merge sum-merged the
+    # per-worker cache_hit_reason tallies, inflating counts by N
+    # workers for any always-re-run bucket (issue #193's 3-worker
+    # / 2-failed = 6-reported reproduction).
+    it 'collapses identical per-worker filtered_examples by id then re-tallies (issue #193)' do
+      filtered = { 'ex_F1' => 'Failed previously', 'ex_F2' => 'Failed previously' }
+      tally = { 'Failed previously' => 2 }
+      peer = lambda do |run_id|
+        make_snapshot(run_id: run_id, filtered_examples: filtered, cache_hit_reason: tally)
+      end
+
+      merged = described_class.call([peer.call('p1'), peer.call('p2'), peer.call('p3')], schema_version: schema)
+
+      expect(merged.filtered_examples).to eq(filtered)
+      expect(merged.cache_hit_reason).to eq('Failed previously' => 2)
+    end
+
+    it 'preserves disjoint filtered_examples ids across workers (files_changed case)' do
+      s1 = make_snapshot(
+        run_id: 'p1',
+        filtered_examples: { 'ex_A' => 'Files changed', 'ex_B' => 'Files changed' }
+      )
+      s2 = make_snapshot(
+        run_id: 'p2',
+        filtered_examples: { 'ex_C' => 'Files changed' }
+      )
+
+      merged = described_class.call([s1, s2], schema_version: schema)
+
+      expect(merged.filtered_examples).to eq(
+        'ex_A' => 'Files changed', 'ex_B' => 'Files changed', 'ex_C' => 'Files changed'
+      )
+      expect(merged.cache_hit_reason).to eq('Files changed' => 3)
+    end
+
+    it 'first-write-wins on conflicting reasons (defensive; workers should agree)' do
+      s1 = make_snapshot(run_id: 'p1', filtered_examples: { 'ex' => 'Failed previously' })
+      s2 = make_snapshot(run_id: 'p2', filtered_examples: { 'ex' => 'Files changed' })
+
+      merged = described_class.call([s1, s2], schema_version: schema)
+
+      expect(merged.filtered_examples).to eq('ex' => 'Failed previously')
+      expect(merged.cache_hit_reason).to eq('Failed previously' => 1)
+    end
+
+    it 'derives an empty cache_hit_reason when no peer reports filtered_examples' do
+      s1 = make_snapshot(run_id: 'p1')
+      s2 = make_snapshot(run_id: 'p2')
+
+      merged = described_class.call([s1, s2], schema_version: schema)
+
+      expect(merged.filtered_examples).to eq({})
+      expect(merged.cache_hit_reason).to eq({})
+    end
   end
-  # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations
+  # rubocop:enable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations, RSpec/ExampleLength
 end

--- a/spec/storage/lazy_snapshot_spec.rb
+++ b/spec/storage/lazy_snapshot_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe RSpecTracer::Storage::LazySnapshot do
       wsi_snapshot: {},
       env_snapshot: {},
       env_dependency: {},
-      cache_hit_reason: {}
+      cache_hit_reason: {},
+      filtered_examples: {}
     }
   end
 

--- a/spec/storage/sqlite_backend_spec.rb
+++ b/spec/storage/sqlite_backend_spec.rb
@@ -165,6 +165,14 @@ RSpec.describe RSpecTracer::Storage::SqliteBackend do
       expect(backend.read_field(:examples_coverage))
         .to eq('ex1' => { '/a.rb' => { 0 => 1, 2 => 2 } })
     end
+
+    it 'returns an empty Hash for the JSON-backend-only cache_hit_reason field' do
+      expect(backend.read_field(:cache_hit_reason)).to eq({})
+    end
+
+    it 'returns an empty Hash for the JSON-backend-only filtered_examples field' do
+      expect(backend.read_field(:filtered_examples)).to eq({})
+    end
   end
 
   describe 'save is full-replace per run' do

--- a/taskfiles/test-mutation.yml
+++ b/taskfiles/test-mutation.yml
@@ -577,10 +577,12 @@ tasks:
 
   test:mutation:storage:json-backend-shard-9:
     desc: >-
-      M8.6 JsonBackend shard 9 of 9 — Merger.call (1 subject).
-      Split out from shard-8; Merger.call is the entry point that
-      orchestrates the merge across multiple peer caches and is the
-      densest single subject in JsonBackend.
+      JsonBackend shard 9 of 9 — Merger.call + Merger.build_merged_snapshot
+      (2 subjects). Merger.call orchestrates the merge across peer caches
+      and re-derives cache_hit_reason from the merged filtered_examples
+      values-tally per the #193 fix; build_merged_snapshot was extracted
+      from call to keep the orchestration method under the AbcSize cap.
+      Split out from shard-8; both are entry-point density.
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -593,7 +595,8 @@ tasks:
         out=$(bundle exec mutant run --use rspec --usage opensource \
           --jobs 8 \
           --include lib --require rspec_tracer/storage/json_backend \
-          "RSpecTracer::Storage::JsonBackend::Merger.call" 2>&1 || true)
+          "RSpecTracer::Storage::JsonBackend::Merger.call" \
+          "RSpecTracer::Storage::JsonBackend::Merger.build_merged_snapshot" 2>&1 || true)
         echo "$out"
         cov=$(echo "$out" | awk '/^Coverage:/ { gsub(/%/, "", $2); print $2 }' | tail -1)
         if [ -z "$cov" ]; then
@@ -609,9 +612,16 @@ tasks:
 
   test:mutation:storage:json-backend-shard-6:
     desc: >-
-      M8.6 JsonBackend shard 6 of 6 — Merger second half (4 subjects):
+      JsonBackend shard 6 of 6 — Merger second half (5 subjects):
       Merger.empty_state, Merger.merge_env_dependency!,
-      Merger.merge_examples_coverage!, Merger.reverse_of. Split out
+      Merger.merge_examples_coverage!, Merger.merge_filtered_examples!,
+      Merger.reverse_of. merge_filtered_examples! added in the #193
+      parallel-merge fix (each parallel_tests worker computes identical
+      filtered_examples hashes because the filter walks the global
+      previous-run snapshot; first-write-wins collapses duplicate ids
+      so Merger.call's re-derive of cache_hit_reason from
+      filtered_examples.values.tally produces correct totals, not the
+      N-fold inflated sum of identical per-worker tallies). Split out
       from shard-5 to enforce the per-shard step cap (4-min when
       decided, 5-min after M8.6-B's bump).
     env:
@@ -629,6 +639,7 @@ tasks:
           "RSpecTracer::Storage::JsonBackend::Merger.empty_state" \
           "RSpecTracer::Storage::JsonBackend::Merger.merge_env_dependency!" \
           "RSpecTracer::Storage::JsonBackend::Merger.merge_examples_coverage!" \
+          "RSpecTracer::Storage::JsonBackend::Merger.merge_filtered_examples!" \
           "RSpecTracer::Storage::JsonBackend::Merger.reverse_of" 2>&1 || true)
         echo "$out"
         cov=$(echo "$out" | awk '/^Coverage:/ { gsub(/%/, "", $2); print $2 }' | tail -1)


### PR DESCRIPTION
## Summary

Closes [#193](https://github.com/avmnu-sng/rspec-tracer/issues/193).

Under `parallel_tests` / `parallel_rspec`, the terminal-reporter "by reason:" line and the merged `report.json` `cache_hit_reason` field are inflated by a factor of N (workers) for any reason backed by the always-re-run filter buckets (failed_previously, pending_previously, interrupted_previously). Each worker independently runs `Filter.select` against the same global previous-run snapshot, producing identical `@filtered_examples` hashes -- failed / pending / interrupted ids seeded from `prev` are the same on every worker, and `add_new_examples` / `add_files_changed` intersect against the global `all_example_ids` without scoping to the worker's slice either. The previous `merge_cache_hit_reason!` sum-merged identical per-worker tallies, multiplying counts by N.

Reproduction from the issue:

```sh
bundle exec parallel_rspec spec/clearance -n 3   # cold (2 examples fail)
bundle exec parallel_rspec spec/clearance -n 3   # warm
# Warm output: "by reason: 6 Failed previously"  -- should be 2, not 6 (= 2 * 3 workers)
```

## Fix

Persist `@filtered_examples` (Hash[example_id => reason_string], the per-example backing for `cache_hit_reason`) per-worker. At merge time, union by example_id (first-write-wins; every worker computes the same hash for the always-re-run case) and re-derive `cache_hit_reason` from the merged hash's values-tally. The per-id model collapses identical per-worker duplicates AND handles partitioned cases (disjoint ids across workers in the files_changed bucket) correctly.

`filtered_examples` joins `cache_hit_reason` as a JSON-backend-only snapshot field (missing file coerces to `{}`, no `schema_version` bump; SqliteBackend has no parallel-tests peer-merge path, so the field is a no-op on sqlite via the existing `case` branch). `Merger.call` was just over the AbcSize cap after the new field + derivation, so `build_merged_snapshot` is extracted to keep the orchestration method under the metric.

## Test plan

- [x] 4 round-trip tests at `spec/storage/json_backend_spec.rb` — persist / reload / missing-file-coerce / malformed-bytes-coerce.
- [x] 4 Merger-level regression tests at `spec/storage/json_backend_spec.rb#describe Merger`:
  - 3-worker / 2-failed-previously matches the issue's reproduction: pre-fix would have been `{"Failed previously" => 6}`, now `{"Failed previously" => 2}`.
  - Disjoint Files-changed ids partition correctly (sum of distinct ids).
  - Conflict resolution on the same id is first-write-wins.
  - Empty-peer base case derives empty `cache_hit_reason`.
- [x] `task test:unit` — 1967 examples, 0 failures.
- [x] `task test:property` — 25 examples, 0 failures.
- [x] `task test:mutation:storage:json-backend-shard-6` — 95.97% on the 5 Merger helpers (incl. new `merge_filtered_examples!`).
- [x] `task test:mutation:storage:json-backend-shard-9` — 84.90% on `Merger.call` + new `build_merged_snapshot`.
- [x] `task test:dogfood` — green cold + warm.
- [x] `task benchmark:smoke` — within ratchet.
- [x] `task docs:yard:check` — 100%.

Taskfile shards 6 + 9 updated to gate the new `merge_filtered_examples!` + `build_merged_snapshot` subjects so future PRs don't drop mutation coverage on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)