### PR TITLE
fix(engine): restore flaky-test detection across runs

### DIFF
--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -300,7 +300,8 @@ module RSpecTracer
     def on_example_passed(example_id, result)
       return if @duplicate_examples[example_id]&.count.to_i > 1
 
-      @registry.update_status(example_id, :passed)
+      status = flaky_history?(example_id) ? :flaky : :passed
+      @registry.update_status(example_id, status)
       record_execution_result(example_id, result)
       self
     end
@@ -310,7 +311,8 @@ module RSpecTracer
     def on_example_failed(example_id, result)
       return if @duplicate_examples[example_id]&.count.to_i > 1
 
-      @registry.update_status(example_id, :failed)
+      status = previously_flaky?(example_id) ? :flaky : :failed
+      @registry.update_status(example_id, status)
       record_execution_result(example_id, result)
       self
     end
@@ -938,6 +940,30 @@ module RSpecTracer
       return unless @all_examples.key?(example_id)
 
       @all_examples[example_id][:execution_result] = formatted_execution_result(result)
+    end
+
+    # Ports the 1.x flaky-detection contract: an example transitions
+    # into `:flaky` when it (a) failed on the previous run and passes
+    # on this run (the canonical "intermittent" signal) OR (b) was
+    # already flaky on the previous run, regardless of this run's
+    # outcome (sticky once detected). Mirrors 1.x's
+    # `ReportGenerator#generate_flaky_examples_report` which iterated
+    # `prev_failed | prev_flaky` and registered the example as flaky
+    # unless the prev_failed branch failed again this run.
+    def flaky_history?(id)
+      previously_failed?(id) || previously_flaky?(id)
+    end
+
+    # Internal method on the tracer pipeline.
+    # @api private
+    def previously_failed?(id)
+      @previous_snapshot&.failed_examples&.include?(id)
+    end
+
+    # Internal method on the tracer pipeline.
+    # @api private
+    def previously_flaky?(id)
+      @previous_snapshot&.flaky_examples&.include?(id)
     end
 
     # Internal method on the tracer pipeline.

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -369,6 +369,96 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
+  describe 'flaky-test detection (issue #194)' do
+    let(:dep_file) { File.join(root, 'lib/a.rb') }
+
+    def prime_previous_cache_with(failed: [], flaky: [])
+      ids = (Array(failed) + Array(flaky)).uniq
+      snapshot = RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |s|
+        s.all_examples = ids.to_h { |id| [id, build_example(id)] }
+        s.failed_examples = Set.new(Array(failed))
+        s.flaky_examples = Set.new(Array(flaky))
+        s.dependency = ids.to_h { |id| [id, Set.new([dep_file])] }
+        s.all_files = {
+          dep_file => { file_name: '/lib/a.rb', file_path: dep_file,
+                        digest: Digest::SHA256.file(dep_file).hexdigest }
+        }
+      end
+      RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
+        .save_graph(snapshot, schema_version: 3)
+    end
+
+    def run_one(tracker, id, outcome)
+      allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
+      tracker.register_example(build_example(id))
+      tracker.example_started
+      tracker.example_finished(id)
+      tracker.public_send(:"on_example_#{outcome}", id, build_execution_result(status: outcome))
+    end
+
+    it 'transitions previously-failed -> passed-this-run into :flaky' do
+      prime_previous_cache_with(failed: ['ex_F'])
+      tracker = build_tracker.tap(&:setup)
+
+      run_one(tracker, 'ex_F', :passed)
+      snapshot = tracker.finalize
+
+      expect(snapshot.flaky_examples).to include('ex_F')
+      expect(snapshot.failed_examples).not_to include('ex_F')
+    end
+
+    it 'keeps previously-flaky -> passed-this-run as :flaky (sticky)' do
+      prime_previous_cache_with(flaky: ['ex_K'])
+      tracker = build_tracker.tap(&:setup)
+
+      run_one(tracker, 'ex_K', :passed)
+      snapshot = tracker.finalize
+
+      expect(snapshot.flaky_examples).to include('ex_K')
+    end
+
+    it 'keeps previously-flaky -> failed-this-run as :flaky (sticky on failure)' do
+      prime_previous_cache_with(flaky: ['ex_K'])
+      tracker = build_tracker.tap(&:setup)
+
+      run_one(tracker, 'ex_K', :failed)
+      snapshot = tracker.finalize
+
+      expect(snapshot.flaky_examples).to include('ex_K')
+      expect(snapshot.failed_examples).not_to include('ex_K')
+    end
+
+    it 'records previously-failed -> failed-this-run as :failed (no promotion to flaky)' do
+      prime_previous_cache_with(failed: ['ex_F'])
+      tracker = build_tracker.tap(&:setup)
+
+      run_one(tracker, 'ex_F', :failed)
+      snapshot = tracker.finalize
+
+      expect(snapshot.failed_examples).to include('ex_F')
+      expect(snapshot.flaky_examples).not_to include('ex_F')
+    end
+
+    it 'records a new passing example (no previous snapshot) as :passed (not flaky)' do
+      tracker = build_tracker.tap(&:setup)
+
+      run_one(tracker, 'ex_new', :passed)
+      snapshot = tracker.finalize
+
+      expect(snapshot.flaky_examples).not_to include('ex_new')
+    end
+
+    it 'records a new failing example (no previous snapshot) as :failed (not flaky)' do
+      tracker = build_tracker.tap(&:setup)
+
+      run_one(tracker, 'ex_new', :failed)
+      snapshot = tracker.finalize
+
+      expect(snapshot.failed_examples).to include('ex_new')
+      expect(snapshot.flaky_examples).not_to include('ex_new')
+    end
+  end
+
   describe 'examples_coverage finalize-time merge (M3.8 Part B)' do
     let(:previous_coverage) do
       { 'prev_only' => { '/lib/a.rb' => { '0' => 1, '1' => 2 } },

--- a/spec/integration/flaky_detection_spec.rb
+++ b/spec/integration/flaky_detection_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+# End-to-end regression for #194: flaky-test detection silently
+# regressed in 2.0.0.pre.1 -- registry exposes :flaky status, the
+# filter recognizes :flaky_example, and the JSON / HTML reporters
+# emit flaky_examples, but no production code path transitions an
+# example into the :flaky bucket. README pitches rspec-tracer as a
+# "flaky-test detector" in its first paragraph; 1.x had detection
+# since v1.0.0; the rewrite lost the transition logic.
+#
+# This spec drives the ruby_app fixture with a temp spec whose
+# pass/fail outcome flips on a FAIL env var, then walks the
+# canonical detection cycle and the sticky semantic:
+#
+#   Run 1 (FAIL=1)   -> fails. Stored as :failed.
+#   Run 2 (FAIL nil) -> passes. Transitions to :flaky.
+#   Run 3 (FAIL nil) -> passes. Sticky: stays :flaky.
+#   Run 4 (FAIL=1)   -> fails. Sticky: stays :flaky (NOT :failed).
+#
+# Mirrors 1.x's ReportGenerator#generate_flaky_examples_report
+# contract under 2.0's single-status-per-example registry: a
+# previously-flaky example stays flaky regardless of this run's
+# outcome, and a previously-failed-now-passed example transitions.
+
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'flaky-test detection across runs (issue #194)' do
+  let(:fixture_root) { File.expand_path('../../benchmark/fixtures/ruby_app', __dir__) }
+  let(:cache_dir)    { File.join(fixture_root, 'rspec_tracer_cache') }
+  let(:report_dir)   { File.join(fixture_root, 'rspec_tracer_report') }
+  let(:coverage_dir) { File.join(fixture_root, 'rspec_tracer_coverage') }
+  let(:temp_spec)    { File.join(fixture_root, 'spec', 'flaky_detection_fixture_spec.rb') }
+
+  around do |example|
+    Bundler.with_unbundled_env do
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+      example.run
+    ensure
+      FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+      FileUtils.rm_f(temp_spec)
+    end
+  end
+
+  # FAIL is explicitly threaded so the parent test runner's env can't
+  # leak in. `'FAIL' => nil` deletes the var entirely from the child.
+  def run_rspec(fail_env: nil)
+    Open3.capture2e({ 'FAIL' => fail_env }, 'bundle', 'exec', 'rspec', '--no-color', chdir: fixture_root)
+  end
+
+  def ensure_bundle_installed!
+    Dir.chdir(fixture_root) do
+      next if system('bundle check > /dev/null 2>&1')
+
+      install_out, install_status = Open3.capture2e('bundle', 'install', '--quiet')
+      raise "bundle install failed in #{fixture_root}:\n#{install_out}" unless install_status.success?
+    end
+  end
+
+  before { ensure_bundle_installed! }
+
+  def report_payload
+    JSON.parse(File.read(File.join(report_dir, 'report.json'), encoding: 'UTF-8'))
+  end
+
+  def find_example(description_substring)
+    report_payload['reports']['all_examples'].find do |e|
+      e['description']&.include?(description_substring)
+    end
+  end
+
+  def flaky_ids
+    report_payload['reports']['flaky_examples'].map { |e| e['id'] }
+  end
+
+  def write_flaky_fixture
+    File.write(temp_spec, <<~RUBY)
+      RSpec.describe 'flaky detection fixture' do
+        it 'pass-or-fail based on FAIL env var' do
+          expect(ENV['FAIL']).to be_nil
+        end
+      end
+    RUBY
+  end
+
+  it 'detects failed -> passed transition and keeps flaky sticky across subsequent runs' do
+    write_flaky_fixture
+
+    _, status1 = run_rspec(fail_env: '1')
+    expect(status1.exitstatus).not_to eq(0), 'run 1 should fail (FAIL=1)'
+    fixture_id = find_example('pass-or-fail')&.fetch('id')
+    expect(fixture_id).not_to be_nil
+    expect(flaky_ids).not_to include(fixture_id), 'no flaky transition yet on first run'
+
+    _, status2 = run_rspec
+    expect(status2.exitstatus).to eq(0), 'run 2 should pass (FAIL unset)'
+    expect(flaky_ids).to include(fixture_id), 'failed -> passed promotes to :flaky'
+
+    _, status3 = run_rspec
+    expect(status3.exitstatus).to eq(0), 'run 3 should pass (FAIL unset)'
+    expect(flaky_ids).to include(fixture_id), 'sticky: prev-flaky + this-run-passed stays :flaky'
+  end
+
+  it 'keeps a previously-flaky example sticky when it fails again' do
+    write_flaky_fixture
+
+    _, status1 = run_rspec(fail_env: '1')
+    expect(status1.exitstatus).not_to eq(0)
+    fixture_id = find_example('pass-or-fail')&.fetch('id')
+    expect(fixture_id).not_to be_nil
+
+    _, status2 = run_rspec
+    expect(status2.exitstatus).to eq(0)
+    expect(flaky_ids).to include(fixture_id), 'failed -> passed promotes to :flaky'
+
+    _, status3 = run_rspec(fail_env: '1')
+    expect(status3.exitstatus).not_to eq(0), 'run 3 should fail (FAIL=1 reintroduced)'
+    expect(flaky_ids).to include(fixture_id), 'sticky: prev-flaky + this-run-failed stays :flaky'
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength


### PR DESCRIPTION
## Summary

Closes [#194](https://github.com/avmnu-sng/rspec-tracer/issues/194).

Flaky-test detection has been a top-line README feature since v1.0.0 (2021), but the 2.0 rewrite silently dropped the transition logic. The registry kept the `:flaky` status, the filter kept the `:flaky_example` reason, the snapshot kept the `flaky_examples` field, and the HTML reporter kept the Flaky tab -- but no production code path transitioned an example into `:flaky`. A `grep "update_status.*flaky\\|status.*=.*:flaky"` across `lib/` returned zero matches before this PR. `on_example_passed` unconditionally set `:passed`; a previously-failed-now-passing example simply lost its history, and a previously-flaky example demoted back to `:passed` or `:failed` on the next run regardless of outcome.

**Framed as regression fix, not new feature.** The README pitched rspec-tracer as a "flaky-test detector" in its first paragraph; 1.x had this since v1.0.0 (CHANGELOG entry: "Flaky tests detection (#19)"). The 2.0 rewrite lost it. This PR restores the contract.

## Fix

Port 1.x's `ReportGenerator#generate_flaky_examples_report` contract ([`v1.0.0 lib/rspec_tracer/report_generator.rb:84-91`](https://github.com/avmnu-sng/rspec-tracer/blob/v1.0.0/lib/rspec_tracer/report_generator.rb#L84-L91)) under 2.0's single-status-per-example registry:

```ruby
def on_example_passed(example_id, result)
  status = flaky_history?(example_id) ? :flaky : :passed
  @registry.update_status(example_id, status)
  ...
end

def on_example_failed(example_id, result)
  status = previously_flaky?(example_id) ? :flaky : :failed
  @registry.update_status(example_id, status)
  ...
end

def flaky_history?(id)
  previously_failed?(id) || previously_flaky?(id)
end
```

`flaky_history?(id) -> :flaky on pass` covers both detection paths the 1.x report_generator's `next unless @cache.flaky_examples.include?(id) || @reporter.example_passed?(id)` covered: the failed-then-passed promotion AND the sticky-flaky semantic (once detected, stays flaky regardless of subsequent runs). `on_example_failed` also checks `previously_flaky?` so a flaky example that fails again stays flaky (matching 1.x's `@cache.flaky_examples.include?` branch which fires regardless of this run's outcome).

Skipped / pending / interrupted outcomes on a previously-flaky example follow this run's status -- the same one-status-wins coercion 2.0 already applies for every other path. rspec-retry's within-one-run passed-then-failed pattern remains post-2.0 scope (deferred per the field-test-2 / 2026-05-12 maintainer decision).

## Test plan

- [x] 6 unit tests in `spec/engine_spec.rb#describe 'flaky-test detection (issue #194)'` cover the 4 transition matrix cells (prev_failed/prev_flaky x pass/fail) plus 2 fresh-example cases (no previous snapshot).
- [x] New integration spec at `spec/integration/flaky_detection_spec.rb` drives the ruby_app fixture across 3-4 subprocess runs with an env-toggled flaky example:
  - failed -> passed -> still passes (sticky flaky preserved across 2 subsequent runs)
  - failed -> passed -> fails again (sticky flaky preserved across re-failure)
- [x] `task test:unit` — 1967 examples, 0 failures.
- [x] `task test:property` — 25 examples, 0 failures.
- [x] `task test:dogfood` — green cold + warm.
- [x] `task benchmark:smoke` — within ratchet.
- [x] `task docs:yard:check` — 100%.
- [x] Ad-hoc mutation pass on the 5 touched/added methods — 70.10% (Engine is a documented carve-out subject without direct `describe Engine#method` mapping; M9.2.5-B's PR #200's Engine.register_example was 28.81% under the same pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)