### PR TITLE
feat(coverage): guard Coverage.start + new coverage_modes config DSL

### DIFF
--- a/lib/rspec_tracer.rb
+++ b/lib/rspec_tracer.rb
@@ -190,7 +190,14 @@ module RSpecTracer
 
       require 'coverage'
 
-      ::Coverage.start
+      return if ::Coverage.respond_to?(:running?) && ::Coverage.running?
+
+      ::Coverage.start(**coverage_modes_for_start)
+    rescue RuntimeError
+      # ::Coverage.start raises if already started on some Rubies
+      # without a running? predicate; safe to ignore (matches
+      # Engine#ensure_coverage_started behavior).
+      nil
     end
 
     # Detects Rails by the presence of `::Rails::VERSION`. Users who

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -76,6 +76,18 @@ module RSpecTracer
     # Internal constant.
     # @api private
     STORAGE_BACKEND_SERIALIZERS = %i[json msgpack].freeze
+    # Default Ruby `Coverage` modes when the user has not called the
+    # `coverage_modes` DSL. Matches bare `Coverage.start` semantics so
+    # legacy configs continue to emit lines-only `coverage.json` shape.
+    DEFAULT_COVERAGE_MODES = %i[lines].freeze
+    # Allowed Ruby `Coverage` modes accepted by the `coverage_modes`
+    # DSL. The set tracks Ruby 3.1+ `Coverage.start` keyword args.
+    # `coverage.json` ships the lines-only `Array<Integer|nil>` shape
+    # per file regardless — branches / methods / oneshot_lines / eval
+    # data is collected by Ruby but the user-facing artifact stays on
+    # the documented 1.x shape (see UPGRADING `#SimpleCov branch
+    # coverage now works` for SimpleCov interop).
+    COVERAGE_MODES = %i[lines branches methods oneshot_lines eval].freeze
     # Per-save retention on the local cache's run-id directories.
     # 5 keeps enough history for rollback debugging without letting
     # the cache grow unbounded (issue #20). 0 opts out entirely.
@@ -1126,6 +1138,70 @@ module RSpecTracer
     # @api private
     EMPTY_STORAGE_BACKEND_OPTS = {}.freeze
     private_constant :EMPTY_STORAGE_BACKEND_OPTS
+
+    # Configure which Ruby `Coverage` modes rspec-tracer enables on
+    # the standalone path (when SimpleCov is not running). Pass a
+    # Symbol Array drawn from {COVERAGE_MODES}; `coverage_modes [:lines,
+    # :branches]` translates to `Coverage.start(lines: true, branches:
+    # true)`.
+    #
+    # When SimpleCov is loaded and running at `RSpecTracer.start`
+    # time, the DSL is inert — SimpleCov owns `Coverage.start` and
+    # controls modes via its own `enable_coverage :branch` etc. (the
+    # documented load-order contract; see UPGRADING `#SimpleCov branch
+    # coverage now works`).
+    #
+    # The default `[:lines]` matches the pre-#195 bare `Coverage.start`
+    # semantics so existing configs continue to emit the lines-only
+    # `coverage.json` shape. The `coverage.json` artifact itself stays
+    # on the 1.x `Array<Integer|nil>` per-file format regardless of
+    # modes (storage-format stability). Branches / methods / etc.
+    # data is available to SimpleCov via the documented interop and
+    # to downstream consumers via `Coverage.peek_result` directly.
+    #
+    # @param modes [Array<Symbol>, Symbol, nil] one or more entries
+    #   from {COVERAGE_MODES} (`:lines`, `:branches`, `:methods`,
+    #   `:oneshot_lines`, `:eval`); a single Symbol is wrapped to
+    #   an Array.
+    # @return [Array<Symbol>] the resolved (frozen) modes array. The
+    #   no-arg call returns the current setting (or
+    #   {DEFAULT_COVERAGE_MODES} if unset).
+    # @raise [InvalidUsageError] when `modes` is empty or contains an
+    #   unknown mode.
+    # @example Branch coverage on top of the default lines
+    #   coverage_modes [:lines, :branches]
+    # @example Methods coverage in addition (for downstream tooling)
+    #   coverage_modes [:lines, :methods]
+    def coverage_modes(*args)
+      return read_coverage_modes if args.empty?
+
+      modes_array = Array(args.length == 1 ? args.first : args).flatten.map(&:to_sym)
+      raise InvalidUsageError, 'coverage_modes requires at least one mode (e.g. [:lines])' if modes_array.empty?
+
+      unknown = modes_array - COVERAGE_MODES
+      unless unknown.empty?
+        raise InvalidUsageError,
+              "unknown coverage modes: #{unknown.inspect}; allowed: #{COVERAGE_MODES.inspect}"
+      end
+
+      @coverage_modes = modes_array.uniq.freeze
+    end
+
+    # Hash form of {#coverage_modes} for splatting into
+    # `Coverage.start`. `[:lines, :branches]` becomes
+    # `{lines: true, branches: true}`.
+    def coverage_modes_for_start
+      coverage_modes.to_h { |m| [m, true] }.freeze
+    end
+
+    # Internal method on the tracer pipeline.
+    # @api private
+    def read_coverage_modes
+      return @coverage_modes if defined?(@coverage_modes) && @coverage_modes
+
+      DEFAULT_COVERAGE_MODES
+    end
+    private :read_coverage_modes
 
     # Internal method on the tracer pipeline.
     # @api private

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -660,16 +660,27 @@ module RSpecTracer
 
     # Delegate to the legacy ::Coverage bootstrap if SimpleCov isn't
     # already running. Matches RSpecTracer.setup_coverage behavior so
-    # v2 and legacy agree on when to call ::Coverage.start.
+    # the two entry points agree on when to call ::Coverage.start
+    # AND on which Ruby Coverage modes are enabled.
     def ensure_coverage_started
       return if defined?(SimpleCov) && SimpleCov.running
       return if ::Coverage.respond_to?(:running?) && ::Coverage.running?
 
-      ::Coverage.start
+      ::Coverage.start(**configuration_coverage_modes)
     rescue RuntimeError
       # ::Coverage.start raises if already started on some Rubies
       # without a running? predicate; safe to ignore.
       nil
+    end
+
+    # Reads `coverage_modes` off the configuration when available
+    # (extended with `RSpecTracer::Configuration`). Defaults to an
+    # empty Hash for stubbed-configuration unit tests so the splat
+    # `Coverage.start(**{})` keeps lines-only legacy behavior.
+    def configuration_coverage_modes
+      return {} unless @configuration.respond_to?(:coverage_modes_for_start)
+
+      @configuration.coverage_modes_for_start
     end
 
     # Under parallel_tests, each worker writes to its own per-worker

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -452,6 +452,80 @@ RSpec.describe RSpecTracer::Configuration do
   end
 
   # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+  describe '#coverage_modes' do
+    it 'defaults to [:lines] when never configured' do
+      expect(config.coverage_modes).to eq(%i[lines])
+    end
+
+    it 'accepts a Symbol Array' do
+      config.coverage_modes(%i[lines branches])
+
+      expect(config.coverage_modes).to eq(%i[lines branches])
+    end
+
+    it 'coerces strings to symbols' do
+      config.coverage_modes(%w[lines branches])
+
+      expect(config.coverage_modes).to eq(%i[lines branches])
+    end
+
+    it 'accepts a single Symbol (wrapped to Array)' do
+      config.coverage_modes(:lines)
+
+      expect(config.coverage_modes).to eq(%i[lines])
+    end
+
+    it 'accepts variadic Symbols' do
+      config.coverage_modes(:lines, :branches, :methods)
+
+      expect(config.coverage_modes).to eq(%i[lines branches methods])
+    end
+
+    it 'de-duplicates the modes array' do
+      config.coverage_modes(%i[lines lines branches])
+
+      expect(config.coverage_modes).to eq(%i[lines branches])
+    end
+
+    it 'freezes the resolved modes array' do
+      config.coverage_modes(%i[lines branches])
+
+      expect(config.coverage_modes).to be_frozen
+    end
+
+    it 'accepts every documented mode' do
+      config.coverage_modes(%i[lines branches methods oneshot_lines eval])
+
+      expect(config.coverage_modes).to eq(%i[lines branches methods oneshot_lines eval])
+    end
+
+    it 'raises InvalidUsageError for an unknown mode' do
+      expect { config.coverage_modes(%i[lines bogus]) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /unknown coverage modes/)
+    end
+
+    it 'raises InvalidUsageError on an empty array' do
+      expect { config.coverage_modes([]) }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /at least one mode/)
+    end
+  end
+
+  describe '#coverage_modes_for_start' do
+    it 'maps the default lines-only Array into a kwarg Hash' do
+      expect(config.coverage_modes_for_start).to eq(lines: true)
+    end
+
+    it 'maps every set mode to `true` (kwarg form for Coverage.start)' do
+      config.coverage_modes(%i[lines branches methods])
+
+      expect(config.coverage_modes_for_start).to eq(lines: true, branches: true, methods: true)
+    end
+
+    it 'freezes the hash so it cannot drift between cached lookups' do
+      expect(config.coverage_modes_for_start).to be_frozen
+    end
+  end
+
   describe '#ignore_spec_files' do
     it 'returns a frozen empty array when never configured' do
       result = config.ignore_spec_files

--- a/spec/coverage_modes_spec.rb
+++ b/spec/coverage_modes_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'rspec_tracer'
+
+# Direct tests for RSpecTracer.setup_coverage's interaction with Ruby's
+# `::Coverage` module. Three regressions / additions land here:
+#
+#   * pre-#195: bare `Coverage.start` crashes with
+#     "coverage measurement is already setup" when a user pre-starts
+#     Coverage to opt into branches before `RSpecTracer.start`. The
+#     `Coverage.running?` guard mirrors `Engine#ensure_coverage_started`
+#     so both entry points agree on the predicate.
+#   * pre-#195: standalone path always used the bare `Coverage.start`
+#     default (lines only). The new `coverage_modes` config DSL
+#     threads `[:lines, :branches, :methods, :oneshot_lines, :eval]`
+#     through to `Coverage.start(**modes)`.
+#   * SimpleCov interop unchanged: when SimpleCov is loaded and
+#     running, `setup_coverage` returns immediately (the DSL is inert
+#     under SimpleCov, which owns the Coverage lifecycle via
+#     `enable_coverage :branch` etc.).
+RSpec.describe RSpecTracer, '.setup_coverage + #coverage_modes (issue #195)' do
+  before do
+    # Reset memoized @simplecov / @coverage_modes between examples.
+    described_class.remove_instance_variable(:@simplecov) if described_class.instance_variable_defined?(:@simplecov)
+    if described_class.instance_variable_defined?(:@coverage_modes)
+      described_class.remove_instance_variable(:@coverage_modes)
+    end
+    hide_const('SimpleCov') if defined?(SimpleCov)
+  end
+
+  describe '.setup_coverage with no pre-started Coverage' do
+    before do
+      allow(Coverage).to receive(:respond_to?).and_call_original
+      allow(Coverage).to receive(:respond_to?).with(:running?).and_return(true)
+      allow(Coverage).to receive(:running?).and_return(false)
+      allow(Coverage).to receive(:start)
+    end
+
+    it 'calls Coverage.start with the default lines-only mode' do
+      described_class.send(:setup_coverage)
+
+      expect(Coverage).to have_received(:start).with(lines: true)
+    end
+
+    it 'threads coverage_modes [:lines, :branches] through to Coverage.start' do
+      described_class.coverage_modes(%i[lines branches])
+
+      described_class.send(:setup_coverage)
+
+      expect(Coverage).to have_received(:start).with(lines: true, branches: true)
+    end
+
+    it 'threads every documented mode through' do
+      described_class.coverage_modes(%i[lines branches methods oneshot_lines eval])
+
+      described_class.send(:setup_coverage)
+
+      expect(Coverage).to have_received(:start)
+        .with(lines: true, branches: true, methods: true, oneshot_lines: true, eval: true)
+    end
+  end
+
+  describe '.setup_coverage when Coverage is already running' do
+    before do
+      allow(Coverage).to receive(:respond_to?).and_call_original
+      allow(Coverage).to receive(:respond_to?).with(:running?).and_return(true)
+      allow(Coverage).to receive(:running?).and_return(true)
+      allow(Coverage).to receive(:start)
+    end
+
+    it 'does not crash (the #195 reproduction: pre-started Coverage)' do
+      expect { described_class.send(:setup_coverage) }.not_to raise_error
+    end
+
+    it 'does not re-call Coverage.start' do
+      described_class.send(:setup_coverage)
+
+      expect(Coverage).not_to have_received(:start)
+    end
+  end
+
+  describe '.setup_coverage on Rubies without Coverage.running?' do
+    before do
+      allow(Coverage).to receive(:respond_to?).and_call_original
+      allow(Coverage).to receive(:respond_to?).with(:running?).and_return(false)
+      allow(Coverage).to receive(:start).and_raise(RuntimeError, 'coverage measurement is already setup')
+    end
+
+    it 'rescues RuntimeError defensively (matches Engine#ensure_coverage_started)' do
+      expect { described_class.send(:setup_coverage) }.not_to raise_error
+    end
+  end
+
+  describe '.setup_coverage when SimpleCov is running' do
+    before do
+      simplecov_stub = Module.new
+      simplecov_stub.singleton_class.define_method(:running) { true }
+      stub_const('SimpleCov', simplecov_stub)
+      allow(Coverage).to receive(:start)
+    end
+
+    it 'returns early (SimpleCov owns Coverage.start; DSL is inert)' do
+      described_class.send(:setup_coverage)
+
+      expect(Coverage).not_to have_received(:start)
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'still threads modes through when SimpleCov is NOT running (sanity)' do
+      hide_const('SimpleCov')
+      allow(Coverage).to receive(:respond_to?).and_call_original
+      allow(Coverage).to receive(:respond_to?).with(:running?).and_return(true)
+      allow(Coverage).to receive(:running?).and_return(false)
+      described_class.coverage_modes(%i[lines branches])
+
+      described_class.send(:setup_coverage)
+
+      expect(Coverage).to have_received(:start).with(lines: true, branches: true)
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+end

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -155,6 +155,32 @@ RSpec.describe RSpecTracer::Engine do
       tracker_instance = build_tracker
       expect(tracker_instance.setup).to be(tracker_instance)
     end
+
+    # Coverage + SimpleCov are both running in the test env (rspec-tracer
+    # self-tracking + SimpleCov dogfood), so ensure_coverage_started normally
+    # short-circuits at the SimpleCov guard. These two specs stub both
+    # predicates false so the new #195 path that threads
+    # configuration_coverage_modes through to Coverage.start is reachable.
+    it 'threads configuration.coverage_modes_for_start through to Coverage.start' do
+      allow(SimpleCov).to receive(:running).and_return(false)
+      allow(Coverage).to receive_messages(running?: false, start: nil)
+      config_with_modes = stub_configuration.tap do |c|
+        allow(c).to receive(:coverage_modes_for_start).and_return(lines: true, branches: true)
+      end
+
+      build_tracker(config_with_modes).tap(&:setup)
+
+      expect(Coverage).to have_received(:start).with(lines: true, branches: true)
+    end
+
+    it 'passes an empty kwarg splat when the configuration does not expose coverage_modes_for_start' do
+      allow(SimpleCov).to receive(:running).and_return(false)
+      allow(Coverage).to receive_messages(running?: false, start: nil)
+
+      build_tracker.tap(&:setup)
+
+      expect(Coverage).to have_received(:start).with(no_args)
+    end
   end
 
   describe '#run_example? / #run_example_reason' do

--- a/spec/integration/coverage_modes_spec.rb
+++ b/spec/integration/coverage_modes_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# End-to-end regression for #195's two related bugs:
+#
+#   (a) RSpecTracer.start crashed with
+#       `RuntimeError: coverage measurement is already setup`
+#       when the user pre-started `::Coverage` to opt into branch
+#       coverage. setup_coverage now mirrors
+#       Engine#ensure_coverage_started's `Coverage.running?` guard
+#       (+ rescue) so both entry points agree.
+#
+#   (b) Standalone path was lines-only (`bare Coverage.start`). The
+#       new `coverage_modes` DSL threads any combination of
+#       `[:lines, :branches, :methods, :oneshot_lines, :eval]`
+#       through to `::Coverage.start(**modes)` so users can opt into
+#       branches without SimpleCov.
+#
+# Both scenarios drive a one-off Ruby subprocess against the
+# ruby_app fixture's Gemfile (which depends on rspec-tracer via
+# `path:`); subprocess isolation guarantees no leak from the parent
+# test process's already-running Coverage.
+
+require 'bundler'
+require 'fileutils'
+require 'open3'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'standalone Coverage modes integration (issue #195)' do
+  let(:fixture_root) { File.expand_path('../../benchmark/fixtures/ruby_app', __dir__) }
+  let(:script_path)  { File.join(fixture_root, 'coverage_modes_probe.rb') }
+
+  around do |example|
+    Bundler.with_unbundled_env do
+      example.run
+    ensure
+      FileUtils.rm_f(script_path)
+    end
+  end
+
+  def ensure_bundle_installed!
+    Dir.chdir(fixture_root) do
+      next if system('bundle check > /dev/null 2>&1')
+
+      install_out, install_status = Open3.capture2e('bundle', 'install', '--quiet')
+      raise "bundle install failed in #{fixture_root}:\n#{install_out}" unless install_status.success?
+    end
+  end
+
+  before { ensure_bundle_installed! }
+
+  it 'does not crash when the user pre-starts Coverage with branches' do
+    File.write(script_path, <<~RUBY)
+      require 'coverage'
+      ::Coverage.start(lines: true, branches: true)
+
+      require 'rspec_tracer'
+
+      # setup_coverage was the crash point on a pre-started Coverage.
+      # The Coverage.running? guard short-circuits before the bare
+      # Coverage.start re-call. We drive setup_coverage directly so
+      # the test doesn't depend on the full RSpec hook install chain.
+      RSpecTracer.send(:setup_coverage)
+
+      puts 'OK'
+    RUBY
+
+    out, status = Open3.capture2e('bundle', 'exec', 'ruby', 'coverage_modes_probe.rb', chdir: fixture_root)
+    expect(status.exitstatus).to eq(0), "subprocess failed:\n#{out}"
+    expect(out).to include('OK')
+  end
+
+  it 'threads coverage_modes :branches through to Coverage.start on the standalone path' do
+    File.write(script_path, <<~RUBY)
+      require 'rspec_tracer'
+
+      RSpecTracer.coverage_modes(%i[lines branches])
+      RSpecTracer.send(:setup_coverage)
+
+      # Coverage was started AFTER rspec-tracer loaded, so the
+      # rspec-tracer lib files are not tracked. Load + exercise the
+      # fixture's calculator AFTER the start so its `if b.zero?`
+      # branches yield branch entries in Coverage.peek_result.
+      require_relative 'app/calculator'
+      Calculator.new.divide(10, 2)
+
+      require 'coverage'
+      result = ::Coverage.peek_result
+      any_branch = result.any? { |_path, data| data.is_a?(::Hash) && data.key?(:branches) }
+      puts(any_branch ? 'BRANCHES_TRACKED' : 'NO_BRANCHES')
+    RUBY
+
+    out, status = Open3.capture2e('bundle', 'exec', 'ruby', 'coverage_modes_probe.rb', chdir: fixture_root)
+    expect(status.exitstatus).to eq(0), "subprocess failed:\n#{out}"
+    expect(out).to include('BRANCHES_TRACKED')
+  end
+
+  it 'omits branches from Coverage.peek_result when coverage_modes is not set' do
+    File.write(script_path, <<~RUBY)
+      require 'rspec_tracer'
+
+      RSpecTracer.send(:setup_coverage)
+
+      require_relative 'app/calculator'
+      Calculator.new.divide(10, 2)
+
+      require 'coverage'
+      result = ::Coverage.peek_result
+      branches_present = result.any? { |_path, data| data.is_a?(::Hash) && data.key?(:branches) }
+      puts(branches_present ? 'BRANCHES_TRACKED' : 'NO_BRANCHES')
+    RUBY
+
+    out, status = Open3.capture2e('bundle', 'exec', 'ruby', 'coverage_modes_probe.rb', chdir: fixture_root)
+    expect(status.exitstatus).to eq(0), "subprocess failed:\n#{out}"
+    expect(out).to include('NO_BRANCHES')
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength


### PR DESCRIPTION
## Summary

Closes [#195](https://github.com/avmnu-sng/rspec-tracer/issues/195).

Two related fixes for the standalone (non-SimpleCov) Coverage path. The maintainer's 2026-05-12 expansion (per the issue) folded the minimum-diff `Coverage.running?` guard fix together with a new `coverage_modes` config DSL.

**(a) Pre-started Coverage crashed `RSpecTracer.start`.** The bare `::Coverage.start` in [`setup_coverage`](lib/rspec_tracer.rb:186) raised `RuntimeError: coverage measurement is already setup` when the user pre-started Coverage to opt into branches before `RSpecTracer.start`. [`Engine#ensure_coverage_started`](lib/rspec_tracer/engine.rb:664) had a `Coverage.running?` guard + rescue but the two entry points disagreed on the predicate. Aligned them so both short-circuit on a pre-started Coverage.

**(b) Standalone path was lines-only.** The bare `Coverage.start` only enabled the default `lines` mode -- users without SimpleCov could not opt into branch / method / oneshot_lines / eval coverage even though Ruby 3.1+ supports them. Per Q11's maintainer-approved expansion, this PR adds a `coverage_modes` config DSL accepting a Symbol Array from `[:lines, :branches, :methods, :oneshot_lines, :eval]` (with single-Symbol + variadic-Symbols + Symbol-coercion + de-dup); both `setup_coverage` and `ensure_coverage_started` thread it through to `Coverage.start(**modes)`. Default `[:lines]` keeps byte-compatibility with pre-#195 behavior.

## Q11 expansion

The maintainer-approved DSL expansion (2026-05-12) lands a new user-visible surface:

```ruby
# .rspec-tracer
RSpecTracer.configure do
  coverage_modes [:lines, :branches]
end
```

When SimpleCov is loaded and running at `RSpecTracer.start` time the DSL is inert -- SimpleCov owns the Coverage lifecycle and controls modes via its own `enable_coverage :branch` etc. (the documented load-order contract; see UPGRADING `#SimpleCov branch coverage now works`).

The `coverage.json` artifact itself stays on the 1.x `Array<Integer|nil>` per-file shape regardless of modes (storage-format stability). `peek_unfiltered` already reduces hash-mode `:lines` entries to the lines-only output. Branches / methods / etc. data is available to downstream consumers via `Coverage.peek_result` directly; SimpleCov interop via `enable_coverage :branch` is unchanged.

## Test plan

- [x] 13 unit tests in `spec/configuration_spec.rb` cover the DSL: default `[:lines]`, Symbol Array / variadic / single Symbol / String coercion, de-dup, freeze, every documented mode, unknown-mode rejection, empty-array rejection, plus 3 tests on the `#coverage_modes_for_start` kwarg form.
- [x] 8 unit tests in `spec/coverage_modes_spec.rb` cover `setup_coverage`: default lines-only, full mode threading, `Coverage.running?` short-circuit, RuntimeError rescue on older Rubies, SimpleCov-inert.
- [x] 3 subprocess-driven integration tests in `spec/integration/coverage_modes_spec.rb` against the ruby_app fixture: pre-start no-crash, `[:lines, :branches]` threading visible in `Coverage.peek_result`, default lines-only stays opt-in.
- [x] `task test:unit` -- 1983 examples, 0 failures.
- [x] `task test:property` / `test:dogfood` / `benchmark:smoke` / `docs:yard:check` -- green.
- [x] `task test:mutation:top-level-c` (setup_coverage shard) -- 94.56% PASS.
- [x] Ad-hoc mutation on the new Configuration methods -- 95.07%.

`Engine#ensure_coverage_started` was audited per `feedback_centralizing_rescue_caller_audit` -- it now reads `coverage_modes_for_start` off the configuration via a `respond_to?` guard so engine-unit-spec stubbed configurations (which don't implement the DSL) keep the bare `Coverage.start(**{})` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)