### PR TITLE
docs: cover coverage_modes interop matrix (rspec-tracer + SimpleCov)

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -399,6 +399,49 @@ cold-read time.
 **JRuby**: `:sqlite` is unsupported; the engine warns once and
 falls back to `:json` automatically.
 
+### Coverage modes (rspec-tracer + SimpleCov interop)
+
+By default, rspec-tracer enables Ruby's `lines` coverage mode only.
+The `coverage_modes` DSL opts into additional Ruby `Coverage` modes
+on the standalone (non-SimpleCov) path:
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  coverage_modes [:lines, :branches]
+end
+```
+
+Allowed modes: `:lines`, `:branches`, `:methods`, `:oneshot_lines`,
+`:eval`. The default is `[:lines]` (matches pre-#195 bare
+`Coverage.start` behavior).
+
+When SimpleCov is loaded and running at `RSpecTracer.start` time, the
+DSL is inert — SimpleCov owns `::Coverage.start` and exposes its own
+knobs (`enable_coverage :branch`, `enable_coverage_for_eval`). See
+[`UPGRADING.md` § "SimpleCov branch coverage now works"](UPGRADING.md)
+for the SimpleCov load-order contract.
+
+`coverage.json` stays on the 1.x `Array<Integer|nil>` per-file shape
+regardless of modes (storage-format stability). Branch / method data
+is tracked by Ruby and available via `Coverage.peek_result` directly
+for downstream tooling that reads it; the canonical user-facing
+artifact remains lines-only.
+
+#### Per-mode interop matrix
+
+| Mode | Ruby support | rspec-tracer standalone | rspec-tracer + SimpleCov 0.22 |
+|---|---|---|---|
+| `lines` | yes | yes (default) | yes (SimpleCov default) |
+| `branches` | yes | yes — `coverage_modes [:lines, :branches]` | yes — `SimpleCov.start { enable_coverage :branch }` |
+| `methods` | yes | yes — `coverage_modes [:lines, :methods]` | no (SimpleCov 0.22 has no API to enable) |
+| `oneshot_lines` | yes (alternative to `lines`) | yes — `coverage_modes [:oneshot_lines]` | no (no SimpleCov API) |
+| `eval` | yes | yes — `coverage_modes [:lines, :eval]` | partial — SimpleCov forwards `enable_coverage_for_eval` to `Coverage.start` but `coverage/.resultset.json` strips the `(eval at /path:line)` virtual-file entries |
+
+Validated empirically on Ruby 3.4.8 and Ruby 4.1.0dev with SimpleCov
+0.22.0; check `Coverage.respond_to?(:start)`'s keyword arguments on
+your Ruby version for the authoritative supported set.
+
 ---
 
 ## 10. Debug "why did this test re-run?"

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -73,6 +73,12 @@ you call `SimpleCov.start` after `require 'simplecov'` but before
 `RSpecTracer.start`, you'll see a one-line boot-time warn pointing this
 out.
 
+On the standalone (no-SimpleCov) path, rspec-tracer enables Ruby's
+`lines` coverage mode only by default. Opt into branches / methods /
+oneshot / eval via `coverage_modes`; see
+[`COOKBOOK.md` § "Coverage modes (rspec-tracer + SimpleCov interop)"](COOKBOOK.md)
+for the per-mode matrix.
+
 ## Deprecated config — keeps working with one warning
 
 Each entry below still functions in 2.0 and warns once at first use.


### PR DESCRIPTION
## Summary

Lands the [field-test-2 coverage-modes interop matrix](https://github.com/avmnu-sng/rspec-tracer/issues/195#issuecomment-) verbatim as a new sub-section under COOKBOOK recipe 9 (storage backends), plus a one-line cross-reference in UPGRADING's `SimpleCov branch coverage now works` section.

The field test (2026-05-12) exercised Ruby 3.4.8 + Ruby 4.1.0dev under four configurations (standalone, +SimpleCov branches, +SimpleCov eval, pre-start) and surfaced two artifacts that warranted documentation:

  (a) the standalone path is **lines-only by default** -- users need the new `coverage_modes` DSL (see [#207](https://github.com/avmnu-sng/rspec-tracer/pull/207)) to opt into branches / methods / oneshot_lines / eval; and
  (b) SimpleCov 0.22 surfaces only **lines + branches** in `coverage/.resultset.json` even though Ruby's `Coverage` tracks methods + eval too. `methods` has no SimpleCov API; `eval` data is stripped during resultset serialization (the `(eval at ...)` virtual files fail SimpleCov's "real file" filter).

The matrix puts both per-mode realities in one place so a user debugging "why doesn't my SimpleCov branch coverage match my rspec-tracer expectation?" has a single reference.

## Dependency

This PR references the `coverage_modes` DSL added in [#207](https://github.com/avmnu-sng/rspec-tracer/pull/207). Land #207 first; the docs become accurate at that point.

## Test plan

- [x] `task docs:yard:check` -- 100% documented.
- [x] `task lint:ruby` / `lint:actions` / `lint:yaml` -- green (no docs-relevant offenses; pre-existing gemspec offense remains).
- [x] Markdown links in COOKBOOK / UPGRADING point at existing files / sections (manual visual check).
- [x] The matrix matches the empirical observations from the field-test-2 retro (`docs/revamp/retro/personal-install-test-2026-05-12-followup.md` § "Coverage validation across all modes").

🤖 Generated with [Claude Code](https://claude.com/claude-code)