### PR TITLE
fix(example): stabilize example_id across runs; schema_version 3 → 4

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -49,6 +49,18 @@ implicitly: `Gemfile.lock` is a whole-suite invalidator, so the lockfile
 delta from a Rails major bump triggers a full cold run. Same one-time
 expectation applies.
 
+**The 2.0.0.pre.1 → pre.2 upgrade also costs one cold run.** pre.2
+reshaped how `example_id` is computed: it no longer depends on RSpec's
+load-order-dependent example-group class name or on line numbers, so
+cached ids from pre.1 no longer match. The `schema_version` bump makes a
+pre.1 cache cold-load cleanly; after that one run, cache hits are *more*
+stable than they were under pre.1 — a no-op edit that shifts line
+numbers, or loading two spec files that share a `describe` name, no
+longer flips an example's identity. As a rule of thumb from pre.2 on:
+renaming a file, `describe`, or `it` gives an example a new identity
+(one cold run); restructuring around it — blank lines, reordering,
+metadata edits — keeps it warm.
+
 ## SimpleCov branch coverage now works
 
 The 1.x README warned: *"If you use RSpec Tracer with SimpleCov, then

--- a/lib/rspec_tracer/example.rb
+++ b/lib/rspec_tracer/example.rb
@@ -4,25 +4,62 @@ module RSpecTracer
   # Builds the identity-hash payload (`:example_id`-keyed Hash) that
   # RSpec::RunnerHook attaches to every example pre-run.
   #
-  # All methods declared `def self.x` + `private_class_method` for
-  # the private helpers per feedback_mutation_friendly_modules:
-  # mutant maps tests to the singleton form. Public API
-  # (`Example.from`) is the only call site `runner_hook.rb` + the
-  # runner-hook spec drive; the three private helpers stay reachable
-  # only from `from` itself.
+  # == Identity stability contract
+  #
+  # `example_id` is the MD5 of a stable subset of the payload:
+  # `example_group` (the describe block's *description* string),
+  # `description`, `full_description`, `shared_group` (inclusion
+  # locations with the trailing line number stripped), and
+  # `file_name`. The contract, in one line: *rename = new identity;
+  # restructure = same identity.*
+  #
+  # Identity is PRESERVED when:
+  # - blank lines or comments are added/removed around the example
+  # - examples are reordered within a describe block
+  # - a sibling describe / example in the same file is renamed
+  # - metadata changes (`skip:`, tags, `tracks: { ... }`) - the
+  #   spec-file digest still triggers the re-run and status history
+  #   is kept
+  # - the example body or its hooks (`before`, `let`) are edited -
+  #   again, the file digest triggers the re-run
+  #
+  # Identity CHANGES (one cold "No cache" run) when:
+  # - the file is renamed or moved
+  # - the `describe` / `it` / shared-example name is changed
+  # - the example moves to a different describe block
+  #
+  # `line_number` / `rerun_file_name` / `rerun_line_number` stay in
+  # the returned Hash for the reporter + `explain` location columns,
+  # but are DELIBERATELY EXCLUDED from the digest - a no-op edit that
+  # shifts line numbers must not invalidate the cache. `example_group`
+  # uses `example_group.description` (the user's string) rather than
+  # `example_group.name`: RSpec's generated class name carries a
+  # load-order-dependent `_2` / `_3` suffix when two files share a
+  # describe name, which would otherwise flip the id across runs.
+  #
+  # Helpers are `def self.x` + `private_class_method` so mutant
+  # attributes mutations through the singleton call path.
   module Example
-    # Internal helper for the tracer pipeline.
+    # Builds the identity payload for one RSpec example. The MD5 is
+    # taken over `identity` only (the stability-contract subset);
+    # `line_number` / `rerun_*` ride along in the returned Hash for
+    # the reporters but never enter the digest. See the module
+    # comment for the full stability contract.
     # @api private
     def self.from(example)
-      data = {
-        example_group: example.example_group.name,
+      location = example_location(example)
+      identity = {
+        example_group: example.example_group.description,
         description: example.description,
         full_description: example.full_description,
         shared_group: example.metadata[:shared_group_inclusion_backtrace]
-          .map(&:formatted_inclusion_location)
-      }.merge(example_location(example))
+          .map { |frame| frame.formatted_inclusion_location.sub(/:\d+\z/, '') },
+        file_name: location[:file_name]
+      }
 
-      data.merge(example_id: Digest::MD5.hexdigest(data.to_json))
+      identity
+        .merge(location)
+        .merge(example_id: Digest::MD5.hexdigest(identity.to_json))
     end
 
     # Internal helper for the tracer pipeline.

--- a/lib/rspec_tracer/storage/schema.rb
+++ b/lib/rspec_tracer/storage/schema.rb
@@ -21,12 +21,15 @@ module RSpecTracer
     # caller pays one cold run on upgrade - the deal 1.x users already
     # expect for any rspec-tracer version bump.
     module Schema
-      # schema_version 2 was the first versioned schema (1.x was
-      # unstamped). 2.0 adds `Snapshot.boot_set` - breaking for any
-      # reader that assumed the v2 field list - so CURRENT bumps to 3
-      # and SUPPORTED narrows to only the new version. No v2 caches
-      # were ever persisted in user land.
-      CURRENT = 3
+      # 1.x caches were unstamped; schema_version 2 was the first
+      # versioned schema, and 2.0 bumped to 3 when `Snapshot.boot_set`
+      # landed. schema_version 4 changes the example-identity payload:
+      # `example_id` now hashes the describe block's *description*
+      # (not RSpec's load-order-dependent class name) and excludes
+      # line numbers, so a 3-stamped cache's example_ids no longer
+      # match. The change is breaking, so SUPPORTED stays `[CURRENT]`
+      # and the caller pays one cold run on upgrade.
+      CURRENT = 4
       # Internal constant.
       # @api private
       SUPPORTED = [CURRENT].freeze

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe RSpecTracer::Engine do
   let(:cache_path) { File.join(tmp_base, 'cache') }
   let(:logger) { instance_double(RSpecTracer::Logger, debug: nil, info: nil, warn: nil, error: nil) }
   let(:configuration) { stub_configuration }
+  let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
 
   before do
     write_project_file('lib/a.rb', "module A; VALUE = 1; end\n")
@@ -322,7 +323,7 @@ RSpec.describe RSpecTracer::Engine do
       expect(File).to exist(File.join(cache_path, 'last_run.json'))
     end
 
-    it 'stamps the cache with schema_version 3' do
+    it 'stamps the cache with the current schema_version' do
       allow(tracker.coverage_adapter).to receive(:peek).and_return({}, {})
       tracker.register_example(build_example('ex1'))
       tracker.example_started
@@ -332,7 +333,7 @@ RSpec.describe RSpecTracer::Engine do
       tracker.finalize
 
       manifest = JSON.parse(File.read(File.join(cache_path, 'last_run.json')))
-      expect(manifest['schema_version']).to eq(3)
+      expect(manifest['schema_version']).to eq(current_schema)
     end
 
     it 'flags ids without a terminal status as :interrupted at finalize' do
@@ -400,7 +401,7 @@ RSpec.describe RSpecTracer::Engine do
 
     def prime_previous_cache_with(failed: [], flaky: [])
       ids = (Array(failed) + Array(flaky)).uniq
-      snapshot = RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |s|
+      snapshot = RSpecTracer::Storage::Snapshot.empty(schema_version: current_schema, run_id: 'prev').tap do |s|
         s.all_examples = ids.to_h { |id| [id, build_example(id)] }
         s.failed_examples = Set.new(Array(failed))
         s.flaky_examples = Set.new(Array(flaky))
@@ -411,7 +412,7 @@ RSpec.describe RSpecTracer::Engine do
         }
       end
       RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
-        .save_graph(snapshot, schema_version: 3)
+        .save_graph(snapshot, schema_version: current_schema)
     end
 
     def run_one(tracker, id, outcome)
@@ -491,14 +492,14 @@ RSpec.describe RSpecTracer::Engine do
         'overwritten' => { '/lib/a.rb' => { '0' => 9 } } }
     end
     let(:previous_snapshot) do
-      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |s|
+      RSpecTracer::Storage::Snapshot.empty(schema_version: current_schema, run_id: 'prev').tap do |s|
         s.examples_coverage = previous_coverage
       end
     end
 
     def prime_previous_cache
       backend = RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
-      backend.save_graph(previous_snapshot, schema_version: 3)
+      backend.save_graph(previous_snapshot, schema_version: current_schema)
     end
 
     it 'leaves @examples_coverage empty after setup (no eager seed)' do
@@ -601,7 +602,7 @@ RSpec.describe RSpecTracer::Engine do
       RSpecTracer::Tracker::WholeSuiteInvalidators.new(root: root).digest_snapshot
     end
     let(:previous_snapshot) do
-      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |s|
+      RSpecTracer::Storage::Snapshot.empty(schema_version: current_schema, run_id: 'prev').tap do |s|
         s.all_examples = { 'ex1' => build_example('ex1'), 'ex2' => build_example('ex2') }
         # Non-empty dependency keeps Filter from marking every prev example
         # as :no_cache (Filter maps missing-from-graph to no_cache which
@@ -624,7 +625,7 @@ RSpec.describe RSpecTracer::Engine do
     def prime_previous_cache
       FileUtils.mkdir_p(prev_cache_path)
       backend = RSpecTracer::Storage::JsonBackend.new(cache_path: prev_cache_path, logger: logger)
-      backend.save_graph(previous_snapshot, schema_version: 3)
+      backend.save_graph(previous_snapshot, schema_version: current_schema)
     end
 
     it 'adds env_changed decisions for examples whose tracked env key changed' do
@@ -682,7 +683,7 @@ RSpec.describe RSpecTracer::Engine do
       RSpecTracer::Tracker::WholeSuiteInvalidators.new(root: root).digest_snapshot
     end
     let(:previous_snapshot) do
-      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |s|
+      RSpecTracer::Storage::Snapshot.empty(schema_version: current_schema, run_id: 'prev').tap do |s|
         s.all_examples = {
           'ex1' => build_example('ex1'),
           'ex2' => build_example('ex2'),
@@ -710,7 +711,7 @@ RSpec.describe RSpecTracer::Engine do
     def prime_previous_cache
       FileUtils.mkdir_p(prev_cache_path)
       backend = RSpecTracer::Storage::JsonBackend.new(cache_path: prev_cache_path, logger: logger)
-      backend.save_graph(previous_snapshot, schema_version: 3)
+      backend.save_graph(previous_snapshot, schema_version: current_schema)
     end
 
     it 'unions config-level tracked names into @tracked_env_names at setup' do
@@ -1251,7 +1252,7 @@ RSpec.describe RSpecTracer::Engine do
     end
 
     let(:previous_snapshot) do
-      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |snap|
+      RSpecTracer::Storage::Snapshot.empty(schema_version: current_schema, run_id: 'prev').tap do |snap|
         snap.all_files = {
           '/lib/keep.rb' => {
             file_name: '/lib/keep.rb',
@@ -1277,7 +1278,7 @@ RSpec.describe RSpecTracer::Engine do
 
     def prime_previous_cache
       backend = RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
-      backend.save_graph(previous_snapshot, schema_version: 3)
+      backend.save_graph(previous_snapshot, schema_version: current_schema)
     end
 
     it 'drops carried-over @all_files entries that match a currently-configured filter' do
@@ -1329,7 +1330,7 @@ RSpec.describe RSpecTracer::Engine do
   # field testing across all five reason paths.
   describe 'register_example overwrites prior-run metadata on warm runs' do
     let(:previous_snapshot) do
-      RSpecTracer::Storage::Snapshot.empty(schema_version: 3, run_id: 'prev').tap do |snap|
+      RSpecTracer::Storage::Snapshot.empty(schema_version: current_schema, run_id: 'prev').tap do |snap|
         snap.all_examples = {
           'ex_failed' => build_example('ex_failed').merge(run_reason: 'No cache')
         }
@@ -1339,7 +1340,7 @@ RSpec.describe RSpecTracer::Engine do
 
     def prime_previous_cache
       backend = RSpecTracer::Storage::JsonBackend.new(cache_path: cache_path, logger: logger)
-      backend.save_graph(previous_snapshot, schema_version: 3)
+      backend.save_graph(previous_snapshot, schema_version: current_schema)
     end
 
     it "replaces the seeded run_reason with this run's freshly-tagged value" do

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -1,0 +1,244 @@
+# frozen_string_literal: true
+
+require 'rspec_tracer'
+
+# Unit coverage for RSpecTracer::Example.from — the identity-hash
+# payload builder. The load-bearing contract (see the module's
+# stability-contract YARD comment in lib/rspec_tracer/example.rb):
+# example_id is the MD5 of a STABLE SUBSET of the payload
+# (example_group description, description, full_description,
+# line-stripped shared_group, file_name). line_number / rerun_*
+# ride along in the returned Hash for the reporter + `explain`
+# location columns but are excluded from the digest, so a no-op
+# line-shifting edit must not flip the id (issue #196).
+#
+# rubocop:disable RSpec/VerifiedDoubles, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe RSpecTracer::Example do
+  # An RSpec::Core::Example-shaped double. The overrides Hash lets
+  # each test vary exactly one identity input (engine_spec's
+  # stub_configuration pattern). The example_group double responds
+  # to `description` but NOT `name`: `from` must read `.description`,
+  # and a `.description` -> `.name` mutation raises here.
+  def build_example(overrides = {})
+    opts = {
+      group_description: 'Calculator', parent_groups: [],
+      description: 'adds two numbers',
+      full_description: 'Calculator adds two numbers',
+      file_path: '/proj/spec/calculator_spec.rb', rerun_file_path: nil,
+      line_number: 7, shared_backtrace: []
+    }.merge(overrides)
+
+    example_group = double(
+      'ExampleGroup', description: opts[:group_description], parent_groups: opts[:parent_groups]
+    )
+    double(
+      'Example',
+      example_group: example_group,
+      description: opts[:description],
+      full_description: opts[:full_description],
+      metadata: {
+        file_path: opts[:file_path],
+        rerun_file_path: opts[:rerun_file_path] || opts[:file_path],
+        line_number: opts[:line_number],
+        shared_group_inclusion_backtrace: opts[:shared_backtrace]
+      }
+    )
+  end
+
+  def build_parent_group(file_path:, line_number:, rerun_file_path: nil)
+    double(
+      'ParentGroup',
+      metadata: {
+        file_path: file_path,
+        rerun_file_path: rerun_file_path || file_path,
+        line_number: line_number
+      }
+    )
+  end
+
+  def shared_frame(location)
+    double('SharedFrame', formatted_inclusion_location: location)
+  end
+
+  describe '.from payload shape' do
+    it 'returns the canonical 9-key identity-hash shape' do
+      expect(described_class.from(build_example)).to include(
+        :example_group, :description, :full_description, :shared_group,
+        :file_name, :line_number, :rerun_file_name, :rerun_line_number, :example_id
+      )
+    end
+
+    it 'computes example_id as a 32-char hex MD5' do
+      expect(described_class.from(build_example)[:example_id]).to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it 'is deterministic for the same example across calls' do
+      first = described_class.from(build_example)
+      second = described_class.from(build_example)
+
+      expect(first[:example_id]).to eq(second[:example_id])
+    end
+
+    it 'passes description and full_description through unchanged' do
+      result = described_class.from(build_example(description: 'd', full_description: 'g d'))
+
+      expect(result[:description]).to eq('d')
+      expect(result[:full_description]).to eq('g d')
+    end
+
+    it 'carries line_number / rerun_* through to the returned Hash (reporter columns)' do
+      result = described_class.from(build_example(line_number: 42))
+
+      expect(result[:line_number]).to eq(42)
+      expect(result[:rerun_line_number]).to eq(42)
+      expect(result[:rerun_file_name]).to eq(result[:file_name])
+    end
+
+    it 'derives file_name from the example metadata file_path' do
+      result = described_class.from(build_example(file_path: '/proj/spec/widget_spec.rb'))
+
+      expect(result[:file_name]).to eq('/proj/spec/widget_spec.rb')
+    end
+  end
+
+  describe '.from example_group identity' do
+    it 'reads example_group.description (the user-supplied string)' do
+      result = described_class.from(build_example(group_description: 'PaymentGateway'))
+
+      expect(result[:example_group]).to eq('PaymentGateway')
+    end
+
+    it 'does not read example_group.name (RSpec load-order-dependent class name — issue #196)' do
+      # build_example's group double responds to :description only;
+      # a `.description` -> `.name` mutation raises an unexpected-message
+      # error here, killing the mutation.
+      expect { described_class.from(build_example) }.not_to raise_error
+    end
+  end
+
+  describe '.from shared_group inclusion frames' do
+    it 'strips the trailing :LINE from each frame location' do
+      result = described_class.from(
+        build_example(shared_backtrace: [shared_frame('./spec/support/shared.rb:53')])
+      )
+
+      expect(result[:shared_group]).to eq(['./spec/support/shared.rb'])
+    end
+
+    it 'strips every frame in a multi-frame backtrace' do
+      frames = [shared_frame('./spec/support/a.rb:1'), shared_frame('./spec/support/b.rb:200')]
+      result = described_class.from(build_example(shared_backtrace: frames))
+
+      expect(result[:shared_group]).to eq(['./spec/support/a.rb', './spec/support/b.rb'])
+    end
+
+    it 'is an empty array when the example uses no shared groups' do
+      expect(described_class.from(build_example)[:shared_group]).to eq([])
+    end
+
+    it 'leaves a frame location with no trailing :LINE untouched' do
+      result = described_class.from(
+        build_example(shared_backtrace: [shared_frame('./spec/support/shared.rb')])
+      )
+
+      expect(result[:shared_group]).to eq(['./spec/support/shared.rb'])
+    end
+  end
+
+  describe '.from cross-file rerun location' do
+    it 'walks parent_groups for the rerun location when the example file differs from its rerun file' do
+      host = build_parent_group(file_path: '/proj/spec/host_spec.rb', line_number: 12)
+      result = described_class.from(build_example(
+                                      file_path: '/proj/spec/support/shared_widgets.rb',
+                                      rerun_file_path: '/proj/spec/host_spec.rb',
+                                      parent_groups: [host]
+                                    ))
+
+      expect(result[:file_name]).to eq('/proj/spec/support/shared_widgets.rb')
+      expect(result[:rerun_file_name]).to eq('/proj/spec/host_spec.rb')
+      expect(result[:rerun_line_number]).to eq(12)
+    end
+
+    it 'skips parent groups whose file does not match the rerun file' do
+      outer = build_parent_group(
+        file_path: '/proj/spec/other_spec.rb', rerun_file_path: '/proj/spec/elsewhere.rb', line_number: 3
+      )
+      host = build_parent_group(file_path: '/proj/spec/host_spec.rb', line_number: 12)
+      result = described_class.from(build_example(
+                                      file_path: '/proj/spec/support/shared_widgets.rb',
+                                      rerun_file_path: '/proj/spec/host_spec.rb',
+                                      parent_groups: [outer, host]
+                                    ))
+
+      expect(result[:rerun_file_name]).to eq('/proj/spec/host_spec.rb')
+      expect(result[:rerun_line_number]).to eq(12)
+    end
+  end
+
+  describe '.from digest EXCLUDES line numbers (the #196 fix)' do
+    it 'is stable when only line_number shifts (no-op edit above the example)' do
+      expect(described_class.from(build_example(line_number: 7))[:example_id])
+        .to eq(described_class.from(build_example(line_number: 99))[:example_id])
+    end
+
+    it 'is stable when shared_group frames differ only in their :LINE' do
+      at53 = described_class.from(build_example(shared_backtrace: [shared_frame('./spec/s.rb:53')]))
+      at99 = described_class.from(build_example(shared_backtrace: [shared_frame('./spec/s.rb:99')]))
+
+      expect(at53[:example_id]).to eq(at99[:example_id])
+    end
+  end
+
+  describe '.from digest INCLUDES every identity field' do
+    it 'changes when example_group changes' do
+      expect(described_class.from(build_example(group_description: 'A'))[:example_id])
+        .not_to eq(described_class.from(build_example(group_description: 'B'))[:example_id])
+    end
+
+    it 'changes when description changes' do
+      expect(described_class.from(build_example(description: 'does X'))[:example_id])
+        .not_to eq(described_class.from(build_example(description: 'does Y'))[:example_id])
+    end
+
+    it 'changes when full_description changes' do
+      expect(described_class.from(build_example(full_description: 'G does X'))[:example_id])
+        .not_to eq(described_class.from(build_example(full_description: 'G does Y'))[:example_id])
+    end
+
+    it 'changes when file_name changes (file rename / move)' do
+      expect(described_class.from(build_example(file_path: '/proj/spec/old_spec.rb'))[:example_id])
+        .not_to eq(described_class.from(build_example(file_path: '/proj/spec/new_spec.rb'))[:example_id])
+    end
+
+    it 'changes when a shared_group inclusion path changes' do
+      a = described_class.from(build_example(shared_backtrace: [shared_frame('./spec/a.rb:1')]))
+      b = described_class.from(build_example(shared_backtrace: [shared_frame('./spec/b.rb:1')]))
+
+      expect(a[:example_id]).not_to eq(b[:example_id])
+    end
+  end
+
+  describe '.from describe-block edge cases' do
+    it 'handles a class describe — description is the coerced class name' do
+      result = described_class.from(build_example(group_description: 'String'))
+
+      expect(result[:example_group]).to eq('String')
+      expect(result[:example_id]).to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it 'handles an anonymous describe — description is empty — without crashing' do
+      result = described_class.from(build_example(group_description: ''))
+
+      expect(result[:example_group]).to eq('')
+      expect(result[:example_id]).to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it 'still differentiates anonymous-describe examples via full_description' do
+      a = described_class.from(build_example(group_description: '', full_description: 'anon does X'))
+      b = described_class.from(build_example(group_description: '', full_description: 'anon does Y'))
+
+      expect(a[:example_id]).not_to eq(b[:example_id])
+    end
+  end
+end
+# rubocop:enable RSpec/VerifiedDoubles, RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/fuzz/json_backend_fuzz.rb
+++ b/spec/fuzz/json_backend_fuzz.rb
@@ -29,6 +29,7 @@ require 'tmpdir'
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
 require 'rspec_tracer/storage/json_backend'
+require 'rspec_tracer/storage/schema'
 
 iterations = Integer(ENV.fetch('ITERATIONS', '100'))
 seed       = Integer(ENV.fetch('SEED', Random.new_seed.to_s))
@@ -54,7 +55,10 @@ Dir.mktmpdir('rspec_tracer_fuzz_') do |cache_path|
 
   # Reasonable-manifest baseline; iterations either corrupt it or
   # corrupt one of the per-run JSON files under run_dir.
-  manifest = { 'schema_version' => 3, 'run_id' => run_id, 'timestamp' => Time.now.utc.iso8601 }
+  manifest = {
+    'schema_version' => RSpecTracer::Storage::Schema::CURRENT,
+    'run_id' => run_id, 'timestamp' => Time.now.utc.iso8601
+  }
   File.write(File.join(cache_path, MANIFEST), JSON.pretty_generate(manifest))
   FILENAMES.each do |name|
     next if name == MANIFEST
@@ -75,7 +79,7 @@ Dir.mktmpdir('rspec_tracer_fuzz_') do |cache_path|
     File.binwrite(target, rng.bytes(length))
 
     begin
-      result = backend.load_graph(schema_version: 3)
+      result = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
       outcomes[result.nil? ? :nil : :snapshot] += 1
     rescue SystemExit, Interrupt
       raise

--- a/spec/integration/example_id_stability_spec.rb
+++ b/spec/integration/example_id_stability_spec.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+# End-to-end regression for #196: example_id stability across runs.
+#
+# `example_id` (the MD5 RSpecTracer::Example.from produces) used to
+# hash `example_group.name` — RSpec's generated class name, which
+# carries a load-order-dependent `_2` / `_3` disambiguator suffix
+# when two spec files share a describe-block name. Two files both
+# `RSpec.describe 'Nice'` produced different example_ids depending
+# on which file rspec loaded first, silently invalidating the cache
+# and breaking the failed/pending/flaky always-re-run guarantees.
+# Line numbers in the payload had the same effect: a no-op blank-line
+# edit flipped the id.
+#
+# This spec drives the ruby_app fixture with bespoke temp spec files
+# (the flaky_detection_spec.rb / run_reason_persistence_spec.rb
+# pattern) and walks the documented stability contract — "rename =
+# new identity; restructure = same identity":
+#
+#   1. multi-file same-`describe` name, both rspec load orders -> the
+#      same `it` keeps its id (the headline #196 bug)
+#   2. no-op blank-line edit above an example -> id unchanged
+#   3. spec file renamed -> id changes (rename = new identity)
+#   4. one shared example included twice in the same host -> the two
+#      inclusions now collide (the :LINE strip is what makes them
+#      collide) and duplicate detection fires
+#   5. two identically-described plain examples in one group ->
+#      duplicate detection fires (line_number no longer false-splits)
+#   6. class describe (RSpec.describe SomeClass) -> stable id
+#   7. anonymous describe (RSpec.describe do ... end) -> valid,
+#      distinct ids; full_description disambiguates
+
+require 'bundler'
+require 'fileutils'
+require 'json'
+require 'open3'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
+RSpec.describe 'example_id stability across runs (issue #196)' do
+  let(:fixture_root) { File.expand_path('../../benchmark/fixtures/ruby_app', __dir__) }
+  let(:cache_dir)    { File.join(fixture_root, 'rspec_tracer_cache') }
+  let(:report_dir)   { File.join(fixture_root, 'rspec_tracer_report') }
+  let(:coverage_dir) { File.join(fixture_root, 'rspec_tracer_coverage') }
+  let(:temp_glob)    { File.join(fixture_root, 'spec', 'rt_idstab_*.rb') }
+
+  around do |example|
+    Bundler.with_unbundled_env do
+      cleanup
+      example.run
+    ensure
+      cleanup
+    end
+  end
+
+  before { ensure_bundle_installed! }
+
+  def cleanup
+    FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+    Dir[temp_glob].each { |f| FileUtils.rm_f(f) }
+  end
+
+  def ensure_bundle_installed!
+    Dir.chdir(fixture_root) do
+      next if system('bundle check > /dev/null 2>&1')
+
+      install_out, install_status = Open3.capture2e('bundle', 'install', '--quiet')
+      raise "bundle install failed in #{fixture_root}:\n#{install_out}" unless install_status.success?
+    end
+  end
+
+  # Writes a spec file under the fixture's spec/ dir; returns the
+  # fixture-relative path for use as a positional rspec arg.
+  def write_spec(basename, body)
+    rel = File.join('spec', "rt_idstab_#{basename}.rb")
+    File.write(File.join(fixture_root, rel), body)
+    rel
+  end
+
+  # Cold run: caches are scrubbed first so every invocation computes
+  # the identity hash fresh — a warm run would skip the example and
+  # echo the seeded id, testing cache persistence rather than
+  # identity computation. Positional spec_files also let a test pin
+  # the rspec file LOAD ORDER. RSPEC_TRACER_DISABLE is deleted from
+  # the child env so a parent-runner setting can't leak in.
+  def run_rspec_cold(*spec_files)
+    FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
+    Open3.capture2e(
+      { 'RSPEC_TRACER_DISABLE' => nil },
+      'bundle', 'exec', 'rspec', '--no-color', *spec_files, chdir: fixture_root
+    )
+  end
+
+  def report_payload
+    JSON.parse(File.read(File.join(report_dir, 'report.json'), encoding: 'UTF-8'))
+  end
+
+  def example_id_for(description_substring)
+    report_payload['reports']['all_examples']
+      .find { |e| e['description']&.include?(description_substring) }
+      &.fetch('id')
+  end
+
+  it 'keeps an example_id stable when two files share a describe name, regardless of load order' do
+    file_a = write_spec('file_a_spec', <<~RUBY)
+      RSpec.describe 'Shared Describe Name' do
+        it 'identity case: example defined in file a' do
+          expect(:a).to eq(:a)
+        end
+      end
+    RUBY
+    file_b = write_spec('file_b_spec', <<~RUBY)
+      RSpec.describe 'Shared Describe Name' do
+        it 'identity case: example defined in file b' do
+          expect(:b).to eq(:b)
+        end
+      end
+    RUBY
+
+    _, status_ab = run_rspec_cold(file_a, file_b)
+    expect(status_ab.exitstatus).to eq(0), 'a-then-b run should pass'
+    a_first = example_id_for('example defined in file a')
+    b_first = example_id_for('example defined in file b')
+
+    _, status_ba = run_rspec_cold(file_b, file_a)
+    expect(status_ba.exitstatus).to eq(0), 'b-then-a run should pass'
+    a_second = example_id_for('example defined in file a')
+    b_second = example_id_for('example defined in file b')
+
+    expect(a_first).not_to be_nil
+    expect(b_first).not_to be_nil
+    expect(a_first).to eq(a_second), 'file-a example_id must not depend on rspec load order'
+    expect(b_first).to eq(b_second), 'file-b example_id must not depend on rspec load order'
+  end
+
+  it 'keeps an example_id stable across a no-op line-shifting edit' do
+    body = <<~RUBY
+      RSpec.describe 'Line Shift Fixture' do
+        it 'identity case: stable under blank-line insertion' do
+          expect(1).to eq(1)
+        end
+      end
+    RUBY
+    spec = write_spec('line_shift_spec', body)
+    run_rspec_cold(spec)
+    before_id = example_id_for('stable under blank-line insertion')
+
+    # Three blank lines above the describe — a pure cosmetic edit.
+    write_spec('line_shift_spec', "\n\n\n#{body}")
+    run_rspec_cold(spec)
+    after_id = example_id_for('stable under blank-line insertion')
+
+    expect(before_id).not_to be_nil
+    expect(before_id).to eq(after_id)
+  end
+
+  it 'changes the example_id when the spec file is renamed (rename = new identity)' do
+    body = <<~RUBY
+      RSpec.describe 'Rename Fixture' do
+        it 'identity case: id tracks the file name' do
+          expect(1).to eq(1)
+        end
+      end
+    RUBY
+    original = write_spec('rename_before_spec', body)
+    run_rspec_cold(original)
+    before_id = example_id_for('id tracks the file name')
+
+    renamed = write_spec('rename_after_spec', body)
+    FileUtils.rm_f(File.join(fixture_root, original))
+    run_rspec_cold(renamed)
+    after_id = example_id_for('id tracks the file name')
+
+    expect(before_id).not_to be_nil
+    expect(after_id).not_to be_nil
+    expect(before_id).not_to eq(after_id)
+  end
+
+  it 'flags a shared example included twice in the same host as a duplicate' do
+    spec = write_spec('shared_dup_spec', <<~RUBY)
+      RSpec.shared_examples 'an identity-stable shared example' do
+        it 'identity case: shared example body' do
+          expect(true).to be(true)
+        end
+      end
+
+      RSpec.describe 'Shared Inclusion Host' do
+        it_behaves_like 'an identity-stable shared example'
+        it_behaves_like 'an identity-stable shared example'
+      end
+    RUBY
+
+    out, = run_rspec_cold(spec)
+
+    expect(out).to match(/\d+ duplicate example\(s\) across \d+ identity hash/)
+  end
+
+  it 'flags two identically-described examples in one group as a duplicate' do
+    spec = write_spec('plain_dup_spec', <<~RUBY)
+      RSpec.describe 'Plain Duplicate Host' do
+        it 'identity case: same description twice' do
+          expect(1).to eq(1)
+        end
+
+        it 'identity case: same description twice' do
+          expect(2).to eq(2)
+        end
+      end
+    RUBY
+
+    out, = run_rspec_cold(spec)
+
+    expect(out).to match(/\d+ duplicate example\(s\) across \d+ identity hash/)
+  end
+
+  it 'produces a stable id for a class describe (RSpec.describe SomeClass)' do
+    spec = write_spec('class_describe_spec', <<~RUBY)
+      RSpec.describe String do
+        it 'identity case: class-described example' do
+          expect(described_class).to eq(String)
+        end
+      end
+    RUBY
+
+    _, first_status = run_rspec_cold(spec)
+    expect(first_status.exitstatus).to eq(0)
+    first_id = example_id_for('class-described example')
+
+    _, second_status = run_rspec_cold(spec)
+    expect(second_status.exitstatus).to eq(0)
+    second_id = example_id_for('class-described example')
+
+    expect(first_id).to match(/\A[0-9a-f]{32}\z/)
+    expect(first_id).to eq(second_id)
+  end
+
+  it 'produces distinct ids for examples under an anonymous describe' do
+    spec = write_spec('anonymous_describe_spec', <<~RUBY)
+      RSpec.describe do
+        it 'identity case: anonymous example one' do
+          expect(1).to eq(1)
+        end
+
+        it 'identity case: anonymous example two' do
+          expect(2).to eq(2)
+        end
+      end
+    RUBY
+
+    _, status = run_rspec_cold(spec)
+
+    expect(status.exitstatus).to eq(0)
+    one_id = example_id_for('anonymous example one')
+    two_id = example_id_for('anonymous example two')
+    expect(one_id).to match(/\A[0-9a-f]{32}\z/)
+    expect(two_id).to match(/\A[0-9a-f]{32}\z/)
+    expect(one_id).not_to eq(two_id)
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/integration/fail_on_duplicates_spec.rb
+++ b/spec/integration/fail_on_duplicates_spec.rb
@@ -31,7 +31,7 @@ require 'tmpdir'
 #
 # Fixture: a parameterized `.each` loop wrapping a single `it` block
 # produces N examples that share example_group + description +
-# full_description + file_name + line_number - which is exactly the
+# full_description + shared_group + file_name - which is exactly the
 # tuple `RSpecTracer::Example.from` MD5-hashes into example_id. So
 # the two iterations collide on rspec-tracer's identity hash even
 # though RSpec itself treats them as distinct examples.

--- a/spec/integration/ruby_app_spec.rb
+++ b/spec/integration/ruby_app_spec.rb
@@ -4,8 +4,8 @@
 # ruby_app fixture. Runs the fixture via subprocess and asserts that:
 #
 #   - the suite exits green cold and warm
-#   - the 13-file cache is written under run_id/, with schema_version 3
-#     in last_run.json
+#   - the 13-file cache is written under run_id/, stamped with the
+#     current schema_version in last_run.json
 #   - dependency + boot_set maps are populated
 #
 # Post-M5.1 there is no "legacy engine" path to compare against -
@@ -64,10 +64,10 @@ RSpec.describe 'ruby_app v2 engine integration' do
       expect(out).to include('RSpec tracer')
     end
 
-    it 'writes a v2 cache with schema_version 3' do
+    it 'writes a v2 cache stamped with the current schema_version' do
       run_rspec
 
-      expect(load_last_run_manifest['schema_version']).to eq(3)
+      expect(load_last_run_manifest['schema_version']).to eq(RSpecTracer::Storage::Schema::CURRENT)
     end
 
     it 'writes every FILENAMES entry under the run-id directory' do

--- a/spec/integration/schema_version_upgrade_spec.rb
+++ b/spec/integration/schema_version_upgrade_spec.rb
@@ -105,6 +105,24 @@ RSpec.describe 'Storage::JsonBackend 1.x -> 2.0 cache schema cold-run upgrade ce
     end
   end
 
+  context 'when the on-disk cache carries the 2.0.0.pre.1 schema (3)' do
+    before do
+      write_legacy_manifest('schema_version' => 3, 'run_id' => 'pre1-run')
+      write_legacy_run_dir('pre1-run', 'all_examples.json' => JSON.dump({}))
+    end
+
+    # The 2.0.0.pre.1 -> pre.2 example-identity change reshaped the
+    # cache; a pre.1 cache (schema_version 3) must trigger one clean
+    # cold run, not a crash, on the pre.2 upgrade.
+    it 'falls back to cold run + logs the version delta' do
+      result = build_backend.load_graph(schema_version: current_schema)
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:info)
+        .with(a_string_including('stored=3').and(a_string_including('cold run')))
+    end
+  end
+
   context 'when the on-disk cache carries a future / unsupported schema' do
     before do
       write_legacy_manifest('schema_version' => 999_999, 'run_id' => 'future-run')

--- a/spec/regressions/gem_generated_example_no_source_spec.rb
+++ b/spec/regressions/gem_generated_example_no_source_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'gem-generated example with phantom file_path (regression for ups
     }
   end
   let(:phantom_example_group) do
-    double('ExampleGroup', name: 'GemGeneratedExamples', parent_groups: [])
+    double('ExampleGroup', description: 'GemGeneratedExamples', parent_groups: [])
   end
   let(:phantom_example) do
     double('Example',

--- a/spec/remote_cache/archive_spec.rb
+++ b/spec/remote_cache/archive_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RSpecTracer::RemoteCache::Archive do
     src = File.join(@dir, 'src')
     FileUtils.mkdir_p(File.join(src, run_id))
     File.write(File.join(src, 'last_run.json'),
-               JSON.pretty_generate('schema_version' => 3, 'run_id' => run_id))
+               JSON.pretty_generate('schema_version' => 4, 'run_id' => run_id))
     file_count.times do |i|
       File.write(File.join(src, run_id, "file#{i}.json"),
                  JSON.pretty_generate('k' => 'v' * 100))

--- a/spec/storage/schema_spec.rb
+++ b/spec/storage/schema_spec.rb
@@ -4,8 +4,8 @@ require 'rspec_tracer/storage/schema'
 
 RSpec.describe RSpecTracer::Storage::Schema do
   describe 'CURRENT' do
-    it 'is 3 (M3.7 added Snapshot.boot_set; prior v2 shape is not backward-readable)' do
-      expect(described_class::CURRENT).to eq(3)
+    it 'is 4 (schema 4 reshaped the example-identity payload; schema-3 caches no longer match)' do
+      expect(described_class::CURRENT).to eq(4)
     end
   end
 

--- a/taskfiles/test-mutation.yml
+++ b/taskfiles/test-mutation.yml
@@ -9,12 +9,12 @@ version: '3'
 tasks:
   test:mutation:smoke:
     desc: >-
-      Mutation smoke — 14 subjects (TimeFormatter.format_time, Tracker::Input,
-      Tracker::DeclaredGlobs, Tracker::WholeSuiteInvalidators, Storage::Schema,
-      Storage::Snapshot, Storage::Backend, Tracker::DependencyGraph,
-      Tracker::ExampleRegistry, Tracker::Filter, Tracker::LoadedFilesTracker,
-      Rails::Preset, Tracker::EnvSnapshot, Tracker::EnvMatcher)
-      must each hit >= 90% (< 2 min budget)
+      Mutation smoke — 15 subjects (TimeFormatter.format_time, Example,
+      Tracker::Input, Tracker::DeclaredGlobs, Tracker::WholeSuiteInvalidators,
+      Storage::Schema, Storage::Snapshot, Storage::Backend,
+      Tracker::DependencyGraph, Tracker::ExampleRegistry, Tracker::Filter,
+      Tracker::LoadedFilesTracker, Rails::Preset, Tracker::EnvSnapshot,
+      Tracker::EnvMatcher) must each hit >= 90% (< 2 min budget)
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -54,6 +54,9 @@ tasks:
         run_mutant_subject "TimeFormatter.format_time" \
           "rspec_tracer/time_formatter" \
           "RSpecTracer::TimeFormatter.format_time" || fail=1
+        run_mutant_subject "Example" \
+          "rspec_tracer/example" \
+          "RSpecTracer::Example*" || fail=1
         run_mutant_subject "Tracker::Input" \
           "rspec_tracer/tracker/input" \
           "RSpecTracer::Tracker::Input*" || fail=1


### PR DESCRIPTION
## Summary

`example_id` is the MD5 `RSpecTracer::Example.from` attaches to every example. Pre-fix it hashed RSpec's generated example-group class name (`example_group.name`) plus line numbers — so the same example got a different id depending on rspec's file load order (when two files share a `describe` name) or after a no-op blank-line edit. That silently thrashed the cache and broke the failed / pending / flaky always-re-run guarantees.

Per the holistic identity-hash audit on the issue ([#196 comment](https://github.com/avmnu-sng/rspec-tracer/issues/196#issuecomment-4433443921)), the digest now covers only a stable subset:

- `example_group` — the describe block's `.description` string, not the load-order-dependent generated class name
- `description`, `full_description`
- `shared_group` — inclusion locations with the trailing `:LINE` stripped
- `file_name`

`line_number` / `rerun_file_name` / `rerun_line_number` still ride along in the returned Hash for the reporter + `explain` location columns, but no longer enter the digest — so the reporter / `explain` output is unchanged.

### Stability contract

*Rename = new identity; restructure = same identity.* Documented in a YARD comment on `RSpecTracer::Example` and in `UPGRADING.md`. Identity is preserved across blank-line / comment edits, example reordering, sibling renames, and metadata changes; it changes only when a file / `describe` / `it` / shared-example is renamed or moved.

### Cache schema bump

`Storage::Schema::CURRENT` 3 → 4. Every cached `example_id` changes, so a `2.0.0.pre.1` cache cold-loads cleanly on upgrade — one cold run, then warm. `UPGRADING.md`'s "Cache: one cold run on upgrade" section documents it; `spec/integration/schema_version_upgrade_spec.rb` gains a case asserting a schema-3 cache triggers a clean cold run.

### Duplicate-detection consequence

Dropping line numbers from the digest means two identically-described examples in one `describe`, or one shared example included twice in the same host, now collide on identity and surface via duplicate detection — where line numbers previously gave them a false-distinct identity that broke on any blank-line edit. This is the intended behavior; covered by two cases in the new integration spec.

## Test plan

- [x] `task lint:ruby` / `lint:actions` / `lint:yaml` — clean (1 pre-existing gemspec warning, unrelated)
- [x] `task test:unit` — 2035 examples, 0 failures
- [x] `task test:property` / `test:dogfood` / `test:fuzz:smoke` — green
- [x] `task test:mutation:smoke` — all 15 subjects ≥ 90% (`Example` 93.63%, `Storage::Schema` 100%; `Example` newly registered in the smoke gate)
- [x] `task benchmark:smoke` — `cold_ruby` + `warm_noop` within ratchet
- [x] `task docs:yard:check` — 100%
- [x] codecov-equivalent patch coverage inspected — `example.rb` + `storage/schema.rb` have zero uncovered lines / branches
- [x] new `spec/example_spec.rb` (24 unit tests) + `spec/integration/example_id_stability_spec.rb` (7 cases: multi-file load-order stability, line-shift no-op, file-rename, shared-example-twice + plain-`it` duplicate detection, class describe, anonymous describe)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)