### PR TITLE
fix(example): stabilize example_id for unnamed examples

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -61,6 +61,15 @@ renaming a file, `describe`, or `it` gives an example a new identity
 (one cold run); restructuring around it — blank lines, reordering,
 metadata edits — keeps it warm.
 
+One carve-out: an **unnamed** example (`it { ... }`, `specify { ... }`,
+`example { ... }` — no description string) has no stable name to hash,
+so its identity is its position among the unnamed examples of its
+group. Blank-line and comment edits still keep it warm, and adding or
+renaming *named* siblings doesn't disturb it — but reordering the
+unnamed examples, or inserting/removing one ahead of it, gives the
+shifted examples a new identity (one cold run). Give an example an
+explicit description for a fully reorder-stable identity.
+
 ## SimpleCov branch coverage now works
 
 The 1.x README warned: *"If you use RSpec Tracer with SimpleCov, then
@@ -107,6 +116,27 @@ A `.rspec-tracer` file using only the old names runs identically to one
 using the new names; the warns are advisory.
 
 ## Behavior changes worth knowing
+
+### Duplicate example identities
+
+rspec-tracer identifies each example by a hash of its `describe`
+chain, description, and file, so it can carry that example's
+pass / fail / flaky history across runs. Two examples that hash to
+the *same* identity can't be tracked apart — which happens when
+examples are genuinely indistinguishable: a copy-pasted `it` with an
+identical description in the same group, or a parameterized
+`[...].each { it 'same description' do ... end }` loop.
+
+From 2.0.0.pre.2 on, rspec-tracer logs an error that **names the
+colliding examples** (file, line, description), **drops just those
+examples** from the run, and runs the rest of the suite normally.
+`fail_on_duplicates` (default `true`) then governs the exit code —
+the run still exits non-zero so the collision can't pass unnoticed in
+CI; `fail_on_duplicates false` keeps the exit code at zero. Either
+way, the fix is to give the colliding examples distinct descriptions.
+
+Unnamed `it { ... }` blocks do *not* collide this way — each gets a
+distinct position-based identity (see the cache section above).
 
 ### `track_ar_schema_notifications` precondition
 

--- a/lib/rspec_tracer/example.rb
+++ b/lib/rspec_tracer/example.rb
@@ -60,6 +60,13 @@ module RSpecTracer
   # Helpers are `def self.x` + `private_class_method` so mutant
   # attributes mutations through the singleton call path.
   module Example
+    # Identity-keyed cache of `<example_group> => Array<unnamed sibling>`
+    # populated lazily by `unnamed_description`. A group with N unnamed
+    # examples computes the sibling list once per group rather than N
+    # times. Memory is bounded by the live group set (RSpec retains
+    # those for the run anyway).
+    @unnamed_siblings_cache = {}.compare_by_identity
+
     # Builds the identity payload for one RSpec example. The MD5 is
     # taken over the stability-contract subset (see `digest_identity`
     # for the named-vs-unnamed split); `line_number` / `rerun_*` ride
@@ -114,11 +121,22 @@ module RSpecTracer
     # are reordered or one is inserted / removed ahead of it (the
     # documented carve-out - see the module comment). Closes the
     # remaining #196 gap reported in #210.
+    #
+    # The unnamed-siblings list is memoized per example_group object,
+    # so a group with N unnamed examples computes the list once, not N
+    # times. The discriminator string takes a Ruby-inspect-style
+    # `#<...>` form to make spoofing implausible - and even if a user
+    # description literally matched, full_description would still
+    # differ between the unnamed example (`"<group> "`) and the named
+    # one (`"<group> #<...>"`), so no real digest collision is
+    # possible.
     # @api private
     def self.unnamed_description(example)
-      unnamed_siblings = example.example_group.examples.select { |sibling| unnamed?(sibling) }
+      group = example.example_group
+      unnamed_siblings = @unnamed_siblings_cache[group] ||=
+        group.examples.select { |sibling| unnamed?(sibling) }
 
-      "example at unnamed index #{unnamed_siblings.index(example)}"
+      "#<rspec-tracer unnamed example #{unnamed_siblings.index(example)}>"
     end
 
     # Internal helper for the tracer pipeline.

--- a/lib/rspec_tracer/example.rb
+++ b/lib/rspec_tracer/example.rb
@@ -15,7 +15,8 @@ module RSpecTracer
   #
   # Identity is PRESERVED when:
   # - blank lines or comments are added/removed around the example
-  # - examples are reordered within a describe block
+  # - examples are reordered within a describe block (named
+  #   examples only - see "Unnamed examples" below)
   # - a sibling describe / example in the same file is renamed
   # - metadata changes (`skip:`, tags, `tracks: { ... }`) - the
   #   spec-file digest still triggers the re-run and status history
@@ -27,6 +28,25 @@ module RSpecTracer
   # - the file is renamed or moved
   # - the `describe` / `it` / shared-example name is changed
   # - the example moves to a different describe block
+  #
+  # == Unnamed examples (`it { }`, `specify { }`, `example { }`)
+  #
+  # An example with no description string has no stable name to hash,
+  # and identity must be computed pre-run (for the filter decision),
+  # before RSpec generates a matcher-derived description. The only
+  # line-independent signal RSpec exposes pre-run is position, so an
+  # unnamed example's identity is derived from its ordinal among the
+  # *unnamed* examples of its group. (RSpec's `description` for an
+  # unnamed example is the line-bearing `"example at <path>:<line>"`
+  # fallback, which would otherwise leak the line number straight
+  # back into the digest - issue #210.)
+  #
+  # For unnamed examples the contract above is amended: identity is
+  # still PRESERVED across blank-line / comment edits, sibling
+  # renames, and adding or removing *named* siblings - but it CHANGES
+  # when the unnamed examples are reordered, or one is inserted or
+  # removed ahead of it. Give an example an explicit description
+  # (`it 'does X' do`) for a fully reorder-stable identity.
   #
   # `line_number` / `rerun_file_name` / `rerun_line_number` stay in
   # the returned Hash for the reporter + `explain` location columns,
@@ -41,10 +61,10 @@ module RSpecTracer
   # attributes mutations through the singleton call path.
   module Example
     # Builds the identity payload for one RSpec example. The MD5 is
-    # taken over `identity` only (the stability-contract subset);
-    # `line_number` / `rerun_*` ride along in the returned Hash for
-    # the reporters but never enter the digest. See the module
-    # comment for the full stability contract.
+    # taken over the stability-contract subset (see `digest_identity`
+    # for the named-vs-unnamed split); `line_number` / `rerun_*` ride
+    # along in the returned Hash for the reporters but never enter the
+    # digest. See the module comment for the full stability contract.
     # @api private
     def self.from(example)
       location = example_location(example)
@@ -59,7 +79,46 @@ module RSpecTracer
 
       identity
         .merge(location)
-        .merge(example_id: Digest::MD5.hexdigest(identity.to_json))
+        .merge(example_id: Digest::MD5.hexdigest(digest_identity(example, identity).to_json))
+    end
+
+    # The Hash actually fed to the MD5. For a named example this is
+    # `identity` unchanged - byte-identical to the pre-#210 digest.
+    # For an unnamed example (`it { }` / `specify { }` / `example { }`)
+    # RSpec's `description` is the line-bearing location fallback
+    # `"example at <path>:<line>"`, so `description` is swapped for a
+    # line-independent positional discriminator before hashing. The
+    # returned/stored payload still carries RSpec's `description` /
+    # `full_description` untouched - only the digest input differs.
+    # @api private
+    def self.digest_identity(example, identity)
+      return identity unless unnamed?(example)
+
+      identity.merge(description: unnamed_description(example))
+    end
+
+    # True when the example has no explicit description string. RSpec's
+    # raw `metadata[:description]` is `""` for `it { }` / `specify { }`
+    # / `example { }`; the `description` *method* would instead return
+    # the line-bearing `"example at <path>:<line>"` fallback, so the
+    # raw metadata value is what cleanly tells named from unnamed.
+    # @api private
+    def self.unnamed?(example)
+      example.metadata[:description].to_s.strip.empty?
+    end
+
+    # Line-independent identity discriminator for an unnamed example:
+    # its 0-based ordinal among the *unnamed* examples of its group.
+    # Stable across blank-line / comment edits and across adding or
+    # renaming *named* siblings; changes only when the unnamed examples
+    # are reordered or one is inserted / removed ahead of it (the
+    # documented carve-out - see the module comment). Closes the
+    # remaining #196 gap reported in #210.
+    # @api private
+    def self.unnamed_description(example)
+      unnamed_siblings = example.example_group.examples.select { |sibling| unnamed?(sibling) }
+
+      "example at unnamed index #{unnamed_siblings.index(example)}"
     end
 
     # Internal helper for the tracer pipeline.
@@ -105,6 +164,7 @@ module RSpecTracer
       RSpecTracer::SourceFile.file_name(file_path)
     end
 
-    private_class_method :example_location, :example_rerun_location, :location_file_name
+    private_class_method :digest_identity, :unnamed?, :unnamed_description,
+                         :example_location, :example_rerun_location, :location_file_name
   end
 end

--- a/lib/rspec_tracer/rspec/runner_hook.rb
+++ b/lib/rspec_tracer/rspec/runner_hook.rb
@@ -209,7 +209,7 @@ module RSpecTracer
       # colliding ones are removed.
       # @api private
       def _rspec_tracer_drop_duplicate_examples(examples_map, example_groups)
-        duplicate_ids = RSpecTracer.engine.duplicate_examples.keys
+        duplicate_ids = Set.new(RSpecTracer.engine.duplicate_examples.keys)
 
         kept_map = examples_map.each_with_object({}) do |(group, examples), kept|
           survivors = examples.reject do |example|

--- a/lib/rspec_tracer/rspec/runner_hook.rb
+++ b/lib/rspec_tracer/rspec/runner_hook.rb
@@ -20,9 +20,11 @@ module RSpecTracer
     #      ignored examples (matched by `Configuration#ignore_spec_files`)
     #      pass through untouched - RSpec still runs them, but the tracer
     #      never sees them. Closes #41.
-    #   3. Detect duplicate example identities. `fail_on_duplicates=true`
-    #      surfaces via `::Kernel.exit(1)` in `at_exit_behavior`; the
-    #      hook passes `[]` to super so RSpec doesn't execute anything.
+    #   3. Detect duplicate example identities. Colliding examples are
+    #      dropped from the run (per-example tracking can't attribute
+    #      coverage to two examples sharing one identity hash); the
+    #      rest of the suite still runs. `fail_on_duplicates=true` then
+    #      surfaces a `::Kernel.exit(1)` in `at_exit_behavior`.
     #   4. Overwrite `RSpec.world.@filtered_examples` +
     #      `@example_groups` with the filtered set, then log the run
     #      banner and delegate to `super`.
@@ -46,10 +48,9 @@ module RSpecTracer
         filtered_examples_map, filtered_example_groups = _rspec_tracer_build_filter_decision
 
         if _rspec_tracer_duplicates_detected?
-          RSpecTracer.running = true
           RSpecTracer.duplicate_examples = RSpecTracer.fail_on_duplicates
-          super([])
-          return
+          filtered_examples_map, filtered_example_groups =
+            _rspec_tracer_drop_duplicate_examples(filtered_examples_map, filtered_example_groups)
         end
 
         ::RSpec.world.instance_variable_set(:@filtered_examples, filtered_examples_map)
@@ -160,18 +161,64 @@ module RSpecTracer
         end
       end
 
-      # Internal method on the tracer pipeline.
+      # Logs the duplicate-identity diagnostic and returns whether any
+      # were found. The summary line keeps its 1.x wording (CI log
+      # parsers + specs match on it); the indented detail names each
+      # colliding example so the user can find and rename them.
       # @api private
       def _rspec_tracer_duplicates_detected?
         duplicates = RSpecTracer.engine.duplicate_examples
         return false if duplicates.empty?
 
         total = duplicates.sum { |_, entries| entries.count }
-        hashes = duplicates.size
         RSpecTracer.logger.error(
-          "RSpec tracer detected #{total} duplicate example(s) across #{hashes} identity hash(es)"
+          "RSpec tracer detected #{total} duplicate example(s) across " \
+          "#{duplicates.size} identity hash(es). Examples that share one rspec-tracer " \
+          'identity cannot be tracked separately and are dropped from this run - give ' \
+          "them distinct descriptions to fix:\n#{_rspec_tracer_duplicate_report(duplicates)}"
         )
         true
+      end
+
+      # The indented per-hash detail block for the duplicate
+      # diagnostic: the identity hash, then one labelled line per
+      # colliding example under it.
+      # @api private
+      def _rspec_tracer_duplicate_report(duplicates)
+        duplicates.map do |example_id, entries|
+          labelled = entries.map { |entry| "    - #{_rspec_tracer_example_label(entry)}" }
+          "  #{example_id}\n#{labelled.join("\n")}"
+        end.join("\n")
+      end
+
+      # `file:line description` for one colliding example, read off the
+      # `Example.from` payload (rerun location preferred, mirroring the
+      # reporter + `explain` columns).
+      # @api private
+      def _rspec_tracer_example_label(entry)
+        file = entry[:rerun_file_name] || entry[:file_name]
+        line = entry[:rerun_line_number] || entry[:line_number]
+
+        "#{file}:#{line} #{entry[:full_description] || entry[:description]}".rstrip
+      end
+
+      # Drops the colliding examples from the filtered run set. The
+      # rest of the suite still runs; `fail_on_duplicates` governs only
+      # the exit code (via `at_exit_behavior`), not whether anything
+      # runs. A group is kept only if it still has examples after the
+      # colliding ones are removed.
+      # @api private
+      def _rspec_tracer_drop_duplicate_examples(examples_map, example_groups)
+        duplicate_ids = RSpecTracer.engine.duplicate_examples.keys
+
+        kept_map = examples_map.each_with_object({}) do |(group, examples), kept|
+          survivors = examples.reject do |example|
+            duplicate_ids.include?(example.metadata[:rspec_tracer_example_id])
+          end
+          kept[group] = survivors unless survivors.empty?
+        end
+
+        [kept_map, example_groups.select { |group| kept_map.key?(group) }]
       end
     end
   end

--- a/lib/rspec_tracer/storage/schema.rb
+++ b/lib/rspec_tracer/storage/schema.rb
@@ -23,13 +23,17 @@ module RSpecTracer
     module Schema
       # 1.x caches were unstamped; schema_version 2 was the first
       # versioned schema, and 2.0 bumped to 3 when `Snapshot.boot_set`
-      # landed. schema_version 4 changes the example-identity payload:
-      # `example_id` now hashes the describe block's *description*
-      # (not RSpec's load-order-dependent class name) and excludes
-      # line numbers, so a 3-stamped cache's example_ids no longer
-      # match. The change is breaking, so SUPPORTED stays `[CURRENT]`
-      # and the caller pays one cold run on upgrade.
-      CURRENT = 4
+      # landed. schema_version 4 reshaped the example-identity payload:
+      # `example_id` hashes the describe block's *description* (not
+      # RSpec's load-order-dependent class name) and excludes line
+      # numbers. schema_version 5 closes the remaining gap for unnamed
+      # examples (`it { }` / `specify { }` / `example { }`): their
+      # `example_id` now derives from an intra-group ordinal instead
+      # of RSpec's line-bearing `"example at <path>:<line>"` fallback,
+      # so a 4-stamped cache's unnamed-example ids no longer match.
+      # Each bump is breaking, so SUPPORTED stays `[CURRENT]` and the
+      # caller pays one cold run on upgrade.
+      CURRENT = 5
       # Internal constant.
       # @api private
       SUPPORTED = [CURRENT].freeze

--- a/spec/example_spec.rb
+++ b/spec/example_spec.rb
@@ -12,6 +12,14 @@ require 'rspec_tracer'
 # location columns but are excluded from the digest, so a no-op
 # line-shifting edit must not flip the id (issue #196).
 #
+# For an UNNAMED example (it { } / specify { } / example { }) RSpec's
+# `description` is the line-bearing "example at <path>:<line>"
+# fallback, which would re-leak the line number into the digest; the
+# digest substitutes the example's ordinal among its group's unnamed
+# examples instead (issue #210). The it-side variant matrix below
+# exercises every shape: named/unnamed, the ordinal's line-
+# independence, within-group uniqueness, and the reorder carve-out.
+#
 # rubocop:disable RSpec/VerifiedDoubles, RSpec/MultipleExpectations, RSpec/ExampleLength
 RSpec.describe RSpecTracer::Example do
   # An RSpec::Core::Example-shaped double. The overrides Hash lets
@@ -19,30 +27,41 @@ RSpec.describe RSpecTracer::Example do
   # stub_configuration pattern). The example_group double responds
   # to `description` but NOT `name`: `from` must read `.description`,
   # and a `.description` -> `.name` mutation raises here.
+  #
+  # `raw_description` is metadata[:description] - RSpec's RAW explicit
+  # description string ('' or nil for an unnamed it { } / specify { }
+  # / example { }). It defaults to `description`, so a plain
+  # build_example models a NAMED example; pass `raw_description: ''`
+  # for an unnamed one. `siblings` overrides example_group.examples
+  # (default [self]) so `Example.unnamed_description` can take the
+  # intra-group ordinal.
   def build_example(overrides = {})
     opts = {
       group_description: 'Calculator', parent_groups: [],
-      description: 'adds two numbers',
-      full_description: 'Calculator adds two numbers',
+      description: 'adds two numbers', full_description: 'Calculator adds two numbers',
       file_path: '/proj/spec/calculator_spec.rb', rerun_file_path: nil,
       line_number: 7, shared_backtrace: []
     }.merge(overrides)
 
+    raw_description = overrides.key?(:raw_description) ? overrides[:raw_description] : opts[:description]
     example_group = double(
       'ExampleGroup', description: opts[:group_description], parent_groups: opts[:parent_groups]
     )
-    double(
+    example = double(
       'Example',
       example_group: example_group,
       description: opts[:description],
       full_description: opts[:full_description],
       metadata: {
+        description: raw_description,
         file_path: opts[:file_path],
         rerun_file_path: opts[:rerun_file_path] || opts[:file_path],
         line_number: opts[:line_number],
         shared_group_inclusion_backtrace: opts[:shared_backtrace]
       }
     )
+    allow(example_group).to receive(:examples).and_return(overrides[:siblings] || [example])
+    example
   end
 
   def build_parent_group(file_path:, line_number:, rerun_file_path: nil)
@@ -58,6 +77,50 @@ RSpec.describe RSpecTracer::Example do
 
   def shared_frame(location)
     double('SharedFrame', formatted_inclusion_location: location)
+  end
+
+  # Builds N example doubles sharing one example_group, for the
+  # intra-group-ordinal tests. Each entry in `raw_descriptions` is one
+  # example's metadata[:description] ('' / nil => unnamed). Every
+  # example's example_group.examples is the full ordered list, so
+  # `Example.unnamed_description` can take ordinals. `line_base`
+  # shifts every line number uniformly (a no-op-edit simulation)
+  # without changing definition order.
+  def build_group(raw_descriptions, group_description: 'G', file_path: '/proj/spec/g_spec.rb', line_base: 0)
+    examples = []
+    example_group = double('ExampleGroup', description: group_description, parent_groups: [])
+    allow(example_group).to receive(:examples).and_return(examples)
+    raw_descriptions.each_with_index do |raw, idx|
+      line = line_base + ((idx + 1) * 10)
+      unnamed = raw.to_s.strip.empty?
+      examples << double(
+        "Example#{idx}",
+        example_group: example_group,
+        description: unnamed ? "example at #{file_path}:#{line}" : raw,
+        full_description: unnamed ? "#{group_description} " : "#{group_description} #{raw}",
+        metadata: {
+          description: raw,
+          file_path: file_path,
+          rerun_file_path: file_path,
+          line_number: line,
+          shared_group_inclusion_backtrace: []
+        }
+      )
+    end
+    examples
+  end
+
+  # An unnamed-example double (it { } / specify { } / example { }):
+  # empty metadata[:description], with `description` modelling RSpec's
+  # line-bearing "example at <path>:<line>" pre-run fallback.
+  def unnamed_example(line:, siblings: nil)
+    build_example(
+      raw_description: '',
+      description: "example at /proj/spec/calculator_spec.rb:#{line}",
+      full_description: 'Calculator ',
+      line_number: line,
+      siblings: siblings
+    )
   end
 
   describe '.from payload shape' do
@@ -238,6 +301,92 @@ RSpec.describe RSpecTracer::Example do
       b = described_class.from(build_example(group_description: '', full_description: 'anon does Y'))
 
       expect(a[:example_id]).not_to eq(b[:example_id])
+    end
+  end
+
+  describe '.from unnamed examples (it { } / specify { } / example { } — issue #210)' do
+    # An unnamed example has no explicit description string, so RSpec's
+    # `description` method returns the line-bearing
+    # "example at <path>:<line>" fallback (computed pre-run, before any
+    # matcher description exists). `Example.from` must not let that
+    # line number reach the digest: it substitutes the example's
+    # ordinal among its group's UNNAMED examples. `it`, `specify` and
+    # `example` are indistinguishable here (all yield an empty
+    # metadata[:description]); alias coverage lives in
+    # spec/integration/example_id_stability_spec.rb.
+
+    it 'still produces a valid 32-char hex example_id' do
+      expect(described_class.from(unnamed_example(line: 7))[:example_id])
+        .to match(/\A[0-9a-f]{32}\z/)
+    end
+
+    it 'is line-independent — a no-op edit above an it { } no longer flips the id (#210)' do
+      at7 = described_class.from(unnamed_example(line: 7))
+      at99 = described_class.from(unnamed_example(line: 99))
+
+      expect(at7[:example_id]).to eq(at99[:example_id])
+    end
+
+    it 'stays line-independent even with a named sibling present and a large line shift' do
+      shifted = build_group(['', 'a named sibling'], line_base: 500).first
+      unshifted = build_group(['', 'a named sibling'], line_base: 0).first
+
+      expect(described_class.from(shifted)[:example_id])
+        .to eq(described_class.from(unshifted)[:example_id])
+    end
+
+    it 'keeps RSpec description / full_description in the stored payload (digest-input only)' do
+      result = described_class.from(unnamed_example(line: 7))
+
+      # the line-bearing description never enters the digest, but it
+      # IS carried through for the reporter + `explain` columns.
+      expect(result[:description]).to eq('example at /proj/spec/calculator_spec.rb:7')
+      expect(result[:full_description]).to eq('Calculator ')
+    end
+
+    it 'gives two unnamed siblings distinct ids — positional, so reordering them re-keys (carve-out)' do
+      # unnamed identity is the ordinal among unnamed siblings, so the
+      # 1st and 2nd unnamed examples get distinct ids; the documented
+      # cost is that swapping two unnamed examples swaps their ids.
+      first, second = build_group(['', ''])
+
+      expect(described_class.from(first)[:example_id])
+        .not_to eq(described_class.from(second)[:example_id])
+    end
+
+    it 'counts the ordinal among UNNAMED siblings only — a named sibling does not shift it' do
+      # the unnamed example sits at all-index 1 here, all-index 2 here,
+      # but unnamed-index 0 in both => identical id.
+      after_one_named = build_group(['a named example', ''])[1]
+      after_two_named = build_group(['a named example', 'another named one', ''])[2]
+
+      expect(described_class.from(after_one_named)[:example_id])
+        .to eq(described_class.from(after_two_named)[:example_id])
+    end
+
+    it 'treats a nil metadata[:description] as unnamed (kills the .to_s guard mutation)' do
+      at7 = build_example(raw_description: nil, description: 'example at /x:7', line_number: 7)
+      at9 = build_example(raw_description: nil, description: 'example at /x:9', line_number: 9)
+
+      expect(described_class.from(at7)[:example_id]).to eq(described_class.from(at9)[:example_id])
+    end
+
+    it 'treats an all-whitespace metadata[:description] as unnamed (kills the .strip mutation)' do
+      at7 = build_example(raw_description: '   ', description: 'example at /x:7', line_number: 7)
+      at9 = build_example(raw_description: '   ', description: 'example at /x:9', line_number: 9)
+
+      expect(described_class.from(at7)[:example_id]).to eq(described_class.from(at9)[:example_id])
+    end
+
+    it 'leaves named examples on the #209 digest path — the ordinal branch never touches them' do
+      # the unnamed-ordinal path reads example_group.examples; a named
+      # example must never consult it. Identical named identity inputs
+      # + wildly different sibling lists => identical example_id.
+      lonely = build_example(siblings: [])
+      crowded = build_example(siblings: [double('x'), double('y'), double('z')])
+
+      expect(described_class.from(lonely)[:example_id])
+        .to eq(described_class.from(crowded)[:example_id])
     end
   end
 end

--- a/spec/integration/example_id_stability_spec.rb
+++ b/spec/integration/example_id_stability_spec.rb
@@ -29,6 +29,13 @@
 #   6. class describe (RSpec.describe SomeClass) -> stable id
 #   7. anonymous describe (RSpec.describe do ... end) -> valid,
 #      distinct ids; full_description disambiguates
+#   8. it { } / specify { } / example { } (unnamed) -> id stable
+#      across a no-op line-shift; #209's fix didn't reach these
+#      because RSpec's pre-run `description` for an unnamed example
+#      is the line-bearing "example at <path>:<line>" fallback (#210)
+#   9. N sibling it { } blocks -> N distinct ids, suite runs all N
+#      (the intra-group ordinal keeps them from colliding)
+#  10. specify { } / example { } behave identically to it { }
 
 require 'bundler'
 require 'fileutils'
@@ -84,10 +91,15 @@ RSpec.describe 'example_id stability across runs (issue #196)' do
   # the child env so a parent-runner setting can't leak in.
   def run_rspec_cold(*spec_files)
     FileUtils.rm_rf([cache_dir, report_dir, coverage_dir])
-    Open3.capture2e(
+    out, status = Open3.capture2e(
       { 'RSPEC_TRACER_DISABLE' => nil },
       'bundle', 'exec', 'rspec', '--no-color', *spec_files, chdir: fixture_root
     )
+    # rspec-tracer's run summary carries a non-ASCII '·'; force UTF-8 +
+    # scrub so callers can `match` against `out` regardless of the
+    # parent process's default external encoding (US-ASCII under a
+    # bare LANG).
+    [out.dup.force_encoding('UTF-8').scrub, status]
   end
 
   def report_payload
@@ -254,6 +266,80 @@ RSpec.describe 'example_id stability across runs (issue #196)' do
     expect(one_id).to match(/\A[0-9a-f]{32}\z/)
     expect(two_id).to match(/\A[0-9a-f]{32}\z/)
     expect(one_id).not_to eq(two_id)
+  end
+
+  # --- issue #210: unnamed examples (it { } / specify { } / example { }) ---
+  #
+  # An unnamed example's report description is its group's
+  # full_description ("<group> "), since RSpec's pre-run example
+  # description is the line-bearing location fallback — so these
+  # cases key example_id_for on a distinctive GROUP name.
+
+  it 'keeps an it { } example_id stable across a no-op line-shifting edit (#210)' do
+    body = <<~RUBY
+      RSpec.describe 'Unnamed Line Shift Fixture' do
+        it { expect(1).to eq(1) }
+      end
+    RUBY
+    spec = write_spec('unnamed_line_shift_spec', body)
+    run_rspec_cold(spec)
+    before_id = example_id_for('Unnamed Line Shift Fixture')
+
+    # Three blank lines above the describe — a pure cosmetic edit that
+    # shifts the it { } block's line number. Pre-#210 this flipped the
+    # id: RSpec's "example at <path>:<line>" fallback leaked the line.
+    write_spec('unnamed_line_shift_spec', "\n\n\n#{body}")
+    run_rspec_cold(spec)
+    after_id = example_id_for('Unnamed Line Shift Fixture')
+
+    expect(before_id).not_to be_nil
+    expect(before_id).to eq(after_id)
+  end
+
+  it 'gives N sibling it { } blocks N distinct ids and runs all N (no false collision)' do
+    spec = write_spec('unnamed_siblings_spec', <<~RUBY)
+      RSpec.describe 'Unnamed Siblings Fixture' do
+        it { expect(1).to eq(1) }
+        it { expect(2).to eq(2) }
+        it { expect(3).to eq(3) }
+      end
+    RUBY
+
+    out, status = run_rspec_cold(spec)
+
+    # Each it { } gets a distinct intra-group ordinal, so the three do
+    # NOT collide into one identity hash. A naive line-strip would
+    # have collided them and tripped duplicate detection, which would
+    # then drop them from the run.
+    expect(status.exitstatus).to eq(0), "expected all three to run:\n#{out}"
+    expect(out).not_to match(/duplicate example\(s\)/)
+    ids = report_payload['reports']['all_examples'].map { |entry| entry['id'] }
+    expect(ids.size).to eq(3)
+    expect(ids.uniq.size).to eq(3)
+  end
+
+  it 'treats specify { } and example { } like it { } — line-shift-stable' do
+    body = <<~RUBY
+      RSpec.describe 'Specify Alias Fixture' do
+        specify { expect(1).to eq(1) }
+      end
+
+      RSpec.describe 'Example Alias Fixture' do
+        example { expect(2).to eq(2) }
+      end
+    RUBY
+    spec = write_spec('unnamed_aliases_spec', body)
+    run_rspec_cold(spec)
+    specify_before = example_id_for('Specify Alias Fixture')
+    example_before = example_id_for('Example Alias Fixture')
+
+    write_spec('unnamed_aliases_spec', "\n\n\n#{body}")
+    run_rspec_cold(spec)
+
+    expect(specify_before).not_to be_nil
+    expect(example_before).not_to be_nil
+    expect(specify_before).to eq(example_id_for('Specify Alias Fixture'))
+    expect(example_before).to eq(example_id_for('Example Alias Fixture'))
   end
 end
 # rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/integration/fail_on_duplicates_spec.rb
+++ b/spec/integration/fail_on_duplicates_spec.rb
@@ -14,20 +14,24 @@ require 'tmpdir'
 #   2. ENV path - `RSPEC_TRACER_FAIL_ON_DUPLICATES=true` overrides
 #      the DSL value at config-load time.
 #
-# Behavioral contract:
-#   - When duplicates detected AND fail_on_duplicates=true:
-#       runner_hook drops every group from the run; at_exit_behavior
-#       calls Kernel.exit(1) BEFORE engine.finalize fires - so NO
-#       cache is written, and stderr carries the "N duplicate
-#       example(s) across M identity hash(es)" error log.
-#   - When duplicates detected AND fail_on_duplicates=false:
-#       runner_hook still drops the colliding groups but exits 0;
-#       cache (including duplicate_examples.json) IS written.
+# Behavioral contract (rspec-tracer drops the colliding examples but
+# still runs the rest of the suite - issue #210):
+#   - duplicates detected, fail_on_duplicates=true:
+#       the colliding examples are dropped, the non-duplicate
+#       examples still run, and at_exit_behavior calls Kernel.exit(1)
+#       BEFORE the cache is written - so NO cache, and the
+#       "N duplicate example(s) across M identity hash(es)" error log
+#       names the colliding examples.
+#   - duplicates detected, fail_on_duplicates=false:
+#       same prune, but the run exits 0 and the cache (including
+#       duplicate_examples.json + the non-duplicate examples) IS
+#       written.
+#   In both cases the rspec-tracer banner reports the surviving
+#   example count - the suite is NOT aborted to zero examples.
 #
-# Assertion shape per `feedback_v2_integration_exit_status`: cache
-# state is the load-bearing check on the exit-0 path; on the exit-1
-# path the cache write is intentionally skipped, so the log message
-# in stderr is the load-bearing assertion.
+# Assertion shape per `feedback_v2_integration_exit_status`: the
+# load-bearing checks are the exit code, the banner's surviving-
+# example count, and (on the exit-0 path) the written cache.
 #
 # Fixture: a parameterized `.each` loop wrapping a single `it` block
 # produces N examples that share example_group + description +
@@ -84,8 +88,12 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
         'GIT_DEFAULT_BRANCH' => nil,
         'GIT_BRANCH' => nil
       }.merge(env_overrides)
-      Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color', 'duplicates_spec.rb',
-                      chdir: dir)
+      out, status = Open3.capture2e(env, 'bundle', 'exec', 'rspec', '--no-color',
+                                    'duplicates_spec.rb', chdir: dir)
+      # rspec-tracer's run summary carries a non-ASCII '·'; force UTF-8
+      # + scrub so callers can match against `out` regardless of the
+      # parent process's default external encoding.
+      [out.dup.force_encoding('UTF-8').scrub, status]
     end
   end
 
@@ -96,8 +104,15 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
     JSON.parse(File.read(File.join(cache_dir, run_id, 'duplicate_examples.json'), encoding: 'UTF-8'))
   end
 
+  def read_all_examples(dir)
+    cache_dir = File.join(dir, 'rspec_tracer_cache')
+    manifest = JSON.parse(File.read(File.join(cache_dir, 'last_run.json'), encoding: 'UTF-8'))
+    run_id = manifest.fetch('run_id')
+    JSON.parse(File.read(File.join(cache_dir, run_id, 'all_examples.json'), encoding: 'UTF-8'))
+  end
+
   context 'when fail_on_duplicates is true via the DSL' do
-    it 'exits non-zero AND emits the duplicate-detection error log' do
+    it 'drops the duplicates, runs the rest, then exits non-zero with the error log' do
       Dir.mktmpdir do |dir|
         write_fixture(dir, dsl_body: "fail_on_duplicates true\n")
 
@@ -108,12 +123,15 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           "expected non-zero exit when fail_on_duplicates is true, got 0:\n#{out}"
         )
         expect(out).to match(duplicate_log_re)
+        # the non-duplicate baseline still runs - the suite is not
+        # aborted to zero examples (issue #210).
+        expect(out).to include('running 1 examples')
       end
     end
   end
 
   context 'when fail_on_duplicates is false via the DSL' do
-    it 'exits zero AND writes duplicate_examples.json with the colliding identity' do
+    it 'drops the duplicates, runs + caches the rest, and exits zero' do
       Dir.mktmpdir do |dir|
         write_fixture(dir, dsl_body: "fail_on_duplicates false\n")
 
@@ -123,9 +141,13 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           be(true),
           "expected zero exit when fail_on_duplicates is false, got #{status.exitstatus}:\n#{out}"
         )
+        expect(out).to include('running 1 examples')
         duplicates = read_duplicate_examples(dir)
         expect(duplicates).not_to be_empty
         expect(duplicates.values.flatten.size).to be >= 2
+        # the non-duplicate baseline ran and was cached; the colliding
+        # examples were dropped from all_examples by deregistration.
+        expect(read_all_examples(dir).size).to eq(1)
       end
     end
   end
@@ -142,6 +164,7 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           "expected non-zero exit when env=true overrides DSL=false, got 0:\n#{out}"
         )
         expect(out).to match(duplicate_log_re)
+        expect(out).to include('running 1 examples')
       end
     end
   end
@@ -157,6 +180,7 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           be(true),
           "expected zero exit when env=false overrides DSL=true, got #{status.exitstatus}:\n#{out}"
         )
+        expect(out).to include('running 1 examples')
         duplicates = read_duplicate_examples(dir)
         expect(duplicates).not_to be_empty
       end

--- a/spec/integration/schema_version_upgrade_spec.rb
+++ b/spec/integration/schema_version_upgrade_spec.rb
@@ -123,6 +123,24 @@ RSpec.describe 'Storage::JsonBackend 1.x -> 2.0 cache schema cold-run upgrade ce
     end
   end
 
+  context 'when the on-disk cache carries the schema reshaped by #209 (4)' do
+    before do
+      write_legacy_manifest('schema_version' => 4, 'run_id' => 'schema4-run')
+      write_legacy_run_dir('schema4-run', 'all_examples.json' => JSON.dump({}))
+    end
+
+    # schema_version 5 reshaped unnamed-example identity (issue #210);
+    # a schema-4 cache (the window between #209 and the #210 fix) must
+    # trigger one clean cold run, not a crash, on the upgrade.
+    it 'falls back to cold run + logs the version delta' do
+      result = build_backend.load_graph(schema_version: current_schema)
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:info)
+        .with(a_string_including('stored=4').and(a_string_including('cold run')))
+    end
+  end
+
   context 'when the on-disk cache carries a future / unsupported schema' do
     before do
       write_legacy_manifest('schema_version' => 999_999, 'run_id' => 'future-run')

--- a/spec/regressions/gem_generated_example_no_source_spec.rb
+++ b/spec/regressions/gem_generated_example_no_source_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe 'gem-generated example with phantom file_path (regression for ups
       file_path: phantom_file_path,
       rerun_file_path: phantom_file_path,
       line_number: 1,
+      # RSpec's raw explicit description — present (non-empty) for a
+      # named example, which is what `Example.from` reads to tell
+      # named from unnamed (issue #210).
+      description: 'phantom-source example',
       shared_group_inclusion_backtrace: []
     }
   end

--- a/spec/remote_cache/archive_spec.rb
+++ b/spec/remote_cache/archive_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe RSpecTracer::RemoteCache::Archive do
     src = File.join(@dir, 'src')
     FileUtils.mkdir_p(File.join(src, run_id))
     File.write(File.join(src, 'last_run.json'),
-               JSON.pretty_generate('schema_version' => 4, 'run_id' => run_id))
+               JSON.pretty_generate('schema_version' => 5, 'run_id' => run_id))
     file_count.times do |i|
       File.write(File.join(src, run_id, "file#{i}.json"),
                  JSON.pretty_generate('k' => 'v' * 100))

--- a/spec/rspec/runner_hook_spec.rb
+++ b/spec/rspec/runner_hook_spec.rb
@@ -85,20 +85,83 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
     end
 
     context 'when duplicate examples are detected' do
+      let(:colliding_metadata) { { file_path: 'spec/user_spec.rb' } }
+      let(:unique_metadata) { { file_path: 'spec/user_spec.rb' } }
+      let(:colliding_example) do
+        double('CollidingExample', metadata: colliding_metadata, description: 'collides',
+                                   example_group: double('EG', parent_groups: [example_group]))
+      end
+      let(:unique_example) do
+        double('UniqueExample', metadata: unique_metadata, description: 'is unique',
+                                example_group: double('EG', parent_groups: [example_group]))
+      end
+      let(:duplicate_entries) do
+        [
+          { example_id: 'dup-id', file_name: 'spec/user_spec.rb', line_number: 6,
+            full_description: 'User is valid' },
+          { example_id: 'dup-id', file_name: 'spec/user_spec.rb', line_number: 7,
+            full_description: 'User is valid' }
+        ]
+      end
+
       before do
-        allow(world).to receive_messages(example_count: 1, filtered_examples: {})
-        allow(engine).to receive(:duplicate_examples).and_return(
-          'ex1' => [{ example_id: 'ex1' }, { example_id: 'ex1' }]
-        )
+        allow(world).to receive(:example_count).and_return(2, 1)
+        allow(world).to receive(:filtered_examples)
+          .and_return(example_group => [colliding_example, unique_example])
+        allow(world).to receive(:instance_variable_set)
+        allow(RSpecTracer::Example).to receive(:from).with(colliding_example)
+          .and_return(example_id: 'dup-id')
+        allow(RSpecTracer::Example).to receive(:from).with(unique_example)
+          .and_return(example_id: 'unique-id')
+        allow(engine).to receive(:duplicate_examples).and_return('dup-id' => duplicate_entries)
         allow(RSpecTracer).to receive(:fail_on_duplicates).and_return(true)
       end
 
-      it 'logs an error, flips duplicate_examples, and calls super with an empty list' do
+      it 'logs the summary line, the identity hash, the colliding examples, and a remediation hint' do
         runner.run_specs([:original])
 
-        expect(logger).to have_received(:error).with(/2 duplicate example\(s\) across 1 identity hash/)
+        expect(logger).to have_received(:error).with(
+          a_string_including('2 duplicate example(s) across 1 identity hash(es)')
+            .and(a_string_including('dup-id'))
+            .and(a_string_including('spec/user_spec.rb:6 User is valid'))
+            .and(a_string_including('spec/user_spec.rb:7 User is valid'))
+            .and(a_string_including('distinct descriptions'))
+        )
+      end
+
+      it 'flips RSpecTracer.duplicate_examples to the fail_on_duplicates value' do
+        runner.run_specs([:original])
+
         expect(RSpecTracer).to have_received(:duplicate_examples=).with(true)
-        expect(runner.super_calls).to eq([[]])
+      end
+
+      it 'drops only the colliding examples and still runs the rest of the suite' do
+        runner.run_specs([:original])
+
+        expect(world).to have_received(:instance_variable_set)
+          .with(:@filtered_examples, example_group => [unique_example])
+        expect(runner.super_calls.last).to eq([example_group])
+      end
+
+      it 'drops a group entirely when every one of its examples collides' do
+        allow(world).to receive(:filtered_examples).and_return(example_group => [colliding_example])
+
+        runner.run_specs([:original])
+
+        expect(world).to have_received(:instance_variable_set).with(:@filtered_examples, {})
+        expect(world).to have_received(:instance_variable_set).with(:@example_groups, [])
+        expect(runner.super_calls.last).to eq([])
+      end
+
+      it 'labels a colliding example file:line description, preferring the rerun location' do
+        label = runner.send(
+          :_rspec_tracer_example_label,
+          rerun_file_name: 'spec/a_spec.rb', rerun_line_number: 9,
+          file_name: 'spec/support/shared.rb', line_number: 99,
+          full_description: 'Thing behaves like shared '
+        )
+
+        expect(label).to eq('spec/a_spec.rb:9 Thing behaves like shared')
       end
     end
 

--- a/spec/storage/schema_spec.rb
+++ b/spec/storage/schema_spec.rb
@@ -4,8 +4,8 @@ require 'rspec_tracer/storage/schema'
 
 RSpec.describe RSpecTracer::Storage::Schema do
   describe 'CURRENT' do
-    it 'is 4 (schema 4 reshaped the example-identity payload; schema-3 caches no longer match)' do
-      expect(described_class::CURRENT).to eq(4)
+    it 'is 5 (schema 5 reshaped unnamed-example identity; schema-4 caches no longer match)' do
+      expect(described_class::CURRENT).to eq(5)
     end
   end
 


### PR DESCRIPTION
## Summary

Completes the #196 `example_id` stability work. #209 fixed it for explicitly-described examples but left it line-unstable for **unnamed** examples (`it { }` / `specify { }` / `example { }`): `Example.from` runs pre-run, so `example.description` is RSpec's line-bearing `"example at <path>:<line>"` fallback — re-leaking the line number #209 removed from the digest. A no-op blank-line edit above an `it { }` flipped its `example_id`, orphaning its cache entry and always-re-run history (pervasive in shoulda-matchers model specs).

- **Unnamed-example identity** — the digest substitutes a line-independent positional discriminator: the example's ordinal among its group's *unnamed* examples. Line-stable + unique-within-group. Named examples are byte-identical to #209. Documented trade-off: reordering unnamed examples re-keys them (named examples stay fully reorder-stable). Digest-input only — the stored payload keeps RSpec's `description`/`full_description`, so reporters and `explain` are unchanged.
- **`Storage::Schema::CURRENT` 4 → 5** — unnamed-example ids change, so a schema-4 cache cold-loads cleanly instead of silently partial-missing.
- **Duplicate-detection redesign** — colliding examples are now *dropped from the run* while the rest of the suite still runs, instead of `super([])` aborting the whole suite to zero examples. `fail_on_duplicates` governs the exit code only. The error log now names the colliding examples (file:line + description) with a remediation hint.
- `UPGRADING.md` documents the unnamed-example carve-out + the duplicate-collision behavior.

Closes #210.

## Test plan

- [x] `spec/example_spec.rb` — extended with the full `it`-side variant matrix (named/unnamed, line-independence, within-group uniqueness, the reorder carve-out, `nil`/whitespace `metadata[:description]` mutation cases, named-example regression guard)
- [x] `spec/integration/example_id_stability_spec.rb` — new cases: `it { }` line-shift stability, N sibling `it { }` → N distinct ids + suite runs all N, `specify { }`/`example { }` aliases
- [x] `spec/rspec/runner_hook_spec.rb` + `spec/integration/fail_on_duplicates_spec.rb` — duplicate-detection redesign (prune-and-continue, improved error message, baseline survives the prune)
- [x] `spec/storage/schema_spec.rb` + `spec/remote_cache/archive_spec.rb` + `spec/integration/schema_version_upgrade_spec.rb` — schema 4 → 5 (incl. a new schema-4 cold-run case)
- [x] Pre-PR parity: lint:ruby / lint:actions / lint:yaml / check:bundle / security:bundle-audit / test:unit (2052/0) / test:property / test:mutation:smoke (Example 94.36%, Storage::Schema 100%) / test:dogfood / test:fuzz:smoke / benchmark:smoke / docs:yard:check (100%)
- [x] codecov resultset inspection — every new/changed `lib/` line has ≥ 1 hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)