### PR TITLE
chore(lib): drop internal milestone IDs from shipped comments

### DIFF
--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -94,10 +94,9 @@ module RSpecTracer
     DEFAULT_CACHE_RETENTION_LOCAL_COUNT = 5
     # Size budgets (MiB). Warn at save time when any single cache
     # file exceeds the per-file threshold or when the cache total
-    # exceeds the aggregate threshold. Surfaces B11 symptoms
-    # (dependency.json ballooning past the few-MB range) while
-    # the user can still act on them. Set to 0 to disable either
-    # individually.
+    # exceeds the aggregate threshold. Surfaces dependency.json
+    # ballooning past the few-MB range while the user can still
+    # act on them. Set to 0 to disable either individually.
     DEFAULT_CACHE_SIZE_WARN_PER_FILE_MB = 50
     # Internal constant.
     # @api private

--- a/lib/rspec_tracer/storage/json_backend.rb
+++ b/lib/rspec_tracer/storage/json_backend.rb
@@ -562,8 +562,8 @@ module RSpecTracer
       # effective remediations in order: add_filter for vendor paths
       # (usually the biggest win), transitive_load_tracking off
       # (cuts the constants-blind-spot overhead), and the `:msgpack`
-      # serializer (PR B). Budgets surface B11 symptoms (issue #15 /
-      # #20) without forcing behavior change.
+      # serializer. Budgets surface size-blow-up symptoms (issues
+      # #15 / #20) without forcing behavior change.
       def maybe_warn_size_budget(run_id)
         warn_oversized_run_files(run_id) if positive_threshold?(@warn_per_file_mb)
         warn_oversized_cache_total if positive_threshold?(@warn_total_mb)

--- a/lib/rspec_tracer/storage/lazy_snapshot.rb
+++ b/lib/rspec_tracer/storage/lazy_snapshot.rb
@@ -9,7 +9,7 @@ module RSpecTracer
     # read + deserialization for each field until the caller touches it.
     #
     # Rationale: on a large cache (100 MB+), eager-reading every file
-    # at setup dominates warm-run startup (see issue #17 / B12). Engine
+    # at setup dominates warm-run startup (issue #17). Engine
     # at setup touches 10/15 fields; reporters never touch the previous
     # snapshot; third-party tooling often reads one or two. The 3-5
     # fields the Engine does NOT touch at setup (duplicate_examples,

--- a/lib/rspec_tracer/storage/sqlite_backend.rb
+++ b/lib/rspec_tracer/storage/sqlite_backend.rb
@@ -537,11 +537,11 @@ module RSpecTracer
           # JSON-backend-only surfaces; sqlite no-op. SqliteBackend
           # does not persist these aggregates (would require meta-
           # table columns / schema bump). SqliteBackend also has no
-          # parallel-tests peer-merge path (M5.1 / M5.5 are
-          # JsonBackend-only), so the per-id filtered_examples that
-          # backs cache_hit_reason isn't needed either. Empty default
-          # mirrors the missing-file-coerces-to-{} contract used by
-          # JsonBackend's per-field reads.
+          # parallel-tests peer-merge path (that's JsonBackend-only),
+          # so the per-id filtered_examples that backs cache_hit_reason
+          # isn't needed either. Empty default mirrors the missing-
+          # file-coerces-to-{} contract used by JsonBackend's
+          # per-field reads.
           {}
         else                    dispatch_read_grouped(db, field)
         end

--- a/lib/rspec_tracer/tracker/loaded_files_tracker.rb
+++ b/lib/rspec_tracer/tracker/loaded_files_tracker.rb
@@ -11,7 +11,7 @@ module RSpecTracer
   # @api private
   module Tracker
     # Observer #5 in the 2.0 tracker pipeline. Closes the constants-
-    # lookup blind spot documented in KNOWN_ISSUES.md B10.
+    # lookup blind spot in 1.x's coverage-diff approach.
     #
     # The bug: when file A defines constants at load time and example E2
     # references them without triggering a re-require, E2's coverage

--- a/lib/rspec_tracer/tracker/new_file_detector.rb
+++ b/lib/rspec_tracer/tracker/new_file_detector.rb
@@ -9,9 +9,9 @@ module RSpecTracer
   # @api private
   module Tracker
     # Observer #5 (composition of DeclaredGlobs + cache diff). Fixes
-    # KNOWN_ISSUES Section B5: 1.x's fetch_changed_files loop only
-    # iterated the previous run's cache, so newly-added source files
-    # were never discovered and never triggered re-runs.
+    # a 1.x gap: fetch_changed_files only iterated the previous run's
+    # cache, so newly-added source files were never discovered and
+    # never triggered re-runs.
     #
     # The fix: at boot, walk the union of user-declared globs and a
     # pure-Ruby default set (lib/**/*.rb). Every match on disk that is


### PR DESCRIPTION
## Summary
- Removes references to internal numbering (B5/B10/B11/B12, M5.1/M5.5) and a local-only `KNOWN_ISSUES.md` doc from 6 lib/ source files.
- Replaces them with descriptive prose; public issue references (#15, #17, #20) preserved.
- No behavior change — comment-only edits.

## Test plan
- [x] `task check` green locally (2052 examples, 0 failures)
- [ ] CI lint + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)