### PR TITLE
chore(gemspec): require MFA for publishing

### DIFF
--- a/rspec-tracer.gemspec
+++ b/rspec-tracer.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.metadata['source_code_uri'] = "https://github.com/avmnu-sng/rspec-tracer/tree/v#{spec.version}"
   spec.metadata['changelog_uri'] = 'https://github.com/avmnu-sng/rspec-tracer/blob/main/CHANGELOG.md'
   spec.metadata['bug_tracker_uri'] = 'https://github.com/avmnu-sng/rspec-tracer/issues'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.required_ruby_version = '>= 3.1.0'
 


### PR DESCRIPTION
## Summary
- Adds `rubygems_mfa_required` metadata to the gemspec so future `gem push` invocations require the maintainer's MFA challenge.
- Closes a pre-existing `Gemspec/RequireMFA` rubocop offense.

## Test plan
- [x] `task lint:ruby` clean locally (227 files inspected, no offenses)
- [ ] CI lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)