### PR TITLE
docs(cookbook): document :msgpack serializer + .msgpack.gz filename caveat

### DIFF
--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -399,6 +399,26 @@ cold-read time.
 **JRuby**: `:sqlite` is unsupported; the engine warns once and
 falls back to `:json` automatically.
 
+### Smaller caches with `:msgpack`
+
+Goal: ~3.5x on-disk cache reduction (helps CI artifact size and
+remote_cache upload time on suites with many examples).
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  storage_backend :json, serializer: :msgpack
+end
+```
+
+Add `gem 'msgpack'` to your Gemfile (test group). Cache files now
+end with `.msgpack.gz` instead of `.json`. If `msgpack` isn't
+loadable at boot, the engine warns once and falls back to `:json`.
+
+**Filename caveat**: despite the `.gz` suffix, payloads are raw
+`Zlib::Deflate` streams (not gzip format) — `gunzip` fails on them.
+The suffix is cosmetic and may change in a future major release.
+
 ### Coverage modes (rspec-tracer + SimpleCov interop)
 
 By default, rspec-tracer enables Ruby's `lines` coverage mode only.


### PR DESCRIPTION
## Summary
- Adds a recipe under COOKBOOK § 9 covering the `storage_backend :json, serializer: :msgpack` option for ~3.5× smaller caches.
- Notes that `.msgpack.gz` payloads are raw `Zlib::Deflate` streams (not gzip format) — `gunzip` fails on them. The suffix is cosmetic and may change in a future major release.
- Closes a user-discoverability gap: prior to this PR, the only documentation of the `:msgpack` serializer lived in `lib/` source comments.

## Test plan
- [ ] Render COOKBOOK.md on GitHub and verify the new sub-section reads cleanly under § 9

🤖 Generated with [Claude Code](https://claude.com/claude-code)