### PR TITLE
fix(configuration): clarify error when remote_cache DSLs conflict

### DIFF
--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -312,7 +312,9 @@ module RSpecTracer
     #   remote_cache_backend MyCustomBackend, custom_opt: 'value'
     def remote_cache_backend(name_or_class, **opts)
       if defined?(@remote_cache_backend_entry) && @remote_cache_backend_entry
-        raise InvalidUsageError, 'remote_cache_backend already configured'
+        raise InvalidUsageError,
+              'remote_cache already configured. `remote_cache_backend` and ' \
+              '`remote_cache_uri` are alternative DSLs — call one exactly once.'
       end
 
       validate_remote_cache_backend(name_or_class)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -804,9 +804,14 @@ RSpec.describe RSpecTracer::Configuration do
 
     it 'raises when called a second time' do
       config.remote_cache_backend(:s3, bucket: 'b', prefix: 'p')
-
       expect { config.remote_cache_backend(:s3, bucket: 'other') }
-        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /already configured/)
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /already configured.*alternative DSLs/m)
+    end
+
+    it 'raises with alternative-DSL guidance when remote_cache_uri was called first' do
+      config.remote_cache_uri('file:///tmp/cache')
+      expect { config.remote_cache_backend(:local_fs, root: '/tmp/cache') }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /alternative DSLs/)
     end
 
     it 'rejects invalid name types' do
@@ -848,6 +853,12 @@ RSpec.describe RSpecTracer::Configuration do
     it 'rejects malformed URIs' do
       expect { config.remote_cache_uri('this-is-not-a-uri ${whatever}') }
         .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /invalid remote_cache_uri/)
+    end
+
+    it 'raises with alternative-DSL guidance when remote_cache_backend was called first' do
+      config.remote_cache_backend(:local_fs, root: '/tmp/cache')
+      expect { config.remote_cache_uri('file:///tmp/cache') }
+        .to raise_error(RSpecTracer::Configuration::InvalidUsageError, /alternative DSLs/)
     end
   end
 


### PR DESCRIPTION
## Summary
- `InvalidUsageError` raised when `remote_cache_backend` is called twice also fires when `remote_cache_uri` is called after `remote_cache_backend` (and vice versa), because `remote_cache_uri` dispatches internally to `remote_cache_backend`.
- Old message (`remote_cache_backend already configured`) was confusing when the user only typed `remote_cache_uri`.
- New message names both DSLs explicitly and says they are alternatives, so the user sees actionable guidance regardless of which combination triggered the error.
- 2 new spec cases cover the cross-DSL paths (uri-then-backend, backend-then-uri).

## Test plan
- [x] `task check` green locally (2054 examples, 0 failures — +2 new)
- [ ] CI lint + tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)