### PR TITLE
fix(spec/remote_cache): disable git background maintenance in fake-repo

### DIFF
--- a/spec/integration/rake_remote_cache_spec.rb
+++ b/spec/integration/rake_remote_cache_spec.rb
@@ -33,6 +33,21 @@ require 'uri'
 # rubocop:disable Lint/ConstantDefinitionInBlock
 RSpec.describe 'rake rspec_tracer:remote_cache:* tasks against LocalStack', :integration, :localstack do
   LOCALSTACK_ENDPOINT_RAKE = ENV.fetch('LOCALSTACK_ENDPOINT', 'http://localhost:4566')
+  # Disable git background maintenance for the fake-repo setup below.
+  # Matches the constant in spec/remote_cache/git_ancestry_spec.rb;
+  # see that file for the failure-mode rationale (`bitmap-ref-tips_*`
+  # vs Dir.mktmpdir cleanup race). This spec only does 1 commit so the
+  # race window is much smaller than git_ancestry_spec's 30-commit
+  # loop, but the fixture pattern is identical — preemptive parity.
+  GIT_NO_MAINTENANCE_RAKE = %w[
+    -c gc.auto=0
+    -c gc.autoPackLimit=0
+    -c maintenance.auto=false
+    -c core.commitGraph=false
+    -c gc.writeCommitGraph=false
+    -c fetch.writeCommitGraph=false
+    -c pack.writeBitmaps=false
+  ].freeze
 
   def localstack_reachable?
     return false unless system('command', '-v', 'awslocal', out: File::NULL, err: File::NULL)
@@ -99,12 +114,12 @@ RSpec.describe 'rake rspec_tracer:remote_cache:* tasks against LocalStack', :int
       # GitAncestry can compute branch refs (uses HEAD + a single
       # commit so `git rev-list --max-count=25 HEAD` resolves).
       Dir.chdir(dir) do
-        system('git', 'init', '-q', '-b', 'main') || raise('git init failed')
-        system('git', 'config', 'user.email', 'rspec-tracer-rake-spec@example.com') || raise
-        system('git', 'config', 'user.name', 'rspec-tracer rake spec') || raise
+        system('git', *GIT_NO_MAINTENANCE_RAKE, 'init', '-q', '-b', 'main') || raise('git init failed')
+        system('git', *GIT_NO_MAINTENANCE_RAKE, 'config', 'user.email', 'rspec-tracer-rake-spec@example.com') || raise
+        system('git', *GIT_NO_MAINTENANCE_RAKE, 'config', 'user.name', 'rspec-tracer rake spec') || raise
         File.write('seed.txt', 'seed')
-        system('git', 'add', 'seed.txt') || raise
-        system('git', 'commit', '-q', '-m', 'seed') || raise
+        system('git', *GIT_NO_MAINTENANCE_RAKE, 'add', 'seed.txt') || raise
+        system('git', *GIT_NO_MAINTENANCE_RAKE, 'commit', '-q', '-m', 'seed') || raise
       end
 
       # Seed a small cache for upload to consume.

--- a/spec/remote_cache/git_ancestry_spec.rb
+++ b/spec/remote_cache/git_ancestry_spec.rb
@@ -17,7 +17,27 @@ require 'rspec_tracer/remote_cache/git_ancestry'
 # Git commands are run quietly (stdout+stderr to /dev/null) except
 # when we want to inspect failures. `sh!` raises on non-zero; `sh`
 # returns status+stdout.
+#
+# Every git invocation is prefixed with `GIT_NO_MAINTENANCE` flags.
+# Recent git (>= 2.x) writes transient `.git/objects/bitmap-ref-tips_*`
+# files in the background when commit-graph / multi-pack-index /
+# auto-gc / bitmap writes are enabled. Those temp files race with
+# `Dir.mktmpdir`'s recursive cleanup — the cleanup walks the dir,
+# sees a temp file, then `apply2files` raises `Errno::ENOENT` once
+# git removes it out from under the cleanup, and the parent rmdir
+# then raises `Errno::ENOTEMPTY`. Disabling the writes outright
+# (rather than retrying cleanup) removes the source of the race.
 module FakeGitRepo
+  GIT_NO_MAINTENANCE = %w[
+    -c gc.auto=0
+    -c gc.autoPackLimit=0
+    -c maintenance.auto=false
+    -c core.commitGraph=false
+    -c gc.writeCommitGraph=false
+    -c fetch.writeCommitGraph=false
+    -c pack.writeBitmaps=false
+  ].freeze
+
   def with_fake_repo(&)
     Dir.mktmpdir do |remote_dir|
       Dir.mktmpdir do |work_dir|
@@ -66,11 +86,12 @@ module FakeGitRepo
   end
 
   def current_head
-    out, = Open3.capture3('git', 'rev-parse', 'HEAD')
+    out, = Open3.capture3('git', *GIT_NO_MAINTENANCE, 'rev-parse', 'HEAD')
     out.chomp
   end
 
   def sh!(*cmd)
+    cmd = ['git', *GIT_NO_MAINTENANCE, *cmd.drop(1)] if cmd.first == 'git'
     _stdout, stderr, status = Open3.capture3(*cmd)
     raise "git cmd failed: #{cmd.join(' ')}\n#{stderr}" unless status.success?
   end


### PR DESCRIPTION
## Summary

Hardens the two `spec/` files that build fake git repos inside `Dir.mktmpdir` against a CI flake class where git's background commit-graph / multi-pack-index / bitmap-index writes race with `Dir.mktmpdir`'s recursive cleanup.

**Failure shape:** test body does N git commits → git writes transient `.git/objects/bitmap-ref-tips_<random>` in the background → `Dir.mktmpdir` block exits → cleanup walks the dir, sees the temp file, then `apply2files` raises `Errno::ENOENT` once git removes it; the parent rmdir then raises `Errno::ENOTEMPTY`.

**Two observed recurrences** of the same test (`spec/remote_cache/git_ancestry_spec.rb:223 "bounds to ANCESTRY_DEPTH (25) commits"`):

- Ruby 3.3 spec cell during M8.1-B work — different symptom (mid-commit `Error building trees / invalid object`), same fake-repo fixture pattern; closed at the time as "Single transient; wait for repeat."
- Ruby 3.1 spec cell on a recent CI run ([job 76216571060](https://github.com/avmnu-sng/rspec-tracer/actions/runs/25928400174/job/76216571060)) — `ENOTEMPTY` / `ENOENT` pair, triggering this fix.

## Fix

Inject `git -c gc.auto=0 -c gc.autoPackLimit=0 -c maintenance.auto=false -c core.commitGraph=false -c gc.writeCommitGraph=false -c fetch.writeCommitGraph=false -c pack.writeBitmaps=false` on every git invocation in the fake-repo fixtures. Removes the source of the racing temp files (no async writes during the test body) rather than retrying cleanup. No production code touched — spec-only.

**Two callsites:**

- [`spec/remote_cache/git_ancestry_spec.rb`](spec/remote_cache/git_ancestry_spec.rb) — proven fix (30-commit example was the triggering recurrence).
- [`spec/integration/rake_remote_cache_spec.rb`](spec/integration/rake_remote_cache_spec.rb) — preemptive parity (1-commit fixture; identical pattern, much smaller race window, no proven flake yet).

Constant duplicated inline rather than extracted to `spec/support/` — only two callsites, small constant; extract if a third appears.

## Test plan

- [x] 30/30 passes locally on the previously-flaky `bounds to ANCESTRY_DEPTH (25) commits` example
- [x] `task check` green
- [ ] CI full-matrix lands green on first try
- [ ] Integration job exercising rake_remote_cache_spec lands green (LocalStack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)