### PR TITLE
fix(runner_hook): preserve Hash default block when dropping duplicate examples

### DIFF
--- a/lib/rspec_tracer/rspec/runner_hook.rb
+++ b/lib/rspec_tracer/rspec/runner_hook.rb
@@ -207,15 +207,29 @@ module RSpecTracer
       # the exit code (via `at_exit_behavior`), not whether anything
       # runs. A group is kept only if it still has examples after the
       # colliding ones are removed.
+      #
+      # The returned Hash uses the same `Hash.new { |h, k| h[k] = [] }`
+      # default-block shape as `_rspec_tracer_build_filter_decision`'s
+      # `to_run`. That contract matters because rspec-core's
+      # `RSpec::Core::World#example_count` walks `g.descendants` for
+      # every top-level group and reads `e.filtered_examples`
+      # (= `world.filtered_examples[e]`) on each descendant — including
+      # INTERMEDIATE groups (a `describe` that contains only nested
+      # `describe`s, no direct `it`s). A plain Hash returns `nil` for
+      # those keys, which then NPEs in
+      # `inject(0) { |a, e| a + e.filtered_examples.size }`. The
+      # default block returns `[]` (`.size == 0`), matching the
+      # pre-drop path's behavior.
       # @api private
       def _rspec_tracer_drop_duplicate_examples(examples_map, example_groups)
         duplicate_ids = Set.new(RSpecTracer.engine.duplicate_examples.keys)
 
-        kept_map = examples_map.each_with_object({}) do |(group, examples), kept|
+        kept_map = Hash.new { |hash, group| hash[group] = [] }
+        examples_map.each do |group, examples|
           survivors = examples.reject do |example|
             duplicate_ids.include?(example.metadata[:rspec_tracer_example_id])
           end
-          kept[group] = survivors unless survivors.empty?
+          kept_map[group] = survivors unless survivors.empty?
         end
 
         [kept_map, example_groups.select { |group| kept_map.key?(group) }]

--- a/spec/rspec/runner_hook_spec.rb
+++ b/spec/rspec/runner_hook_spec.rb
@@ -163,6 +163,38 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
 
         expect(label).to eq('spec/a_spec.rb:9 Thing behaves like shared')
       end
+
+      it 'returns a Hash with a default block so intermediate describe groups do not NPE in example_count' do
+        # rspec-core's RSpec::Core::World#example_count walks
+        # g.descendants for every top-level group and reads
+        # e.filtered_examples (= world.filtered_examples[e]) on each
+        # descendant. Intermediate groups (a `describe` containing only
+        # nested `describe`s, no direct `it`s) have no entry in the
+        # kept Hash. A plain Hash returns nil for those keys; the
+        # missing-key lookup then NPEs in
+        # `inject(0) { |a, e| a + e.filtered_examples.size }`. The
+        # default block returns [] (.size == 0) matching what
+        # _rspec_tracer_build_filter_decision's to_run already does.
+        # Issue: avmnu-sng/rspec-tracer#218.
+        surviving_metadata = { rspec_tracer_example_id: 'unique-id', file_path: 'spec/a_spec.rb' }
+        leaf_group = double('LeafGroup')
+        survivor = double('Survivor', metadata: surviving_metadata, description: 'unique',
+                                      example_group: double('EG', parent_groups: [leaf_group]))
+        intermediate_group = double('IntermediateGroup')
+        allow(engine).to receive(:duplicate_examples)
+          .and_return('dup-id' => duplicate_entries)
+        examples_map = { leaf_group => [survivor] }
+
+        kept_map, kept_groups = runner.send(
+          :_rspec_tracer_drop_duplicate_examples, examples_map, [leaf_group]
+        )
+
+        expect(kept_map[leaf_group]).to eq([survivor])
+        expect(kept_groups).to eq([leaf_group])
+        # Load-bearing assertion: missing-key lookup returns [] not nil.
+        expect(kept_map.default_proc).not_to be_nil
+        expect(kept_map[intermediate_group]).to eq([])
+      end
     end
 
     context 'when examples are tracked and the engine schedules a run' do


### PR DESCRIPTION
Closes #218.

## Summary

`_rspec_tracer_drop_duplicate_examples` built `kept_map` via `each_with_object({})` — a plain Hash with no default block. The caller (`run_specs`) assigns this to `RSpec.world.@filtered_examples` and immediately calls `RSpec.world.example_count`, which walks `g.descendants` for every top-level group and reads `e.filtered_examples` (= `world.filtered_examples[e]`) on each descendant. Intermediate describe groups (a `describe` containing only nested `describe`s, no direct `it`s) have no entry in `kept_map`; the missing-key lookup returns `nil`; `nil.size` then NPEs in rspec-core 3.13.6's `world.rb:111` `inject(0) { |a, e| a + e.filtered_examples.size }`.

Triggered on any suite where two examples have colliding identity hashes AND an outer describe contains at least one intermediate (non-leaf) describe. Latent since the duplicate-drop path was introduced; surfaced more after PR #209 made example identity description-derived. `fail_on_duplicates: false` does NOT mitigate — that flag only controls `at_exit_behavior`'s `Kernel.exit(1)`; the NPE happens in `example_count` before any example runs.

Mirror the default-block contract that `_rspec_tracer_build_filter_decision`'s `to_run` already uses (`Hash.new { |hash, group| hash[group] = [] }`).

```diff
 def _rspec_tracer_drop_duplicate_examples(examples_map, example_groups)
   duplicate_ids = Set.new(RSpecTracer.engine.duplicate_examples.keys)

-  kept_map = examples_map.each_with_object({}) do |(group, examples), kept|
+  kept_map = Hash.new { |hash, group| hash[group] = [] }
+  examples_map.each do |group, examples|
     survivors = examples.reject do |example|
       duplicate_ids.include?(example.metadata[:rspec_tracer_example_id])
     end
-    kept[group] = survivors unless survivors.empty?
+    kept_map[group] = survivors unless survivors.empty?
   end

   [kept_map, example_groups.select { |group| kept_map.key?(group) }]
 end
```

The behavior is unchanged for the per-example drop semantics (colliding examples dropped, surviving siblings kept, groups removed from `kept_map.key?` membership when all their examples collided). The only delta: missing-key reads return `[]` not `nil`. Existing duplicate-detection tests still pass because Hash equality is content-based and ignores `default_proc`.

## Test plan

- [x] `task lint:ruby` (rubocop, 227 files, 0 offenses)
- [x] `task lint:actions` (actionlint, clean)
- [x] `task lint:yaml` (yamllint --strict, clean)
- [x] `task check:bundle`
- [x] `task security:bundle-audit` (no vulnerabilities)
- [x] `task security:trivy` (clean — local soak-fixture false positives ignored per known machine-local quirk)
- [x] `task test:unit` (2055 examples, 0 failures + 100% line + branch coverage gate green on `runner_hook.rb`)
- [x] `task test:property` (25 examples, 0 failures)
- [x] `task test:dogfood` (1 example, 0 failures)
- [x] `task benchmark:smoke` (cold_ruby + warm_noop OK)
- [x] New unit spec in `spec/rspec/runner_hook_spec.rb` drives `_rspec_tracer_drop_duplicate_examples` directly and asserts (a) the returned Hash's `default_proc` is non-nil and (b) missing-key lookup returns `[]` instead of `nil`.

Mutation smoke (`task test:mutation:smoke`) is broken on this development machine due to a mutant/unparser US-ASCII encoding quirk that affects most subjects locally; the CI mutation gate is authoritative.

## Out of scope

- The upstream refinery test-naming bug (two `describe '#thumbnail_dimensions returns correctly with' do … it 'nil' do … end` blocks in `images/spec/models/refinery/image_spec.rb` should be renamed). Separate upstream PR.
- Whether to surface duplicate-detection as a hard error at boot vs the current silent-drop + run-completion behavior. UX design question, separate thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)