### PR TITLE
chore: 2.0.0.pre.2 release prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,193 @@
+## [2.0.0.pre.2] - 2026-05-16
+
+Bug-fix + interop release after the field-test pass that followed
+`v2.0.0.pre.1`. 15 issues filed publicly
+([#182](https://github.com/avmnu-sng/rspec-tracer/issues/182)–[#196](https://github.com/avmnu-sng/rspec-tracer/issues/196))
+plus two follow-on findings
+([#210](https://github.com/avmnu-sng/rspec-tracer/issues/210) and
+[#218](https://github.com/avmnu-sng/rspec-tracer/issues/218))
+surfaced during fix-verification; all 17 are closed at tag. No CI
+surface drops, no Ruby / Rails / RSpec floor changes.
+
+The cumulative cache `schema_version` path is `3 → 5` (two bumps
+across [#209](https://github.com/avmnu-sng/rspec-tracer/pull/209)
+and [#211](https://github.com/avmnu-sng/rspec-tracer/pull/211));
+a pre.1 cache cold-loads cleanly on the pre.2 upgrade in one cold
+run, then warm caches resume. See [`UPGRADING.md`](UPGRADING.md).
+
+### Added
+
+- **`coverage_modes` config DSL** for the standalone Coverage
+  path (no SimpleCov). Pass any subset of
+  `[:lines, :branches, :methods, :oneshot_lines, :eval]`; default
+  `[:lines]` keeps byte-compatibility with prior runs. Threaded
+  through both `RSpecTracer.setup_coverage` and
+  `Engine#ensure_coverage_started`; inert when SimpleCov drives
+  Coverage. New COOKBOOK recipe "Coverage modes (rspec-tracer +
+  SimpleCov interop)" under recipe 9 documents the per-mode
+  interop matrix.
+- **`bin/rspec-tracer cache:clear --force` / `-f`** as a synonym
+  for `--yes` / `-y`. Matches the common Unix-CLI convention.
+- **COOKBOOK recipe for the `:msgpack` serializer** documenting
+  the `storage_backend :json, serializer: :msgpack` option for
+  ~3.5× smaller caches than `:json` on dependency-heavy suites.
+  Notes that `.msgpack.gz` payloads are raw `Zlib::Deflate`
+  streams (not gzip format) — the suffix is cosmetic and may
+  change in a future major release.
+
+### Changed
+
+- **Cache `schema_version` bump 3 → 5** (cumulative). The
+  `example_id` digest now drops the load-order-dependent
+  generated-class-name suffix and the line-number fields, and
+  substitutes a positional discriminator for unnamed
+  `it { }` / `specify { }` / `example { }` examples that
+  previously picked up RSpec's `"example at <path>:<line>"`
+  description fallback. First run on pre.2 is cold; subsequent
+  runs return to warm. See [`UPGRADING.md`](UPGRADING.md)
+  "Schema-version cold runs."
+- **Duplicate-example-identity detection now prune-and-continue.**
+  When the runner detects two examples with the same identity,
+  it drops the colliders from the run and lets the rest of the
+  suite proceed, instead of aborting the entire run to zero
+  examples. `fail_on_duplicates` becomes purely an exit-code
+  lever — the non-colliding remainder always runs. The error log
+  names the colliding examples (file:line + description) with a
+  remediation hint. See [`UPGRADING.md`](UPGRADING.md)
+  "Duplicate example identities."
+
+### Fixed
+
+- **Restored flaky-test detection across runs.** A top-line
+  README feature present in 1.x since v1.0.0; silently dropped
+  in the 2.0 rewrite — the registry `:flaky` status, the
+  `:flaky_example` filter reason, the `flaky_examples` snapshot
+  field, and the HTML reporter's Flaky tab were all retained,
+  but no production code path transitioned an example into
+  `:flaky`. `on_example_passed` now promotes a
+  previously-failed-or-flaky example into `:flaky`;
+  `on_example_failed` keeps a previously-flaky example sticky.
+  Closes [#194](https://github.com/avmnu-sng/rspec-tracer/issues/194).
+- **`run_reason` field in `report.json` (and the terminal
+  `by reason:` line) now persists the correct reason on warm
+  runs for every reason path** — `Failed previously`,
+  `Pending previously`, `Interrupted previously`, `Files changed`,
+  `Environment changed`. Previously displayed as `No cache` on
+  every warm-run case because `Engine#register_example`
+  short-circuited on the entry already seeded from the previous
+  snapshot. Single-character fix closing all five reason paths.
+  Closes [#186](https://github.com/avmnu-sng/rspec-tracer/issues/186).
+- **Parallel-`tests` `cache_hit_reason` counts no longer inflated
+  by worker count.** Each worker independently computed an
+  identical `filtered_examples` hash against the global
+  previous-run snapshot; the pre-fix sum-merge inflated
+  always-re-run buckets N-fold. The merge now keys on
+  `example_id` (first-write-wins), then re-tallies. Closes
+  [#193](https://github.com/avmnu-sng/rspec-tracer/issues/193).
+- **`example_id` stable across runs when multiple files share a
+  `describe` name** (the load-order-dependent
+  `RSpec::ExampleGroups::Name_N` disambiguator suffix is no
+  longer in the digest) **and stable across line-shift edits for
+  unnamed one-liner examples** (`it { is_expected.to eq(7) }`,
+  `specify { ... }`, `example { ... }`). Long-standing bugs since
+  v1.0.0; pervasive in shoulda-matchers model specs which are
+  almost entirely one-liner matcher syntax. Closes
+  [#196](https://github.com/avmnu-sng/rspec-tracer/issues/196)
+  + [#210](https://github.com/avmnu-sng/rspec-tracer/issues/210).
+- **NPE in `RSpec.world.example_count` for suites with
+  intermediate describe groups after rspec-tracer drops a
+  duplicate-identity example.** Companion fix to the
+  duplicate-detection prune-and-continue redesign above — the
+  kept-map needed a default block so descendants of an
+  intermediate describe (a describe containing only nested
+  describes, no direct `it`s) resolve to an empty array on the
+  `filtered_examples` lookup instead of `nil`. Closes
+  [#218](https://github.com/avmnu-sng/rspec-tracer/issues/218).
+- **`storage_backend :json, serializer: :msgpack` no longer
+  crashes on `Time` values** (and `Symbol` values now round-trip
+  losslessly across the cache). Registered
+  `MessagePack::Factory` type extensions for `Time` (12-byte
+  `tv_sec + tv_nsec`, UTC-canonicalized on decode) and `Symbol`
+  (UTF-8 body). Users who followed rspec-tracer's own 50 MiB
+  cache warning's `:msgpack` recommendation no longer brick
+  their cache silently on the first run that writes a `Time`.
+  Closes [#182](https://github.com/avmnu-sng/rspec-tracer/issues/182).
+- **`bin/rspec-tracer cache:info` and `explain` now compose with
+  `storage_backend :sqlite`.** Previously hardcoded the
+  JsonBackend on-disk layout and reported `no last_run.json yet`
+  on every sqlite run, even after a successful rspec. Both CLI
+  sub-commands now dispatch through a shared
+  `Storage::Backend.build` factory; sqlite metadata-table reads
+  surface alongside JSON manifest reads behind the same
+  protocol. Closes
+  [#183](https://github.com/avmnu-sng/rspec-tracer/issues/183).
+- **`bin/rspec-tracer doctor` no longer false-reports `SimpleCov:
+  not loaded` / `Rails: not loaded`** when those gems ARE in the
+  Gemfile (doctor runs in its own process; app code doesn't load
+  there). Three states are now reported: loaded-in-this-process
+  (`OK`), installed-but-not-loaded
+  (`INFO ... installed (<version>; not loaded in doctor's process)`),
+  and not-installed (`INFO ... not installed`). Closes
+  [#184](https://github.com/avmnu-sng/rspec-tracer/issues/184).
+- **`bin/rspec-tracer` invocation guidance flipped to
+  `bundle exec rspec-tracer`** across README, COOKBOOK, and
+  UPGRADING. The bare `bin/rspec-tracer` form required users to
+  run `bundle binstubs rspec-tracer` first; `bundle exec
+  rspec-tracer` works out of the box. Closes
+  [#185](https://github.com/avmnu-sng/rspec-tracer/issues/185).
+- **`reports_s3_path` deprecation warning no longer false-flags
+  on the probe path** — when no `remote_cache_backend` /
+  `remote_cache_uri` is configured AND the user runs
+  `rake rspec_tracer:remote_cache:download` / `:upload` /
+  `:prune_all`. A new non-warning predicate gates the probe; the
+  deprecation now fires only on legitimate use of the legacy
+  DSL. Closes
+  [#187](https://github.com/avmnu-sng/rspec-tracer/issues/187).
+- **`remote_cache` success now emits visible INFO lines** for
+  `download!` (`restored cache from <ref>` — with a
+  `(cross-branch fallback)` qualifier when a PR-tier download
+  falls through to a commit-ancestry ref successfully),
+  `upload!` (`uploaded cache to <ref>`), and `prune_all!`
+  (`prune_all removed N refs`). One fix covers all three
+  backends (s3 / redis / file) + the cron-driven `prune_all`
+  admin task. Closes
+  [#188](https://github.com/avmnu-sng/rspec-tracer/issues/188).
+- **`track_ar_schema_notifications` now installs correctly under
+  the canonical README setup order** (`RSpecTracer.start` BEFORE
+  `require_relative '../config/environment'`). Previously,
+  `defined?(::Rails::VERSION)` was false at engine.setup time
+  and the entire Rails-observer install path short-circuited —
+  the `sql.active_record` subscriber never attached AND the
+  documented `use_transactional_fixtures`-widening warn never
+  fired. Now late-binds via a `before(:suite)` hook that
+  re-checks Rails-loaded state after `rails_helper.rb` has
+  required the environment. Closes
+  [#192](https://github.com/avmnu-sng/rspec-tracer/issues/192).
+- **`RSpecTracer.start` no longer crashes** when the user
+  pre-starts `::Coverage` (e.g. to opt into branch coverage for
+  SimpleCov-free runs). The `setup_coverage` entry point now
+  matches `Engine#ensure_coverage_started`'s `Coverage.running?`
+  guard + `RuntimeError` rescue. Closes
+  [#195](https://github.com/avmnu-sng/rspec-tracer/issues/195).
+- **`InvalidUsageError` raised on conflicting
+  `remote_cache_backend` / `remote_cache_uri` configuration now
+  names both DSLs and explains they are alternatives.** The
+  previous `<dsl> already configured` message was confusing when
+  the user only typed `remote_cache_uri` (which dispatches
+  internally to `remote_cache_backend`).
+- **README per-example-precision section now covers Rails
+  engines.** An engine's own `lib/` is `require`d at gem-load
+  time via the Gemfile.lock cascade and lands in the boot set
+  **regardless of `eager_load`**. COOKBOOK gains a
+  `transitive_load_tracking false` opt-out recipe with the
+  trade-off documented. Closes
+  [#189](https://github.com/avmnu-sng/rspec-tracer/issues/189).
+- **Engine + dummy-app two-rspec-summary explainer** added to
+  COOKBOOK — clarifies which of the two terminal summary totals
+  is authoritative when an engine fixture invokes RSpec against
+  its dummy app. Closes
+  [#190](https://github.com/avmnu-sng/rspec-tracer/issues/190).
+
 ## [2.0.0.pre.1] - 2026-05-06
 
 The first pre-release of the 2.0 line. Architecture rewrite around

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -32,7 +32,7 @@ Goal: skip already-passing examples on subsequent runs.
 ```ruby
 # Gemfile
 # 2.0 is in pre-release; switch to '~> 2.0' once 2.0.0 final ships.
-gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
+gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
 ```
 
 ```sh
@@ -76,7 +76,7 @@ with views, locales, fixtures, schema, and per-example AR queries.
 ```ruby
 # Gemfile (test group)
 # 2.0 is in pre-release; switch to '~> 2.0' once 2.0.0 final ships.
-gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
+gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
 ```
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Rails 8.0 needs Ruby 3.2+. JRuby 9.4 is supported.
    ```ruby
    # 2.0 is in pre-release. Pin to the pre-release version explicitly;
    # switch to '~> 2.0' once 2.0.0 final ships.
-   gem 'rspec-tracer', '= 2.0.0.pre.1', group: :test, require: false
+   gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
    ```
 
    `bundle install` will resolve the pre-release version. You can

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -1173,10 +1173,10 @@ module RSpecTracer
     #   coverage_modes [:lines, :branches]
     # @example Methods coverage in addition (for downstream tooling)
     #   coverage_modes [:lines, :methods]
-    def coverage_modes(*args)
-      return read_coverage_modes if args.empty?
+    def coverage_modes(*modes)
+      return read_coverage_modes if modes.empty?
 
-      modes_array = Array(args.length == 1 ? args.first : args).flatten.map(&:to_sym)
+      modes_array = Array(modes.length == 1 ? modes.first : modes).flatten.map(&:to_sym)
       raise InvalidUsageError, 'coverage_modes requires at least one mode (e.g. [:lines])' if modes_array.empty?
 
       unknown = modes_array - COVERAGE_MODES

--- a/lib/rspec_tracer/version.rb
+++ b/lib/rspec_tracer/version.rb
@@ -4,5 +4,5 @@ module RSpecTracer
   # The currently installed gem version, in `MAJOR.MINOR.PATCH[.pre.N]`
   # form. Bumped per release; CI's release workflow asserts the tag
   # matches this constant before pushing to RubyGems.
-  VERSION = '2.0.0.pre.1'
+  VERSION = '2.0.0.pre.2'
 end


### PR DESCRIPTION
## Summary

Release-prep PR for `v2.0.0.pre.2`. Mirrors the [`v2.0.0.pre.1` prep PR (#175)](https://github.com/avmnu-sng/rspec-tracer/pull/175) shape, plus a one-character YARD-doc fix folded in per maintainer request.

- `lib/rspec_tracer/version.rb`: `'2.0.0.pre.1'` → `'2.0.0.pre.2'`.
- `CHANGELOG.md`: prepends `## [2.0.0.pre.2] - 2026-05-16` per keep-a-changelog convention.
  - **`### Added`**: `coverage_modes` config DSL ([#207](https://github.com/avmnu-sng/rspec-tracer/pull/207)) + COOKBOOK recipe ([#208](https://github.com/avmnu-sng/rspec-tracer/pull/208)); `cache:clear --force` / `-f` synonym ([#204](https://github.com/avmnu-sng/rspec-tracer/pull/204)); COOKBOOK `:msgpack` serializer recipe ([#215](https://github.com/avmnu-sng/rspec-tracer/pull/215)).
  - **`### Changed`**: cumulative `Storage::Schema::CURRENT` 3 → 5 (one cold-run on upgrade, pre.1 → pre.2); duplicate-example-identity detection redesigned to prune-and-continue (`fail_on_duplicates` is now purely an exit-code lever; cross-links `UPGRADING.md`).
  - **`### Fixed`**: 13 lib/docs fixes covering all 17 closed issues ([#182](https://github.com/avmnu-sng/rspec-tracer/issues/182)–[#196](https://github.com/avmnu-sng/rspec-tracer/issues/196) + [#210](https://github.com/avmnu-sng/rspec-tracer/issues/210) + [#218](https://github.com/avmnu-sng/rspec-tracer/issues/218)). Leads with **flaky-test detection restoration** ([#194](https://github.com/avmnu-sng/rspec-tracer/issues/194) — present in 1.x since v1.0.0, silently dropped in the 2.0 rewrite). Frames [#196](https://github.com/avmnu-sng/rspec-tracer/issues/196) + [#210](https://github.com/avmnu-sng/rspec-tracer/issues/210) as long-standing bugs since v1.0.0. Includes [#218](https://github.com/avmnu-sng/rspec-tracer/issues/218) (NPE in `RSpec.world.example_count`) as a companion fix to [#211](https://github.com/avmnu-sng/rspec-tracer/pull/211)'s prune-and-continue redesign.
- `README.md` install-pin (1 hit at line 51): `'= 2.0.0.pre.1'` → `'= 2.0.0.pre.2'`.
- `COOKBOOK.md` install-pin (2 hits at lines 35 + 79): same flip.
- **`lib/rspec_tracer/configuration.rb`**: rename `def coverage_modes(*args)` → `def coverage_modes(*modes)` to match the YARD `@param modes` tag (carried over from [#207](https://github.com/avmnu-sng/rspec-tracer/pull/207); silent `task docs:yard:check` warning). Body references (`args.empty?`, `args.length`, `args.first`) update mechanically. Pure identifier rename, no behavior change.

Codecov-ignore mirror unchanged — `lib/rspec_tracer/version.rb` is already in `codecov.yml` + `spec/spec_helper.rb` + `scripts/merge_coverage.rb` ignore lists (mirrored at pre.1 prep). The `configuration.rb` rename touches 3 lines all with hits ≥ 1 in `coverage/.resultset.json` (1, 29, 13, 13 from `test:unit`).

## Pre-tag verifications (local, full `lint-and-specs.yml` job set)

- [x] `task lint:ruby` — 0 offenses across 227 files (the pre-existing `Gemspec/RequireMFA` carry-over is now resolved post-[#214](https://github.com/avmnu-sng/rspec-tracer/pull/214)).
- [x] `task lint:actions` + `task lint:yaml` — clean.
- [x] `task check:bundle` — `Gemfile.lock` installable.
- [x] `task security:bundle-audit` — 0 vulnerabilities (1122 advisories scanned).
- [x] `task security:trivy` — 0 vulnerabilities on `Gemfile.lock` + `lib/rspec_tracer/reporters/html/package-lock.json`.
- [x] `task test:unit` — 2055 examples, 0 failures (re-run post-YARD-fix: still 2055 / 0).
- [x] `task test:property` — 25 examples + 100 successful Rantly tests.
- [x] `task test:mutation:smoke` — all 15 subjects PASS ≥ 90% (`Example` 94.41%, `Storage::Schema` 100.00%).
- [x] `task test:dogfood` — 1 example, 0 failures (tracer-on-tracer subprocess smoke).
- [x] `task test:fuzz:smoke` — both fuzz harnesses clean (100% nil / 100% set outcomes).
- [x] `task test:regressions:plain` — 8 examples, 0 failures.
- [x] `task test:edge-cases` — 103 examples, 0 failures.
- [x] `task benchmark:smoke` — `cold_ruby` p50=0.306s (0.68× threshold), `warm_noop` p50=0.292s (0.72× threshold).
- [x] `task docs:yard:check` — 100% documented, **warning-free post-rename** (was emitting `@param tag has unknown parameter name: modes` on `configuration.rb:1176`).
- [x] `task gem:build` + `gem unpack pkg/rspec-tracer-2.0.0.pre.2.gem` + `grep -rnE 'M[0-9]+\.[0-9]+|docs/revamp'` → **ZERO matches** across the unpacked tree.
- [x] `release.yml` tag-trigger pattern — strict form `'v[0-9]+.[0-9]+.[0-9]+.pre.[0-9]+'` (post-[#179](https://github.com/avmnu-sng/rspec-tracer/pull/179); matches `v2.0.0.pre.2`).
- [x] First-cycle CI on commit 1 (`66293df4`): 77 pass / 14 path-gate skips / 0 fail.

## Maintainer-action chain after merge

1. Tag `v2.0.0.pre.2` on the merge commit and push:

   ```sh
   git tag -a v2.0.0.pre.2 -m "rspec-tracer 2.0.0.pre.2"
   git push origin v2.0.0.pre.2
   ```

2. Within ~60s of push, `gh run list --workflow release.yml --limit 1` should show a new run for the `v2.0.0.pre.2` ref. (If it doesn't fire, do not retry-push — RubyGems forbids re-pushing the same version; recovery is `v2.0.0.pre.3`.)
3. `release.yml` validates `RSpecTracer::VERSION`-matches-tag → builds gem → `gem push` via `RUBYGEMS_API_KEY` → creates GH release with `isPrerelease: true`.
4. `docs-publish.yml` fires on the same tag → deploys `/v2.0.0.pre.2/yard/` + `/demo/` + updates landing page `latest_prerelease`.

After both workflows green + gem live on RubyGems, the rest of the ceremony resumes here:

- Phase A→E personal install re-run against the published `gem 'rspec-tracer', '= 2.0.0.pre.2'`.
- Curated release notes via `gh release edit v2.0.0.pre.2 --notes-file <curated>`.
- Issue-close ceremony for the 17 closed issues ([#182](https://github.com/avmnu-sng/rspec-tracer/issues/182)–[#196](https://github.com/avmnu-sng/rspec-tracer/issues/196) + [#210](https://github.com/avmnu-sng/rspec-tracer/issues/210) + [#218](https://github.com/avmnu-sng/rspec-tracer/issues/218)) + `2.0-feedback` label clear.
- Discussion [#180](https://github.com/avmnu-sng/rspec-tracer/discussions/180) follow-up reply.

## Test plan

- [x] Full local pre-PR parity green (above).
- [x] CI green first cycle on `66293df4` (77 pass / 14 path-gate skips / 0 fail).
- [ ] CI green on `19317a32` (YARD fold-in cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)