### PR TITLE
chore(ci): cache Task binary in setup composite action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,8 +5,8 @@ description: >-
   shellcheck, yamllint, trivy, bundler-audit) + HTML reporter npm
   deps. Used by every parallel job in lint-and-specs.yml; underlying
   caches (setup-ruby bundler-cache, setup-node npm cache, explicit
-  tools cache on Taskfile.yml + .tool-versions) keep per-job warm-up
-  under ~30 s.
+  Task tool-cache, explicit out-of-bundle tools cache on Taskfile.yml
+  + .tool-versions) keep per-job warm-up under ~30 s.
 
 runs:
   using: composite
@@ -24,6 +24,35 @@ runs:
         node-version: '20'
         cache: npm
         cache-dependency-path: lib/rspec_tracer/reporters/html/package-lock.json
+
+    - name: Cache Task binary
+      uses: actions/cache@v5
+      with:
+        # go-task/setup-task@v2 calls `tc.find('task', version)` from
+        # @actions/tool-cache before downloading; a hit at
+        # $RUNNER_TOOL_CACHE/task/<version>/<arch> skips the download
+        # entirely. Cache the directory before setup-task runs so the
+        # restore lands ahead of the find() call.
+        #
+        # Same shape as the bin/+.venv/ cache below — addresses the
+        # same class of GitHub-Releases CDN flakes that motivated that
+        # cache. The 502 that bit lint-and-specs / test-mutation-
+        # storage-json-backend-shard-{4,7} on the 2026-05-16 main CI
+        # run after #220 merge was at THIS step (the Task download),
+        # not the bin/ tools — Task wasn't covered by the existing
+        # cache because it lives in the runner tool-cache, not bin/.
+        #
+        # Key is os + arch + version so the cache busts naturally on a
+        # Task version bump; restore-keys fallback bridges any
+        # out-of-band eviction. Task version is duplicated across the
+        # 20+ setup-task call sites in this repo (an unrelated single-
+        # source-of-truth cleanup); when bumping, search-replace
+        # `3.45.4` to keep this key + every workflow's `version:` in
+        # lock-step.
+        path: ${{ runner.tool_cache }}/task
+        key: task-${{ runner.os }}-${{ runner.arch }}-3.45.4
+        restore-keys: |
+          task-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Setup Task
       uses: go-task/setup-task@v2


### PR DESCRIPTION
## Summary

Today's main CI on `a93b244d` (the post-#220 merge) failed at the **`Setup Task` step** (`go-task/setup-task@v2` downloading `v3.45.4`) with two consecutive GitHub-Releases CDN **502** Bad Gateway responses on `lint-and-specs / test-mutation-storage-json-backend-shard-{4,7}` at the **same wall-clock second** (`08:23:32Z`). Pure infrastructure flake — no causal path from any recent diff to the failing subject (JsonBackend has zero references to `Configuration#coverage_modes`, the only lib change in #220's YARD fold-in cycle).

Failed run: [25957226761](https://github.com/avmnu-sng/rspec-tracer/actions/runs/25957226761). Rerun cleared on the same SHA.

The existing `actions/cache@v5` in this composite action covers `bin/` + `.venv/` (actionlint, shellcheck, yamllint, trivy, bundler-audit; shipped after a previous PR #129 trivy CDN flake per the inline comment) — but does **NOT cover Task**. Task lives in the runner tool-cache (`$RUNNER_TOOL_CACHE/task/<version>/<arch>`), not `bin/`, so the existing cache doesn't reach it.

## Change

Add an `actions/cache@v5` step **before** `go-task/setup-task@v2` targeting `${{ runner.tool_cache }}/task`. `setup-task@v2` calls `tc.find('task', version)` from `@actions/tool-cache` before deciding whether to download; a hit at that path skips the download entirely. Same `restore-keys:` fallback pattern as the existing `bin/+.venv/` cache for out-of-band eviction recovery.

Cache key shape: `task-${{ runner.os }}-${{ runner.arch }}-3.45.4`. Hardcoded version matches the inline `setup-task` `version:` — bump in lock-step when upgrading Task.

## Scope

**In scope:** the composite action `./.github/actions/setup` only. This covers all 11 jobs in `lint-and-specs.yml` (lint / security / test-unit / test-edge-cases / test-fuzz / test-regressions-plain / test-integration-remote / test-mutation-* / coverage), which is the per-PR blocking workflow.

**Out of scope (separate cleanup):** the 20+ standalone `setup-task` call sites in `regen-ratchet` / `multi-run-ratchet` / `example-tracer-cache` / `combinations` / `full-matrix` / `flake-gate` / `soak` / `docs-publish` hardcode the same `3.45.4` inline and are not covered here. Those are weekly-cron / manual-dispatch / tag-push triggered, less time-critical than the per-PR loop. A follow-up could fold them into a shared `TASK_VERSION` env + the same cache-step pattern.

## Test plan

- [x] `task lint:actions` — clean
- [x] `task lint:yaml` — clean
- [ ] First CI run after merge: cache MISS expected (no prior `task-*` key matching the new key); Task downloads via `setup-task@v2` as before — no regression vs current behavior; the cache populates on the post-job save
- [ ] Subsequent CI runs: cache HIT expected on the new `task-*` key; `setup-task@v2`'s `tc.find()` finds Task in the tool-cache and skips the download → protected from CDN flakes on the Task release-binary path

🤖 Generated with [Claude Code](https://claude.com/claude-code)