### PR TITLE
docs(roadmap): add auto-fallback + distribution workstream + #239 evidence-gate

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -95,6 +95,13 @@ Items:
 - **Confidence scoring on per-run summary.** Terminal output extends
   to show what proportion of selection decisions came from explicit
   vs inferred dependencies; surfaces invalidation hotspots.
+- **Auto-fallback when self-measured confidence is low.** Runtime
+  decision logic that consumes the confidence score: if confidence
+  drops below a configurable threshold OR N consecutive runs show
+  downward drift, automatically fall back to full-suite execution
+  with a clear warn line. Converts the trust story from
+  *observe-and-report* to *observe-and-self-defend* — the tool
+  structurally cannot skip silently when its own confidence is low.
 
 ### Flaky detection as first-class
 
@@ -122,7 +129,11 @@ invalidator — safe but coarser than per-example attribution.
   real and documented; users opt in per their cost / precision trade-off.
   *(Originally planned for 2.1; promoted to the 2.0 final scope because
   per-example precision under the most common Rails CI configuration is
-  a trust story, not a feature story.)*
+  a trust story, not a feature story. Implementation is evidence-gated
+  on shadow-mode data + reference-adopter feedback during rc.3 — if
+  whole-suite invalidation under `eager_load = true` proves not to be
+  the binding constraint on real-world Rails apps, the feature defers
+  back to 2.1.)*
 
 ### Documentation + positioning
 
@@ -147,6 +158,37 @@ The same release ramp also reshapes how rspec-tracer is presented:
   surfacing the existing Ruby-HEAD CI in the README. Closes
   "single-maintainer infrastructure on volatile tooling" as an
   adoption objection.
+
+### Distribution + adoption
+
+Running in parallel with the engineering cycles above — not after
+2.0 ships. The recognition: after the rc cycles complete, the
+binding constraint flips from *"is the tool trustworthy enough"*
+to *"does anyone know it exists and will a credible team vouch
+for it."* Owned as a first-class workstream rather than treated
+as an afterthought.
+
+- **Reference adopter recruitment + first public case study.**
+  Warm-target outreach to known active users + co-authored case
+  study published alongside the GA tag. Self-reported maintainer
+  benchmarks are discounted by default; third-party *"we cut CI
+  from N min to M min, here's the config"* is the artifact that
+  closes adoption-side Q&A loops.
+- **Conference talks + technical blog series.** CFP submissions
+  for RubyConf / Rails World in the GA window; 3-part blog series
+  anchored to the trust + soundness-ledger narrative; newsletter
+  pitches to Ruby Weekly + This Week in Rails.
+- **Ongoing community presence.** Maintainer presence in
+  3+ Ruby/Rails community real-time channels (Discord / Slack)
+  with sustained ~1-2 hr/week cadence. Lower-overhead than
+  conferences/blog but compounds over time.
+
+The distribution workstream feeds the engineering cycles too:
+reference-adopter feedback empirically validates whether
+`track_class_attribution` under `eager_load = true` is the
+binding constraint adopters care about (vs a theoretical concern),
+which influences whether that feature lands in 2.0 GA or defers
+back to 2.1.
 
 ---
 


### PR DESCRIPTION
## Summary

Calibrates ROADMAP.md against the post-pre.2 strategic-feedback synthesis cycle's **5th feedback round** (Feedback E, 2026-05-17). Three additions; +43/-1 LOC.

### 1. Auto-fallback (Trust + observability)

New bullet next to confidence scoring: the runtime decision logic that CONSUMES the confidence signal. If confidence drops below threshold or N consecutive runs show drift, auto-fall back to full-suite + warn.

Feedback E's framing: *"The trust cluster observes but doesn't self-protect. #237 measures, #240 scores, #238 publishes. Nothing CONSUMES the confidence signal at runtime."* This issue closes the gap. Categorical upgrade from observe-and-report to observe-and-self-defend.

Tracked: [#249](https://github.com/avmnu-sng/rspec-tracer/issues/249) (rc.3 milestone).

### 2. `track_class_attribution` evidence-gate (Rails per-example precision)

Existing bullet gains an explicit note: implementation gated on shadow-mode data + reference-adopter feedback during rc.3. If whole-suite invalidation under `eager_load = true` proves not to be the binding constraint on real-world Rails apps, the feature defers back to 2.1.

Feedback E's framing: *"The XL #239 spend is built on a theorized model of adopter fear ... build #237/#240 first, let the shadow data tell you whether #239 is the binding constraint, and treat #239's go/no-go as evidence-gated rather than pre-committed."*

### 3. NEW "Distribution + adoption" section

Closes the workstream that was entirely absent from the prior roadmap. Three subsections:
- Reference adopter recruitment + first public case study
- Conference talks + technical blog series + newsletter
- Ongoing community presence (Discord / Slack)

Runs **in parallel with** the engineering cycles, not after — distribution starts when the first rc is tagged so deliverables are publication-ready alongside the GA tag.

Feedback E's framing: *"There is no distribution workstream anywhere in the 24. Every issue is a code or docs artifact. ... After rc.3 the binding constraint flips from 'is it trustworthy enough' to 'does anyone know it exists and will a credible team vouch for it.' Roadmaps without a distribution owner ship excellent software into silence."*

Tracked: [#250](https://github.com/avmnu-sng/rspec-tracer/issues/250) / [#251](https://github.com/avmnu-sng/rspec-tracer/issues/251) / [#252](https://github.com/avmnu-sng/rspec-tracer/issues/252) / [#253](https://github.com/avmnu-sng/rspec-tracer/issues/253) (v2.0.0 milestone).

## Test plan

- [x] `task lint:yaml` — clean
- [x] Internal-ID leak check (`grep -rnE 'M[0-9]+\.[0-9]+|docs/revamp|KNOWN_ISSUES' ROADMAP.md`) returns ZERO
- [ ] CI green first cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)