### PR TITLE
chore(deps): raise sample rails_app puma floor past PROXY advisories

### DIFF
--- a/sample_projects/rails_app/Gemfile
+++ b/sample_projects/rails_app/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', ENV['RAILS_VERSION']
 # to 2.x and then the gem activation blows up. Rails 8.0 needs
 # sqlite3 >= 2.1. Pick the right major via env var from the workflow.
 gem 'sqlite3', ENV.fetch('SQLITE3_VERSION', '~> 1.4')
-gem 'puma', '~> 6.0'
+gem 'puma', '>= 7.2.1'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.4', require: false
 


### PR DESCRIPTION
## Summary

Raises the puma constraint in `sample_projects/rails_app/Gemfile` from `~> 6.0` to `>= 7.2.1` — the last two open Dependabot alerts (43–44, high) flag puma `>= 5.5.0, < 7.2.1` for the PROXY protocol advisories (GHSA-c2f4-cvqm-65w2, GHSA-hmx2-2w2p-2r5w).

The sample tree is not exercised by any CI job or task (it is a 1.x-era artifact referenced only by lint-config exclusions); the floor change stops the manifest from advertising a vulnerable range. Worth considering deleting `sample_projects/` entirely in a future cleanup, which would retire this alert surface for good.

The npm advisories originally bundled here moved to #263 — the security job's npm audit and the lint job's RuboCop failures were mutually red, so both fixes need to land in one PR to produce a green `ci-done`.

## Merge order

After #263 (this PR's lint/security jobs go green once #263 is on `main`; re-run checks).