### PR TITLE
fix: keep nested groups when dropping duplicates + unstick nightly soak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [Unreleased]
+
+### Fixed
+
+- **Duplicate-example drop no longer discards nested spec files**
+  ([#262](https://github.com/avmnu-sng/rspec-tracer/issues/262)).
+  With at least one pair of colliding example identities anywhere in
+  the suite, the drop path rebuilt RSpec's top-level group list by
+  requiring each top-level group to directly own surviving examples,
+  so every spec file whose examples live inside nested `describe`
+  blocks was removed wholesale (a 399-example suite with one
+  colliding pair ran only 68 examples; with
+  `fail_on_duplicates false` that under-run exited zero). The group
+  filter now maps each surviving example back to its top-level
+  group, so exactly the colliding examples are dropped — the
+  behavior UPGRADING.md documents.
+
 ## [2.0.0.pre.2] - 2026-05-16
 
 Bug-fix + interop release after the field-test pass that followed

--- a/lib/rspec_tracer/rspec/runner_hook.rb
+++ b/lib/rspec_tracer/rspec/runner_hook.rb
@@ -220,19 +220,36 @@ module RSpecTracer
       # `inject(0) { |a, e| a + e.filtered_examples.size }`. The
       # default block returns `[]` (`.size == 0`), matching the
       # pre-drop path's behavior.
+      #
+      # `examples_map` is keyed by LEAF groups (the keys of
+      # `RSpec.world.filtered_examples`) while `example_groups` holds
+      # TOP-LEVEL groups (`example.example_group.parent_groups.last`,
+      # collected by `_rspec_tracer_build_filter_decision`). For any
+      # spec file with nested describes those two sets are disjoint,
+      # so the group filter maps each survivor back to its top-level
+      # parent — mirroring how the pre-drop path built the group list.
+      # Filtering `example_groups` by `kept_map.key?` instead used to
+      # drop every nested spec file in the suite the moment one
+      # duplicate pair existed anywhere (refinery soak: "running 68
+      # examples (actual: 399, skipped: 331)" from a single colliding
+      # pair in a 399-example suite).
       # @api private
       def _rspec_tracer_drop_duplicate_examples(examples_map, example_groups)
         duplicate_ids = Set.new(RSpecTracer.engine.duplicate_examples.keys)
 
         kept_map = Hash.new { |hash, group| hash[group] = [] }
+        kept_top_level = Set.new
         examples_map.each do |group, examples|
           survivors = examples.reject do |example|
             duplicate_ids.include?(example.metadata[:rspec_tracer_example_id])
           end
-          kept_map[group] = survivors unless survivors.empty?
+          next if survivors.empty?
+
+          kept_map[group] = survivors
+          survivors.each { |example| kept_top_level << example.example_group.parent_groups.last }
         end
 
-        [kept_map, example_groups.select { |group| kept_map.key?(group) }]
+        [kept_map, example_groups.select { |group| kept_top_level.include?(group) }]
       end
     end
   end

--- a/spec/integration/fail_on_duplicates_spec.rb
+++ b/spec/integration/fail_on_duplicates_spec.rb
@@ -40,6 +40,16 @@ require 'tmpdir'
 # the two iterations collide on rspec-tracer's identity hash even
 # though RSpec itself treats them as distinct examples.
 #
+# The two baselines cover both suite shapes the drop path must
+# preserve: a flat group (example directly under the top-level
+# describe) and a nested group (example inside an inner describe).
+# The nested one is load-bearing: RSpec.world.filtered_examples is
+# keyed by LEAF groups while the runner's group list holds TOP-LEVEL
+# groups, and a drop-path regression that only maps flat groups
+# silently discards every nested spec file in the suite (surfaced by
+# the refinery soak as "running 68 examples (actual: 399,
+# skipped: 331)" on a 2-duplicate suite).
+#
 # rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
 RSpec.describe 'fail_on_duplicates real-user-shape integration' do
   let(:project_root) { File.expand_path('../..', __dir__) }
@@ -59,6 +69,14 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
       RSpec.describe 'a non-duplicate baseline' do
         it 'runs once with a unique identity' do
           expect(true).to be(true)
+        end
+      end
+
+      RSpec.describe 'a nested non-duplicate baseline' do
+        describe 'inner group' do
+          it 'survives the duplicate drop from inside a nested describe' do
+            expect(true).to be(true)
+          end
         end
       end
     RUBY
@@ -125,7 +143,7 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
         expect(out).to match(duplicate_log_re)
         # the non-duplicate baseline still runs - the suite is not
         # aborted to zero examples (issue #210).
-        expect(out).to include('running 1 examples')
+        expect(out).to include('running 2 examples')
       end
     end
   end
@@ -141,13 +159,13 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           be(true),
           "expected zero exit when fail_on_duplicates is false, got #{status.exitstatus}:\n#{out}"
         )
-        expect(out).to include('running 1 examples')
+        expect(out).to include('running 2 examples')
         duplicates = read_duplicate_examples(dir)
         expect(duplicates).not_to be_empty
         expect(duplicates.values.flatten.size).to be >= 2
         # the non-duplicate baseline ran and was cached; the colliding
         # examples were dropped from all_examples by deregistration.
-        expect(read_all_examples(dir).size).to eq(1)
+        expect(read_all_examples(dir).size).to eq(2)
       end
     end
   end
@@ -164,7 +182,7 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           "expected non-zero exit when env=true overrides DSL=false, got 0:\n#{out}"
         )
         expect(out).to match(duplicate_log_re)
-        expect(out).to include('running 1 examples')
+        expect(out).to include('running 2 examples')
       end
     end
   end
@@ -180,7 +198,7 @@ RSpec.describe 'fail_on_duplicates real-user-shape integration' do
           be(true),
           "expected zero exit when env=false overrides DSL=true, got #{status.exitstatus}:\n#{out}"
         )
-        expect(out).to include('running 1 examples')
+        expect(out).to include('running 2 examples')
         duplicates = read_duplicate_examples(dir)
         expect(duplicates).not_to be_empty
       end

--- a/spec/rspec/runner_hook_spec.rb
+++ b/spec/rspec/runner_hook_spec.rb
@@ -195,6 +195,32 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
         expect(kept_map.default_proc).not_to be_nil
         expect(kept_map[intermediate_group]).to eq([])
       end
+
+      it 'keeps a nested top-level group whose leaf describe still has surviving examples' do
+        # RSpec.world.filtered_examples is keyed by LEAF groups while
+        # run_specs' group list holds TOP-LEVEL groups
+        # (`example.example_group.parent_groups.last`). For any spec
+        # file with nested describes those two sets are disjoint, so
+        # the drop path must map survivors back to their top-level
+        # parent instead of requiring the top-level group to be a
+        # kept_map key. Regression: with one colliding pair anywhere
+        # in the suite, every nested spec file was dropped wholesale
+        # (refinery soak: "running 68 examples (actual: 399,
+        # skipped: 331)").
+        top_group = double('TopLevelGroup')
+        leaf_group = double('LeafGroup')
+        survivor_metadata = { rspec_tracer_example_id: 'unique-id', file_path: 'spec/a_spec.rb' }
+        survivor = double('Survivor', metadata: survivor_metadata, description: 'unique',
+                                      example_group: double('EG', parent_groups: [leaf_group, top_group]))
+        examples_map = { leaf_group => [survivor] }
+
+        kept_map, kept_groups = runner.send(
+          :_rspec_tracer_drop_duplicate_examples, examples_map, [top_group]
+        )
+
+        expect(kept_map[leaf_group]).to eq([survivor])
+        expect(kept_groups).to eq([top_group])
+      end
     end
 
     context 'when examples are tracked and the engine schedules a run' do

--- a/spec/soak/realworld_soak_spec.rb
+++ b/spec/soak/realworld_soak_spec.rb
@@ -87,6 +87,16 @@ PROJECT_INVOCATIONS = {
     # at the pinned SHA (CI run 25143397673 cell `soak (solidus)`
     # passed in 4m31s with full suite).
     rspec_args: ['spec'],
+    # spec/i18n_spec.rb is a hygiene lint asserting the api engine's
+    # config/locales/*.yml are i18n-tasks-normalized. The :locale
+    # mutation kind appends comment lines to exactly those files, so
+    # any locale iter that lands on an api locale file re-selects the
+    # spec and fails it - the check working as designed, not a tracer
+    # defect. Deterministic nightly casualty: mutation seed 44 always
+    # picks api/config/locales/en.yml, so every 50-iter cron died at
+    # iter 44. A normalization lint over mutation-target files is
+    # structurally incompatible with the append-mutation model.
+    rspec_exclude: 'spec/i18n_spec.rb',
     extra_env: { 'DB' => 'sqlite' }
   },
   refinery: {
@@ -104,7 +114,17 @@ PROJECT_INVOCATIONS = {
       resources/spec/lib resources/spec/models
       dragonfly/spec/lib
     ],
-    extra_env: {}
+    # Refinery v4.1.0 ships two examples sharing one full description
+    # (images/spec/models/refinery/image_spec.rb:163 / :207, both
+    # "Refinery::Image#thumbnail_dimensions returns correctly with
+    # nil"). rspec-tracer's fail_on_duplicates gate (default true)
+    # turns that into exit 1 on an otherwise green suite, which
+    # failed every nightly iter 1 since the v4.1.0 pin. Duplicate
+    # detection + drop stay exercised (the diagnostic still logs and
+    # the colliding pair is dropped); only the exit gate is disabled
+    # because upstream description hygiene is not the soak's
+    # assertion surface.
+    extra_env: { 'RSPEC_TRACER_FAIL_ON_DUPLICATES' => 'false' }
   },
   spree: {
     gemfile_dir: 'spree/core',
@@ -456,9 +476,15 @@ RSpec.describe "realworld soak (#{PROJECT}#{SHARD_LABEL})" do
     # accumulated to output_buffer for the failure-case raise.
     output_buffer = +''
     status = nil
+    # --exclude-pattern is honored here because rspec_args passes
+    # DIRECTORIES (rspec filters files gathered from dir globbing);
+    # explicit positional file paths would silently bypass it.
+    exclude_args =
+      INVOCATION[:rspec_exclude] ? ['--exclude-pattern', INVOCATION[:rspec_exclude]] : []
     Bundler.with_unbundled_env do
       Open3.popen2e(env, 'bundle', 'exec', 'rspec',
                     '--no-color', '--format', 'progress',
+                    *exclude_args,
                     *INVOCATION[:rspec_args],
                     chdir: ENGINE_PATH.to_s) do |_stdin, out, wait_thr|
         out.each_line do |line|


### PR DESCRIPTION
## Summary

Closes #262. Fixes the duplicate-example drop path discarding whole nested spec files, and fixes both standing nightly-soak failure modes (the soak has failed every night since 2026-05-04).

### Lib fix: duplicate drop discarded nested spec files (#262)

`_rspec_tracer_drop_duplicate_examples` rebuilt RSpec's top-level group list with `example_groups.select { |group| kept_map.key?(group) }` — but `kept_map` is keyed by the **leaf** groups of `RSpec.world.filtered_examples` while `example_groups` holds **top-level** groups. For any spec file with nested `describe` blocks the two sets are disjoint, so one colliding pair anywhere in the suite dropped every nested spec file wholesale: the refinery soak ran **68 of 399 examples** (`skipped: 331` on a cold cache), and with `fail_on_duplicates false` that under-run exits **zero** — a silent mass under-run. The fix maps each surviving example back to its top-level parent (mirroring the pre-drop group collection), so exactly the colliding examples are dropped — the behavior UPGRADING.md documents.

Regression coverage targets the exact blind spot (all prior coverage used flat groups, the one shape the bug didn't affect): a nested-group unit case in `runner_hook_spec.rb` + a nested baseline group in the `fail_on_duplicates` integration fixture (asserting counts red before the fix, green after).

### Soak fix 1: solidus died at iter 44 every night since 2026-05-04

The `:locale` mutation kind appends a comment line to a random locale YAML; mutation seed 44 deterministically picks `api/config/locales/en.yml`, and solidus's own `spec/i18n_spec.rb` (i18n-tasks normalization lint) correctly fails on the append. Every sampled failed run across 16 nights shows the identical `iter 44 / i18n_spec.rb:21` signature. A normalization lint over mutation-target files is structurally incompatible with the append-mutation model, so the spec is excluded via `--exclude-pattern` (honored because the solidus invocation passes a directory, not file paths).

### Soak fix 2: refinery died at iter 1 every night since the v4.1.0 pin (2026-05-16)

Refinery v4.1.0 ships two examples sharing one full description (`images/spec/models/refinery/image_spec.rb:163`/`:207`), so `fail_on_duplicates` (default true) exits 1 on an otherwise green suite. The subprocess now runs with `RSPEC_TRACER_FAIL_ON_DUPLICATES=false`: detection + drop stay exercised every night; upstream description hygiene stops failing the soak. Note this env knob is only honest **with** the lib fix above — without it, the exit-0 path silently ran 17% of the suite, which is how the bug surfaced.

## Verification

- Unit + integration duplicate specs: red before the lib fix (5 failures), green after.
- Refinery, fixture at pinned SHA, patched lib: cold run banner `running 397 examples (actual: 399, skipped: 2)` (was `68 / 331`), 10-iteration smoke 10/10 OK.
- Solidus at the exact failing condition (`SOAK_SHARD=44 SOAK_ITERATIONS=1` = global mutation seed 44): reproduced the i18n failure pre-fix, 648 examples green post-fix.
- Full local parity (lint, unit, property, mutation smoke, contract, dogfood, fuzz, regressions, edge-cases, benchmark smoke, yard, gem build) green.

## Also observed, not addressed here

- spree-shard-1 hit its memory bound once (2026-05-28) in 16 sampled nights; siblings green. Flagged watch-if-recurs.
- The soak workflow's per-cell 4h cap and pin policy are untouched.