### PR TITLE
docs: rc.1 landing-page bundle -- positioning, soundness model, cost framing, maintenance policy

### DIFF
--- a/.github/workflows/example-tracer-cache.yml
+++ b/.github/workflows/example-tracer-cache.yml
@@ -42,10 +42,9 @@ concurrency:
   # an in-flight run. The merge-to-main push fire is the cold-cycle
   # cache-populating run; if a manual workflow_dispatch comes in
   # while it's still going, cancelling the merge run would lose its
-  # post-step cache save (per feedback_actions_cache_post_hook_timeout)
-  # and trap the next dispatch in cold-run hell. Mirrors ci.yml's
-  # rule: main / merge runs must run to completion, never cancelled
-  # because a later trigger arrived.
+  # post-step cache save and trap the next dispatch in cold-run
+  # hell. Mirrors ci.yml's rule: main / merge runs must run to
+  # completion, never cancelled because a later trigger arrived.
   group: example-tracer-cache
   cancel-in-progress: false
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -32,11 +32,17 @@ Every test has zero or more inputs from these buckets:
    `IO`, `YAML`, `JSON`, `Kernel`. Cost: ~100–300 ns per call.
 
 3. **Framework events** — Rails template renders, I18n lookups, etc.
-   *Observed via:* `ActiveSupport::Notifications` subscribers. Cost: already
-   paid by Rails; we just listen.
+   Concretely: template / partial / collection renders, I18n
+   translation loads, and (opt-in, via `track_ar_schema_notifications`)
+   ActiveRecord schema-touching queries.
+   *Observed via:* `ActiveSupport::Notifications` subscribers plus an
+   `I18n::Backend::Base` prepend hook. Cost: already paid by Rails; we
+   just listen.
 
 4. **Declared globs** — inputs the user explicitly tells us to track, e.g.
-   `config/locales/**/*.yml`, `db/schema.rb`, `Gemfile.lock`.
+   `config/locales/**/*.yml`, `db/schema.rb`, `Gemfile.lock`. Declared
+   through `track_files` / `track_rails_defaults` in config, or
+   per-example via the `tracks:` metadata DSL.
    *Observed via:* directory walk at boot, digest cache, declared-to-example
    attribution rules. Cost: proportional to declared files, ~O(20 ms) at
    boot.
@@ -122,77 +128,78 @@ replaceable independently.
 
 ```text
 rspec-tracer/
-├── lib/
-│   └── rspec_tracer/
-│       ├── version.rb
-│       ├── configuration.rb
-│       ├── tracker/                  ← core engine
-│       │   ├── input.rb
-│       │   ├── coverage_adapter.rb
-│       │   ├── io_hooks/
-│       │   │   ├── file.rb
-│       │   │   ├── io.rb
-│       │   │   ├── yaml.rb
-│       │   │   ├── json.rb
-│       │   │   └── kernel.rb
-│       │   ├── notifications/
-│       │   │   └── action_view.rb
-│       │   ├── declared_globs.rb
-│       │   ├── whole_suite_invalidators.rb
-│       │   ├── dependency_graph.rb
-│       │   ├── filter.rb
-│       │   └── example_registry.rb
-│       ├── storage/
-│       │   ├── backend.rb            ← protocol
-│       │   ├── json_backend.rb
-│       │   ├── sqlite_backend.rb     ← optional
-│       │   └── schema_version.rb
-│       ├── remote_cache/
-│       │   ├── backend.rb            ← protocol
-│       │   ├── s3_backend.rb
-│       │   ├── local_fs_backend.rb
-│       │   └── redis_backend.rb      ← optional
-│       ├── reporters/
-│       │   ├── base.rb
-│       │   ├── json_reporter.rb
-│       │   ├── terminal_reporter.rb
-│       │   └── html_reporter.rb
-│       ├── rspec/
-│       │   ├── runner_hook.rb
-│       │   ├── reporter_hook.rb
-│       │   ├── metadata.rb           ← per-example `tracks:` DSL
-│       │   └── parallel_tests.rb
-│       ├── rails/
-│       │   ├── preset.rb
-│       │   └── railtie.rb            ← auto-load when Rails present
-│       └── cli.rb
-├── spec/
-│   ├── spec_helper.rb
-│   ├── support/
-│   ├── tracker/
-│   ├── storage/
-│   ├── remote_cache/
-│   ├── reporters/
-│   ├── rspec/
-│   ├── rails/
-│   ├── integration/
-│   │   └── reference_rails_app_spec.rb
-│   └── benchmark/
-│       └── cold_boot_spec.rb
-├── spec/fixtures/
-│   ├── rails_app/                    ← real Rails 7.1 app, load-bearing
-│   └── ruby_app/
-├── Taskfile.yml                      ← dev loop; see DEV_LOOP.md
-├── bin/
-│   ├── rspec-tracer                  ← CLI entry
-│   ├── actionlint                    ← installed by `task install:tools`
-│   └── shellcheck                    ← installed by `task install:tools`
-├── benchmark/
-│   ├── ratchet.json                  ← committed benchmark thresholds
-│   └── harness.rb
-├── docs/
-│   └── revamp/                       ← this directory
-└── ...
+|-- lib/
+|   `-- rspec_tracer/
+|       |-- version.rb
+|       |-- configuration.rb
+|       |-- tracker/                  <- core engine
+|       |   |-- input.rb
+|       |   |-- coverage_adapter.rb
+|       |   |-- io_hooks/
+|       |   |   |-- file.rb
+|       |   |   |-- io.rb
+|       |   |   |-- yaml.rb
+|       |   |   |-- json.rb
+|       |   |   `-- kernel.rb
+|       |   |-- notifications/
+|       |   |   `-- action_view.rb
+|       |   |-- declared_globs.rb
+|       |   |-- whole_suite_invalidators.rb
+|       |   |-- dependency_graph.rb
+|       |   |-- filter.rb
+|       |   `-- example_registry.rb
+|       |-- storage/
+|       |   |-- backend.rb            <- protocol
+|       |   |-- json_backend.rb
+|       |   |-- sqlite_backend.rb     <- optional
+|       |   `-- schema_version.rb
+|       |-- remote_cache/
+|       |   |-- backend.rb            <- protocol
+|       |   |-- s3_backend.rb
+|       |   |-- local_fs_backend.rb
+|       |   `-- redis_backend.rb      <- optional
+|       |-- reporters/
+|       |   |-- base.rb
+|       |   |-- json_reporter.rb
+|       |   |-- terminal_reporter.rb
+|       |   `-- html_reporter.rb
+|       |-- rspec/
+|       |   |-- runner_hook.rb
+|       |   |-- reporter_hook.rb
+|       |   |-- metadata.rb           <- per-example `tracks:` DSL
+|       |   `-- parallel_tests.rb
+|       |-- rails/
+|       |   |-- preset.rb
+|       |   `-- railtie.rb            <- auto-load when Rails present
+|       `-- cli.rb
+|-- spec/
+|   |-- spec_helper.rb
+|   |-- support/
+|   |-- tracker/
+|   |-- storage/
+|   |-- remote_cache/
+|   |-- reporters/
+|   |-- rspec/
+|   |-- rails/
+|   |-- integration/
+|   |   `-- reference_rails_app_spec.rb
+|   `-- benchmark/
+|       `-- cold_boot_spec.rb
+|-- spec/fixtures/
+|   |-- rails_app/                    <- real Rails 7.1 app, load-bearing
+|   `-- ruby_app/
+|-- Taskfile.yml                      <- dev loop; see DEV_LOOP.md
+|-- bin/
+|   |-- rspec-tracer                  <- CLI entry
+|   |-- actionlint                    <- installed by `task install:tools`
+|   `-- shellcheck                    <- installed by `task install:tools`
+|-- benchmark/
+|   |-- ratchet.json                  <- committed benchmark thresholds
+|   `-- harness.rb
+|-- docs/
+|   |-- CI_RECIPES.md                 <- per-provider CI cache recipes
+|   `-- internals/                    <- subsystem deep-dives
+`-- ...
 ```
 
 ## Contracts between layers
@@ -292,6 +299,107 @@ start → storage.load_graph → raises or returns nil (corrupted file, bad JSON
 ```
 
 Never propagate storage errors to the caller.
+
+## Soundness model
+
+"Sound" here means: if a recorded input changes, the tracer is
+guaranteed to notice and to re-run every example that recorded it.
+Not every input type can carry that guarantee, and this section says
+exactly which ones do. The governing rule for everything the tracer
+does observe:
+
+> **When a recorded input is ambiguous, the tracer re-runs.** Doubt
+> is resolved by running the example, never by skipping it.
+
+The honest cost sits on the other side of that line: an input the
+tracer never observed cannot trigger a re-run. The tiers below
+classify every input type by which side it falls on. Independent of
+tier, examples that previously failed, were flagged flaky, were
+pending, or were interrupted are always re-run, as is any example
+with no cache entry -- skip decisions apply only to examples with a
+clean, fully-recorded history.
+
+### The four tiers
+
+| Tier | Guarantee |
+|------|-----------|
+| **Sound** | A change to the recorded input is always detected; every example that recorded it re-runs. |
+| **Conservative** | Detection is sound, but attribution over-approximates: more examples re-run than strictly necessary, never fewer (within the observed scope). |
+| **Heuristic** | Observation rides an event or hook surface that covers the common cases; an input consumed outside that surface is not recorded. |
+| **Blind spot** | Not observable at all. Declare it via the escape hatch below, or the tracer cannot see it. |
+
+### Classification by input type
+
+| Input | Mechanism | Tier | Notes |
+|-------|-----------|------|-------|
+| Whole-suite invalidators (`Gemfile.lock`, `.ruby-version`, `.rspec-tracer`, gem version) | Digest snapshot at boot, value-equality compare | Sound | Any mismatch, including a watched file appearing or disappearing, forces a full run. |
+| Project Ruby source (`.rb` under root, not filtered) | `Coverage` diff per example + loaded-files over-approximation | Sound detection, conservative attribution | Content change is always caught (SHA256). Per-example precision degrades to "every example that ran after the file loaded" for files whose use leaves no coverage delta (constant lookups, memoized state). |
+| Declared file globs (`track_files`, `tracks: { files: ... }`) | Boot-time walk + digest per run | Sound, given the declaration | The guarantee is conditional and applies to files the cache has seen: any change or deletion under a declared glob re-runs the attributed examples. Files added after the last observed run follow the "New source files" row below. |
+| Declared ENV vars (`track_env`, `tracks: { env: ... }`) | Per-run value digest, compared against the cached snapshot | Sound, two documented exceptions | (1) An unset variable and an empty string digest identically, so unset -> `""` is not a change. (2) Wildcard patterns (`RAILS_*`) re-expand against the live environment each run; a variable that disappears entirely also drops off the watch list. Prefer literal names for variables that come and go. |
+| Boot-set files (everything loaded before the first example: `spec_helper` requires, gem-loaded engine `lib/`, eager-loaded `app/`) | Digest snapshot of the boot set; any change invalidates the whole suite | Conservative | Deliberately coarse: safe under `config.eager_load = true` and constant autoload timing, at the cost of whole-suite re-runs on boot-file edits. Opt-out: `transitive_load_tracking false` (re-opens the constants-lookup blind spot). |
+| New source files | Boot-set snapshot compare + per-run re-walk of declared globs and `lib/**/*.rb` | Conservative when boot-loaded; blind spot when runtime-only | A new file that loads during boot (eager-loaded `app/`, `spec_helper` requires) changes the boot-set snapshot and re-runs the whole suite. A new spec file's examples always run (no cache entry). But a file that is only consumed at runtime (a new locale file, a constant resolved by reflection) cannot appear in any previously-cached dependency set, so by itself it does not re-run previously-passing examples -- it enters the graph on the first run that observes it. |
+| File I/O (`File.read`, `YAML.load_file`, `JSON.load_file`, `IO.read`, `Kernel#load`, ...) | `Module#prepend` hooks on class-level entry points | Heuristic | Records exactly what passes through the hooked methods, for allow-listed extensions (`.yml .yaml .json .erb .haml .slim .builder .jbuilder .ru .rake`; `.rb` for `Kernel#load`). Reads via unhooked APIs, C extensions, other extensions, or threads other than the example's are not recorded. |
+| Rails template renders | `render_{template,partial,collection}.action_view` subscribers | Heuristic | Attribution is thread-local: renders on another thread (e.g. an app server thread under browser tests) are not attributed. Malformed event payloads are skipped by design. |
+| I18n translations | Prepend on `I18n::Backend::Base#load_translations` | Heuristic | Covers backends that super-call `Base` (Simple, Chain, Cascade). A backend that never calls up is invisible; YAML-file backends are also caught by the I/O hook. |
+| ActiveRecord schema coupling (opt-in) | First `sql.active_record` event per example attributes `db/schema.rb` + `db/structure.sql` | Heuristic | A proxy, not a parse: any DB-touching example couples to the whole schema file (over-approximate per table), but only if a query event fires on the example's thread during the example. |
+| Runtime metaprogramming, monkey-patches in unexecuted or filtered files, ENV branches without declarations, refinements in unexecuted files, database contents | none | Blind spot | See below. |
+
+### What we don't detect
+
+These are the known blind spots -- inputs with no observation
+mechanism. If one of them can change an example's outcome, the tracer
+will not re-run that example on its own:
+
+- **Runtime metaprogramming.** Behavior manufactured from non-file
+  state at runtime (`define_method` / `const_set` driven by data the
+  tracer never saw as a file read).
+- **Monkey-patches in files that never execute in this process** --
+  most commonly gem code outside the project root, or paths excluded
+  by a user filter. A patched gem upgrade is still caught, but only
+  at `Gemfile.lock` granularity (whole-suite invalidator).
+- **ENV-var branches without declarations.** The tracer watches only
+  the ENV names that config or example metadata declares.
+- **Refinements in unexecuted files.** A `using` whose refinement file
+  never loads during the suite leaves no coverage or load trace.
+- **Runtime-only new files.** A file added since an example last ran
+  and consumed only at runtime cannot be in that example's recorded
+  inputs (see the "New source files" row above); boot-loaded
+  additions are caught via the boot set.
+- **State outside the filesystem.** Database rows, external services,
+  the clock: the tracer digests files, not the world. Schema files
+  are the closest observable proxy (see the opt-in row above).
+
+The escape hatch for all of these is declaration -- turning an
+unobservable input into a declared (sound-tier) one:
+
+```ruby
+# .rspec-tracer -- suite-wide
+RSpecTracer.configure do
+  track_files 'config/feature_flags/**/*.yml'
+  track_env 'FEATURE_X'
+end
+
+# or per example group, via metadata
+RSpec.describe Checkout, tracks: { files: 'db/seeds.rb',
+                                   env: 'PAYMENT_GATEWAY' } do
+  # ...
+end
+```
+
+### Reading the tiers as a user
+
+- A **sound** input needs no thought: edit it and the right examples
+  re-run.
+- A **conservative** input trades precision for safety: expect
+  occasional larger-than-necessary re-runs (a boot-file edit re-runs
+  everything), never a missed one.
+- A **heuristic** input is trustworthy inside its stated surface;
+  when your suite consumes it outside that surface (another thread,
+  an exotic backend, an unhooked read path), add a declaration.
+- A **blind spot** must be declared or accepted. When in doubt about
+  whether something is observed, declare it -- a redundant
+  declaration costs one digest per run; a missed input costs a stale
+  green.
 
 ## Schema versioning
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 ## [Unreleased]
 
+### Added
+
+- **Soundness model documentation.** New ARCHITECTURE.md section
+  classifying what the tracer guarantees (content digests, explicit
+  declarations, env snapshots), where it is deliberately
+  conservative, where it relies on heuristics, and what it cannot
+  observe at all -- with the `tracks:` DSL as the escape hatch
+  ([#226](https://github.com/avmnu-sng/rspec-tracer/issues/226)).
+- **Cost framing for CI.** New README section with measured cold/warm
+  timings and a formula for estimating CI-minute and dollar savings
+  from your own suite's numbers and your provider's rate
+  ([#227](https://github.com/avmnu-sng/rspec-tracer/issues/227)).
+- **Maintenance and Ruby EOL policy.** New README Maintenance
+  section: each Ruby is supported until at least upstream EOL plus
+  6 months, with a per-version table
+  ([#229](https://github.com/avmnu-sng/rspec-tracer/issues/229)).
+- **COOKBOOK recipes for flaky-test detection and file-to-test
+  dependency mapping**, placed ahead of the acceleration recipes
+  ([#224](https://github.com/avmnu-sng/rspec-tracer/issues/224)).
+
+### Changed
+
+- **README restructured as a landing page**
+  ([#223](https://github.com/avmnu-sng/rspec-tracer/issues/223)):
+  measured, attributed numbers, quick start, safety summary, and
+  data-stays-local positioning
+  ([#225](https://github.com/avmnu-sng/rspec-tracer/issues/225)) up
+  front; the input-taxonomy depth moved to ARCHITECTURE.md and the
+  eager-load precision guidance to COOKBOOK.md; per-provider CI
+  cache recipes ([`docs/CI_RECIPES.md`](docs/CI_RECIPES.md)) linked
+  from the quick start
+  ([#228](https://github.com/avmnu-sng/rspec-tracer/issues/228)).
+- **Gem summary and description repositioned** to lead with
+  flaky-test detection and dependency mapping, with
+  re-run-only-what-changed as the closing step
+  ([#224](https://github.com/avmnu-sng/rspec-tracer/issues/224)).
+
 ### Fixed
 
 - **Duplicate-example drop no longer discards nested spec files**

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -11,17 +11,19 @@ from 1.x see [`UPGRADING.md`](UPGRADING.md). For internals see
 
 1. [Add to a fresh Ruby gem](#1-add-to-a-fresh-ruby-gem)
 2. [Add to an existing Rails app](#2-add-to-an-existing-rails-app)
-3. [Migrate a 1.x project to 2.0](#3-migrate-a-1x-project-to-20)
-4. [Configure remote cache (S3 / Local-FS / Redis)](#4-configure-remote-cache)
-5. [Run with `parallel_tests`](#5-run-with-parallel_tests)
-6. [Run on JRuby](#6-run-on-jruby)
-7. [Track non-Ruby deps via `tracks:`](#7-track-non-ruby-deps-via-tracks)
-8. [Track env-var branching](#8-track-env-var-branching)
-9. [Use SQLite storage instead of JSON](#9-use-sqlite-storage-instead-of-json)
-10. [Debug "why did this test re-run?"](#10-debug-why-did-this-test-re-run)
-11. [Compose with Knapsack / RSpec::Retry / RSpec::Rerun](#11-compose-with-knapsack--rspecretry--rspecrerun)
-12. [Write a custom storage backend](#12-write-a-custom-storage-backend)
-13. [Write a custom reporter](#13-write-a-custom-reporter)
+3. [Detect flaky tests](#3-detect-flaky-tests)
+4. [Map file-to-test dependencies (Files Dependency)](#4-map-file-to-test-dependencies-files-dependency)
+5. [Migrate a 1.x project to 2.0](#5-migrate-a-1x-project-to-20)
+6. [Configure remote cache (S3 / Local-FS / Redis)](#6-configure-remote-cache)
+7. [Run with `parallel_tests`](#7-run-with-parallel_tests)
+8. [Run on JRuby](#8-run-on-jruby)
+9. [Track non-Ruby deps via `tracks:`](#9-track-non-ruby-deps-via-tracks)
+10. [Track env-var branching](#10-track-env-var-branching)
+11. [Use SQLite storage instead of JSON](#11-use-sqlite-storage-instead-of-json)
+12. [Debug "why did this test re-run?"](#12-debug-why-did-this-test-re-run)
+13. [Compose with Knapsack / RSpec::Retry / RSpec::Rerun](#13-compose-with-knapsack--rspecretry--rspecrerun)
+14. [Write a custom storage backend](#14-write-a-custom-storage-backend)
+15. [Write a custom reporter](#15-write-a-custom-reporter)
 
 ---
 
@@ -66,6 +68,10 @@ bundle exec rspec       # warm; skips unaffected examples
 The `rspec_tracer_report/index.html` file gives you per-example +
 per-file dependency views.
 
+Setting up CI? [docs/CI_RECIPES.md](docs/CI_RECIPES.md) has
+copy-paste cache recipes for CircleCI, GitLab CI, Buildkite, and
+Heroku CI, plus a link to the canonical GitHub Actions workflow.
+
 ---
 
 ## 2. Add to an existing Rails app
@@ -101,15 +107,21 @@ end
 
 `track_rails_defaults` attaches the common Rails-side declared globs
 (views, locales, fixtures, factories, helpers, config, schema). For
-narrower per-example schema attribution, see recipe
-[#4](#4-configure-remote-cache) below.
+narrower per-example schema attribution, see
+[Narrow AR-schema attribution](README.md#narrow-ar-schema-attribution)
+in the README.
 
 **Trade-off worth knowing**: if your test env runs with
 `config.eager_load = true` (Rails CI default), all `app/` files
 load at boot and any `app/` edit triggers a whole-suite re-run. To
 recover per-example precision, set `config.eager_load = false` in
-`config/environments/test.rb`. See README "How it works" for the
-full rationale.
+`config/environments/test.rb`. The boot-set row in
+[ARCHITECTURE.md's soundness model](ARCHITECTURE.md#soundness-model)
+explains why boot-loaded files invalidate the whole suite.
+
+Setting up CI? [docs/CI_RECIPES.md](docs/CI_RECIPES.md) has
+copy-paste cache recipes for CircleCI, GitLab CI, Buildkite, and
+Heroku CI, plus a link to the canonical GitHub Actions workflow.
 
 ### Rails engines: `lib/` always lands in the boot set
 
@@ -157,7 +169,101 @@ to the tracer.
 
 ---
 
-## 3. Migrate a 1.x project to 2.0
+## 3. Detect flaky tests
+
+Goal: find examples that pass and fail without their inputs
+changing -- no extra gems, no retry loops, and no test skipped in
+the process.
+
+rspec-tracer records each example's outcome alongside the inputs it
+consumed. When an example that failed on a previous run passes on a
+later one, it is flagged flaky; once flagged, it stays flagged and
+is never skipped, so every subsequent run re-investigates it.
+
+The default setup is all you need:
+
+```ruby
+# spec/spec_helper.rb -- top of file, before any application code.
+# With SimpleCov, start SimpleCov first -- load order is part of
+# the contract.
+require 'rspec_tracer'
+RSpecTracer.start
+```
+
+Not ready to let the tracer skip anything? Run in record-only mode
+-- every example still runs, and flaky detection works unchanged:
+
+```ruby
+# .rspec-tracer
+RSpecTracer.configure do
+  run_all_examples true
+end
+```
+
+Or per-run: `RSPEC_TRACER_RUN_ALL_EXAMPLES=true bundle exec rspec`.
+
+Where the output lives:
+
+- The terminal summary adds a flaky count to its tally line
+  (e.g. `2 flaky`) whenever any are detected.
+- The HTML report's **Flaky Examples** tab
+  (`rspec_tracer_report/index.html`) lists every flagged example.
+- `rspec_tracer_report/report.json` carries a `flaky_examples`
+  array (id, description, location) under its `reports` key for
+  CI dashboards.
+
+**One honest caveat**: flaky detection needs repeated runs on
+unchanged inputs. A single run proves nothing, and if you edit code
+between runs, a fail-then-pass flip looks like a fix, not a flake.
+The strongest signal comes from re-running the same commit -- CI
+retries, or local re-runs without edits.
+
+Pairing with `RSpec::Retry` so flakes don't block CI while you fix
+them? See recipe
+[#13](#13-compose-with-knapsack--rspecretry--rspecrerun).
+
+---
+
+## 4. Map file-to-test dependencies (Files Dependency)
+
+Goal: answer "what tests run if I change this file?" before you
+change it.
+
+Every run, rspec-tracer inverts its per-example input records into
+a file-to-examples map: for each file the suite consumed, which
+examples depend on it, and through which spec files. No config
+beyond the default:
+
+```ruby
+# spec/spec_helper.rb -- top of file, before any application code.
+# With SimpleCov, start SimpleCov first -- load order is part of
+# the contract.
+require 'rspec_tracer'
+RSpecTracer.start
+```
+
+Run the suite once (a cold run populates the map), then open
+`rspec_tracer_report/index.html`:
+
+- The **Files Dependency** tab is the file-to-tests view: pick a
+  file, see every example that depends on it.
+- The **Examples Dependency** tab is the per-example view: pick an
+  example, see every file it consumed.
+- `rspec_tracer_report/report.json`'s `reports.files_dependency`
+  array carries the same data (file, dependent-example count,
+  spec files) for scripting.
+
+Want the map without enabling skipping? Use the record-only mode
+from recipe [#3](#3-detect-flaky-tests).
+
+**One honest caveat**: the map shows test-to-file dependencies --
+which tests depend on which files -- not code-to-code coupling. Two
+application files that always change together show up only
+indirectly, through the examples that consume both.
+
+---
+
+## 5. Migrate a 1.x project to 2.0
 
 Goal: zero-touch upgrade preserving every 1.x behavior + adopting
 the new `track_rails_defaults` to close Rails blind spots.
@@ -186,10 +292,14 @@ complete migration guide.
 
 ---
 
-## 4. Configure remote cache
+## 6. Configure remote cache
 
 Pick one backend in `.rspec-tracer`. The `rake` task surface stays
 identical — only the storage substrate differs.
+
+Whichever backend you pick, the cache is plain files in
+infrastructure you own (your S3 bucket, your Redis, your
+filesystem) -- nothing ships to a vendor backend.
 
 ### S3 (preserves 1.x layout)
 
@@ -246,7 +356,7 @@ without enumerating the full key namespace.
 
 ---
 
-## 5. Run with `parallel_tests`
+## 7. Run with `parallel_tests`
 
 `parallel_tests` works out of the box. The tracker writes per-worker
 caches under `rspec_tracer_cache/parallel_tests_N/` and merges them
@@ -269,7 +379,7 @@ reports get purged at finalize alongside the per-worker cache dirs).
 
 ---
 
-## 6. Run on JRuby
+## 8. Run on JRuby
 
 ```sh
 export JRUBY_OPTS="--debug -X+O"
@@ -295,7 +405,7 @@ chain transparently.
 
 ---
 
-## 7. Track non-Ruby deps via `tracks:`
+## 9. Track non-Ruby deps via `tracks:`
 
 Goal: invalidate specific examples when a config file or non-Ruby
 asset they read changes.
@@ -335,7 +445,7 @@ attribution.
 
 ---
 
-## 8. Track env-var branching
+## 10. Track env-var branching
 
 Goal: invalidate examples when an env var they branch on changes
 between runs.
@@ -374,7 +484,7 @@ value (or setting/unsetting) invalidates the dependent examples.
 
 ---
 
-## 9. Use SQLite storage instead of JSON
+## 11. Use SQLite storage instead of JSON
 
 Goal: faster cold reads on suites with > ~5,000 examples.
 
@@ -464,7 +574,7 @@ your Ruby version for the authoritative supported set.
 
 ---
 
-## 10. Debug "why did this test re-run?"
+## 12. Debug "why did this test re-run?"
 
 Use `bundle exec rspec-tracer explain <example_id_or_substring>`:
 
@@ -491,7 +601,7 @@ order, schema version, remote-cache reachability, AR-schema config).
 
 ---
 
-## 11. Compose with Knapsack / RSpec::Retry / RSpec::Rerun
+## 13. Compose with Knapsack / RSpec::Retry / RSpec::Rerun
 
 These all coexist with rspec-tracer; their RSpec hooks compose with
 the tracer's `Module#prepend` chain. Add the gems normally.
@@ -547,7 +657,7 @@ through the rerun chain.
 
 ---
 
-## 12. Write a custom storage backend
+## 14. Write a custom storage backend
 
 Implement `RSpecTracer::Storage::Backend`'s 5-method protocol:
 
@@ -598,7 +708,7 @@ add your backend's spec to it.
 
 ---
 
-## 13. Write a custom reporter
+## 15. Write a custom reporter
 
 Subclass `RSpecTracer::Reporters::Base`:
 

--- a/README.md
+++ b/README.md
@@ -5,25 +5,92 @@
 [![codecov](https://codecov.io/gh/avmnu-sng/rspec-tracer/branch/main/graph/badge.svg)](https://codecov.io/gh/avmnu-sng/rspec-tracer)
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://avmnu-sng.github.io/rspec-tracer/)
 
-**RSpec Tracer** is a specs dependency analyzer, flaky-test detector,
-test accelerator, and coverage reporter for RSpec. It records the
-inputs every example consumes — Ruby files (via `Coverage`), file
-I/O (via prepended `File` / `IO` / `YAML` / `JSON` hooks), Rails
-template + AR notifications, and user-declared globs — then re-runs
-only the examples whose inputs changed since the last run.
+**Test-dependency intelligence for RSpec: detect flaky tests, map code
+coupling, and -- when you are ready -- re-run only what changed.**
 
-It never skips:
-- **Failed**, **flaky**, or **pending** examples.
-- Examples whose dependent inputs changed (the whole point).
+rspec-tracer records the inputs it can observe for each RSpec
+example -- Ruby files, file I/O, Rails templates and queries,
+declared globs and ENV branches -- and turns that record into a
+flaky-test detector, a per-example dependency map, and optional CI
+acceleration. The flaky report and the dependency map never skip a
+test: value before trust.
 
-📚 **Full documentation site**: [avmnu-sng.github.io/rspec-tracer](https://avmnu-sng.github.io/rspec-tracer/) — YARD API reference, sample HTML report, cookbook, and per-version coverage report.
+**Measured, not promised.** In the maintainer's May 2026 field test
+(rspec-tracer 2.0.0.pre.1, Apple M2 Max), Mastodon's `spec/lib` --
+1,234 examples, Rails 8.1.3, Ruby 3.4.8 -- ran in 116.4 s cold and
+17.0 s warm: **6.85x**, with the tracer's own recording overhead
+included in both runs. "Cold" here is the tracer's own first run,
+not plain RSpec: recording costs roughly 1.6x plain RSpec on this
+repository's Rails benchmark fixture (approximate), and no
+tracer-free Mastodon baseline was measured, so your gain over a
+suite without the tracer will be smaller than cold minus warm.
+Suite shape matters: across the same field tests, warm-run skip
+rates ranged from 31% (a suite carrying 177 pre-existing failures --
+failed examples are never skipped) to 100%. Measure your own suite
+before you rely on these numbers.
 
-For a complete account of the input taxonomy and how the engine fits
-together, read [`ARCHITECTURE.md`](ARCHITECTURE.md).
+**Conservative by design, honest about its limits.** The tracer
+never skips failed, flaky, or pending examples, nor any example
+whose recorded inputs changed; when a recorded input is ambiguous,
+it re-runs. Real blind spots exist -- runtime metaprogramming and
+monkey-patches are invisible to it; the `tracks:` DSL is the escape
+hatch -- and the [soundness model](ARCHITECTURE.md#soundness-model)
+catalogues the known blind spots. Shadow mode (run everything,
+report what would have been skipped) lands in v2.0.0.rc.2, so you
+can verify the tracer on your own data before trusting it with a
+single skip.
+
+**Your data never leaves your infrastructure.** Everything runs inside
+your test process and your CI cache -- no SaaS backend, no telemetry,
+no per-seat pricing.
+
+## Quick start
+
+Requires Ruby 3.1+ and rspec-core 3.12+ (Rails 7.0+ when using Rails;
+Rails 8.0 needs Ruby 3.2+; JRuby 9.4 supported). Every CI-gated Ruby
+is supported until at least six months past its upstream EOL -- see
+[Maintenance](#maintenance).
+
+```ruby
+# Gemfile -- 2.0 is in pre-release; pin explicitly until 2.0.0 final
+gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
+```
+
+Add the tracer's working directories to your `.gitignore` before the
+first run:
+
+```
+rspec_tracer.lock
+rspec_tracer_cache/
+rspec_tracer_coverage/
+rspec_tracer_report/
+```
+
+```ruby
+# Top of spec_helper.rb / rails_helper.rb, before any application
+# code. With SimpleCov, start SimpleCov first -- load order is part
+# of the contract.
+require 'rspec_tracer'
+RSpecTracer.start
+```
+
+Run the suite twice. The second run skips the examples whose recorded
+inputs are unchanged and prints a per-reason breakdown of what
+re-ran; open `rspec_tracer_report/index.html` to audit every
+per-example decision. Not ready to let it skip anything? Set
+`RSPEC_TRACER_RUN_ALL_EXAMPLES=true` (or `run_all_examples true`
+inside the `RSpecTracer.configure` block in `.rspec-tracer`) --
+every example still runs while the flaky report and the dependency
+maps accumulate data.
+
+Setting up CI? [docs/CI_RECIPES.md](docs/CI_RECIPES.md) has
+copy-paste cache recipes for CircleCI, GitLab CI, Buildkite, and
+Heroku CI, plus a link to the canonical GitHub Actions workflow.
 
 ## Table of contents
 
 - [Quick start](#quick-start)
+- [What it saves](#what-it-saves)
 - [How it works](#how-it-works)
 - [Per-example `tracks:` DSL](#per-example-tracks-dsl)
 - [Rails quick start](#rails-quick-start)
@@ -34,126 +101,71 @@ together, read [`ARCHITECTURE.md`](ARCHITECTURE.md).
 - [SimpleCov interop](#simplecov-interop)
 - [FAQ + comparison](#faq--comparison)
 - [Reports](#reports)
+- [Maintenance](#maintenance)
 - [Documentation + coverage](#documentation--coverage)
 - [Help and community](#help-and-community)
-- [Section anchor map (1.x → 2.0)](#section-anchor-map-1x--20)
+- [Section anchor map (1.x -> 2.0)](#section-anchor-map-1x--20)
 
-## Quick start
+## What it saves
 
-Requires Ruby 3.1+ and rspec-core 3.12+. Rails 7.0+ when using Rails;
-Rails 8.0 needs Ruby 3.2+. JRuby 9.4 is supported.
+All timings are wall-clock and measured, not projected: maintainer
+field tests, May 2026, Apple M2 Max, rspec-tracer 2.0.0.pre.1. In
+every row, "cold" is the tracer's own first, recording run -- it
+costs more than plain RSpec (roughly 1.6x on this repository's Rails
+benchmark fixture; approximate), and no tracer-free baseline was
+measured for these projects -- so your savings versus a suite
+without the tracer will be smaller than cold minus warm.
 
-1. Add the gem:
+| Project measured | Examples | Cold run | Warm run | Warm skip rate | Saved per warm run |
+|---|---|---|---|---|---|
+| Mastodon `spec/lib` (Rails 8.1.3, Ruby 3.4.8) | 1,234 | 116.4 s | 17.0 s | 98% (1,212 skipped) | ~99 s |
+| thoughtbot/clearance (Rails 8 engine + dummy app) | 258 | 11.1 s | 1.6 s | 100% | ~9.5 s |
+| publify (carries 177 pre-existing failures; failed examples are never skipped) | 257 | 6.7 s | 4.8 s | 31% | ~1.9 s |
 
-   ```ruby
-   # 2.0 is in pre-release. Pin to the pre-release version explicitly;
-   # switch to '~> 2.0' once 2.0.0 final ships.
-   gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
-   ```
+The Mastodon warm run is the zero-change best case; in the same
+field test, editing one file re-ran 68 of 1,234 examples in 19.0 s.
+Laptop rows understate CI savings: CI runners are slower than the
+development machine, so the seconds saved per run are typically
+larger there -- the skip ratios are what transfer.
 
-   `bundle install` will resolve the pre-release version. You can
-   also install ad-hoc with `gem install rspec-tracer --pre`.
+**Worked examples** (every input is an assumption you should replace
+with your own). For any suite:
 
-2. Add the canonical directories to your `.gitignore`:
+`(cold seconds - warm seconds) x runs/day / 60 x $/CI-minute x 30 = $/month per full-suite job`
 
-   ```
-   rspec_tracer.lock
-   rspec_tracer_cache/
-   rspec_tracer_coverage/
-   rspec_tracer_report/
-   ```
+At $0.006/CI-minute (illustrative -- GitHub-hosted Linux list price
+at the time of writing; check your provider's current rate) and 50
+CI runs/day on one job:
 
-3. Load and start at the very top of `spec_helper.rb` /
-   `rails_helper.rb`, **before any application code:**
+- Best case (a Mastodon-sized suite saving ~99 s per warm run):
+  ~83 CI-minutes/day, about $15/month per job.
+- Low-skip case (a publify-shaped suite saving ~1.9 s per warm run
+  at 31% skip): about $0.29/month per job.
 
-   ```ruby
-   require 'rspec_tracer'
-   RSpecTracer.start
-   ```
+Multiply by the number of jobs that each run the full suite (for
+example, a Ruby-version matrix); jobs that split one suite across
+workers share the saving rather than multiply it.
 
-   With SimpleCov, start SimpleCov first (load order is part of the
-   contract):
-
-   ```ruby
-   require 'simplecov'
-   SimpleCov.start
-   require 'rspec_tracer'
-   RSpecTracer.start
-   ```
-
-4. Run your suite. After the run, open
-   `rspec_tracer_report/index.html` for the HTML report, and
-   `rspec_tracer_report/report.json` for machine-readable output.
-
-   The terminal prints a one-line summary with cache size and the
-   reasons examples re-ran:
-
-   ```
-   rspec-tracer: 1,820 examples · 42 re-run · 1,778 skipped (97% cached)
-   by reason: 38 Files changed · 4 Failed previously
-   cache: rspec_tracer_cache (14.4 MiB; +6.7 KiB vs prev run)
-   ```
+Conservative assumptions: 50 runs/day and the dollar rate are stated
+assumptions, not measurements; your skip rate may be far lower (see
+the 31% row -- suites with many failing examples skip less, by
+design); remote-cache download time on fresh CI workers is not
+subtracted (measured end-to-end remote-cache gain on clearance was
+still ~4.6x).
 
 ## How it works
 
-Every test is a pure function of its inputs; the tracker's job is to
-identify every input and hash it. Inputs come from six buckets:
-
-1. **Ruby-executed source** — observed via Ruby's `Coverage` module.
-2. **File I/O** (`File.read`, `YAML.load_file`, etc.) — observed via
-   `Module#prepend` hooks.
-3. **Framework events** — Rails template renders + (opt-in) AR
-   schema-touching queries via `ActiveSupport::Notifications`.
-4. **Declared globs** — what you tell the tracker to track via
-   `track_files` / `tracks:` / `track_rails_defaults`.
-5. **Whole-suite invalidators** — `Gemfile.lock`, `.ruby-version`,
-   `.rspec-tracer`, the rspec-tracer gem version itself.
-6. **Truly unobservable inputs** — env-var branches, refinements
-   in unexecuted files. Use `track_env` / `tracks: { env: ... }`
-   to declare them; the tracker can't auto-detect them.
-
-A digest of every observed input is stored per-example. The next run
-loads the cached digest set, recomputes per-input digests, and skips
-examples whose inputs are unchanged.
-
-Read [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full layer
-structure (Tracker / Storage / RemoteCache / Reporters), data flows,
-and extension protocols.
-
-### Per-example precision under Rails `config.eager_load`
-
-A precision tradeoff worth knowing before you run a suite that uses
-Rails:
-
-- **`config.eager_load = false`** in test env — per-example precision
-  works as designed. Files autoloaded during an example land in
-  per-example deps; editing one re-runs only the examples that
-  touched it.
-- **`config.eager_load = true`** (Rails default for CI tests to
-  mirror prod) — all `app/` files load at boot and land in the
-  whole-suite invalidator set. Editing any `app/` file re-runs
-  every example. **Safe** (never misses a dep) but **coarser** than
-  per-example attribution.
-
-If your CI suite runs with `eager_load = true` and your `app/`-edit
-cycle is bottlenecked by whole-suite re-runs, set `config.eager_load
-= false` in test env to recover per-example precision. A future 2.1
-enhancement (working name: `track_class_attribution`) will install
-class-dispatch tracking to trim the invalidator scope under
-eager-loaded test environments — see
-[`CHANGELOG.md`](CHANGELOG.md) "Deferred to 2.1" for the planned
-contract.
-
-**Rails engines:** a gem-loaded engine's own `lib/` files are
-`require`d at gem-load time via the Gemfile.lock cascade and land
-in the boot set **regardless of `eager_load`**. Editing them
-re-runs every example — same SAFE-but-coarser shape as the
-`eager_load = true` case above. The rationale (closing the
-constants-lookup blind spot) lives in
-[`lib/rspec_tracer/tracker/loaded_files_tracker.rb`](lib/rspec_tracer/tracker/loaded_files_tracker.rb).
-Teams that want tighter per-example precision and accept the blind
-spot can set `transitive_load_tracking false` — see
-[`COOKBOOK.md`](COOKBOOK.md) recipe 2 for the trade-off.
+Each example's observed inputs -- executed Ruby source (via
+`Coverage`), file I/O (via `Module#prepend` hooks), Rails framework
+events, declared globs and env vars, and whole-suite invalidators
+like `Gemfile.lock` -- are digested and stored per example. The next
+run recomputes the digests and skips examples whose recorded inputs
+are unchanged. The full input taxonomy lives in
+[ARCHITECTURE.md](ARCHITECTURE.md#input-taxonomy); what each input
+kind does and does not guarantee is the
+[soundness model](ARCHITECTURE.md#soundness-model); the Rails
+`config.eager_load` precision trade-off is covered by the Rails
+recipe in [COOKBOOK.md](COOKBOOK.md).
 
 ## Per-example `tracks:` DSL
 
@@ -275,6 +287,13 @@ rm -f rspec_tracer.lock && bundle exec parallel_rspec
 
 ## Configuring CI
 
+Copy-paste cache recipes for CircleCI, GitLab CI, Buildkite, and
+Heroku CI live in [docs/CI_RECIPES.md](docs/CI_RECIPES.md); the
+canonical GitHub Actions workflow is
+[`.github/workflows/example-tracer-cache.yml`](.github/workflows/example-tracer-cache.yml).
+The rest of this section covers the remote-cache rake flow and the
+cache-key pattern all the recipes share.
+
 The 1.x flow is preserved bit-for-bit. In your project's `Rakefile`:
 
 ```ruby
@@ -324,10 +343,11 @@ The cache step:
       ${{ runner.os }}-
 ```
 
-The 4-component cache key (`runner.os` + Ruby version + the
-rspec-tracer gem's own version + your project's Gemfile lock)
-invalidates when something would make the previous run's decisions
-incorrect: native gem binaries differ across runner OSes, Ruby ABI
+The 4-component cache key (`runner.os` + Ruby version + your
+project's Gemfile lock -- which also pins the rspec-tracer gem's
+version -- + a fixed name suffix) invalidates when something would
+make the previous run's decisions incorrect: native gem binaries
+differ across runner OSes, Ruby ABI
 changes invalidate native extensions, a tracer upgrade can change the
 cache schema, and gem-set drift is the most common cache-staleness
 trigger.
@@ -437,6 +457,14 @@ Compose them: shard with Knapsack, then skip with rspec-tracer.
 A composition smoke spec (`spec/regressions/knapsack_coexistence_spec.rb`)
 proves they coexist.
 
+**Datadog Test Optimization / Buildkite Test Analytics / CircleCI
+Test Insights?** Those are hosted services: your test metadata ships
+to a vendor backend, with the pricing and procurement that implies.
+rspec-tracer runs entirely inside your test process -- the cache and
+reports are plain files in your repo, S3 bucket, or Redis. No SaaS
+backend, no telemetry, no per-seat pricing; keeping it that way is a
+standing commitment in [ROADMAP.md](ROADMAP.md)'s "Won't do" list.
+
 **`RSpec::Retry` / `RSpec::Rerun`?** Retries flaky failures.
 rspec-tracer detects flaky examples (same inputs, different outcomes)
 and refuses to skip them on the next run. Compose: retry to make a
@@ -455,23 +483,47 @@ taxonomy" for the rule.
 ## Reports
 
 After the run, `rspec_tracer_report/index.html` opens five HTML
-reports:
+reports. The first two deliver value even if you never let the
+tracer skip a single example:
 
-- **All Examples** — basic test info (id, status, duration, the inputs
-  the example consumed).
-- **Duplicate Examples** — pairs RSpec couldn't uniquely identify
+- **Flaky Examples** -- examples that failed on one run and passed on
+  a later one, the canonical intermittence signal: a flake list your
+  suite builds passively from the runs you were already doing. Once
+  flagged, the tracer refuses to skip them on subsequent runs.
+- **Files Dependency** -- "if I change this file, which tests run?"
+  The file-to-test map that makes refactors, reviews, and deletions
+  safer -- the report unique to rspec-tracer.
+- **Examples Dependency** -- the per-example inverse: "what does this
+  test depend on?"
+- **All Examples** -- basic test info (id, status, duration, the
+  inputs the example consumed).
+- **Duplicate Examples** -- pairs RSpec couldn't uniquely identify
   (file:line collisions; only appears when duplicates are present).
-- **Flaky Examples** — examples that passed after previously failing
-  without any dependency change. The tracker refuses to skip these
-  on subsequent runs.
-- **Examples Dependency** — per-example file dependency lists; the
-  "what does this test depend on?" view.
-- **Files Dependency** — the inverse: "what tests run if I change
-  this file?" The unique-to-rspec-tracer report that makes refactors
-  safer.
 
 Plus a machine-readable `rspec_tracer_report/report.json` for CI
-dashboards and the terminal one-liner shown in [Quick start](#quick-start).
+dashboards, and a terminal summary with a per-reason breakdown after
+every run (see [Quick start](#quick-start)).
+
+## Maintenance
+
+Every CI-gated Ruby is supported until **at least** six months past
+its upstream end-of-life date. That is a floor, not a drop date:
+versions can stay supported longer, and Ruby 3.1 currently is.
+Upstream EOL dates are published on the official
+[Ruby maintenance schedule](https://www.ruby-lang.org/en/downloads/branches/);
+that page is authoritative for the dates below.
+
+| Version | CI-gated | Status |
+|---------|----------|--------|
+| Ruby 3.1 | Yes | Supported. Upstream EOL was 2025-03-26, so the committed six-month window has lapsed -- and 3.1 is still supported today because the policy is a minimum, not a schedule. It remains the floor for the 2.0 release line. |
+| Ruby 3.2 | Yes | Supported. Upstream EOL was 2026-04-01; supported until at least 2026-10-01, and potentially longer -- the policy is a minimum. |
+| Ruby 3.3 | Yes | Supported. Upstream EOL is expected 2027-03-31; supported until at least six months past the published EOL date. |
+| Ruby 3.4 | Yes | Supported, until at least six months past its upstream EOL date (not yet announced). |
+| Ruby 4.0 | Yes | Supported, until at least six months past its upstream EOL date (not yet announced). |
+| JRuby 9.4 | Yes | Supported. JRuby support tracks the JRuby project's own maintenance schedule, not the Ruby-Core EOL dates above. |
+
+TruffleRuby and Ruby head are best-effort: no CI gate, but issue
+reports are welcome and get investigated.
 
 ## Documentation + coverage
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,14 +70,15 @@ Items:
   would have failed. Designed for teams to run silently in CI for 2-3
   weeks to accumulate empirical "0 missed failures across N runs"
   evidence before flipping the switch. The canonical adoption ramp for
-  correctness-sensitive infrastructure.
+  correctness-sensitive infrastructure. Lands in `v2.0.0.rc.2`.
 - **Soundness tier documentation.** Explicit classification of what
   rspec-tracer guarantees: **sound** (file-content digests, explicit
   `tracks:`, env snapshot), **conservative** (boot-set whole-suite
   invalidator, Rails `lib/` engine-load fallback), **heuristic** (Rails
-  subscriber attribution under common configs), **unsafe** (runtime
-  metaprogramming, monkey-patches, hidden reflection — call-out
-  prominently). Ships as an ARCHITECTURE.md section.
+  subscriber attribution under common configs), **blind spot** (runtime
+  metaprogramming, monkey-patches, hidden reflection -- called out
+  prominently). Shipped -- see
+  [ARCHITECTURE.md](ARCHITECTURE.md#soundness-model).
 - **`safety_mode :paranoid | :balanced | :aggressive` preset DSL.**
   Named presets that toggle existing knobs (`transitive_load_tracking`,
   `whole_suite_invalidators`, `always_re_run_failed_examples`,
@@ -154,8 +155,8 @@ The same release ramp also reshapes how rspec-tracer is presented:
   runs entirely inside customer infrastructure (no telemetry, no
   per-seat cost, no vendor egress). Material for regulated industries
   where commercial test-optimization SaaS isn't viable.
-- **Stated Ruby support / EOL policy** in COMPATIBILITY_MATRIX, plus
-  surfacing the existing Ruby-HEAD CI in the README. Closes
+- **Stated Ruby support / EOL policy** in the README's
+  [Maintenance section](README.md#maintenance). Closes
   "single-maintainer infrastructure on volatile tooling" as an
   adoption objection.
 
@@ -324,10 +325,10 @@ platform teams legitimately raise on infrastructure adoption:
 - **Stated Ruby support window.** rspec-tracer commits to supporting
   Ruby versions until upstream Ruby Core reaches EOL plus 6 months.
   Currently CI-gated per the [README's Quick start](README.md#quick-start):
-  Ruby 3.1, 3.2, 3.3, 3.4, 4.0 + JRuby 9.4. A formal version-by-version
-  EOL alignment doc lands as part of the 2.0 final work.
-- **Ruby HEAD + prereleases on CI** (best-effort tier). rspec-tracer
-  runs against Ruby HEAD on every PR; breakage on a Ruby prerelease
+  Ruby 3.1, 3.2, 3.3, 3.4, 4.0 + JRuby 9.4. The version-by-version
+  EOL table lives in the [README Maintenance section](README.md#maintenance).
+- **Ruby HEAD + TruffleRuby on a best-effort tier.** Neither is
+  CI-gated on every PR, but breakage reported on a Ruby prerelease
   is treated as a high-priority bug, not a future-self problem. Goal:
   rspec-tracer should never be the reason a team can't upgrade Ruby.
 - **Open governance commitment.** Sponsorship channels (GitHub

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -117,6 +117,11 @@ using the new names; the warns are advisory.
 
 ## Behavior changes worth knowing
 
+For the full classification of which invalidation decisions are
+guaranteed, conservative, or heuristic -- and what the tracer cannot
+observe at all -- see the
+[soundness model](ARCHITECTURE.md#soundness-model).
+
 ### Duplicate example identities
 
 rspec-tracer identifies each example by a hash of its `describe`

--- a/docs/CI_RECIPES.md
+++ b/docs/CI_RECIPES.md
@@ -18,8 +18,7 @@ dependency-tracking contract.
 ## Cache key shape
 
 The 4-component canonical key (per
-[ARCHITECTURE.md](../ARCHITECTURE.md) + the `feedback_actions_cache_traps`
-memory) is:
+[ARCHITECTURE.md](../ARCHITECTURE.md)) is:
 
 ```
 <os>-<ruby-version>-<tracer-version>-<gemfile-hash>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -71,7 +71,7 @@
 <body>
   <header>
     <h1>rspec-tracer</h1>
-    <p class="lede">Specs dependency analyzer, flaky-test detector, test accelerator, and coverage reporter for RSpec.</p>
+    <p class="lede">Test-dependency intelligence for RSpec: detect flaky tests, map code coupling, and -- when you are ready -- re-run only what changed.</p>
     <p class="badges">
       <!-- Single-line per anchor: any internal whitespace would become
            a text-node child of the <a> and render as an underline in
@@ -108,7 +108,7 @@
     </article>
     <article class="card">
       <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/COOKBOOK.md">COOKBOOK</a></h3>
-      <p>13 recipes for common setups: Rails apps, parallel_tests, JRuby, custom backends.</p>
+      <p>Recipes for common setups: flaky detection, dependency mapping, Rails apps, parallel_tests, JRuby, custom backends.</p>
     </article>
     <article class="card">
       <h3><a href="https://github.com/avmnu-sng/rspec-tracer/blob/main/ARCHITECTURE.md">ARCHITECTURE</a></h3>

--- a/rspec-tracer.gemspec
+++ b/rspec-tracer.gemspec
@@ -12,15 +12,15 @@ Gem::Specification.new do |spec|
 
   spec.homepage = 'https://github.com/avmnu-sng/rspec-tracer'
   spec.summary = <<-SUMMARY.strip.gsub(/\s+/, ' ')
-    RSpec Tracer is a specs dependency analyzer, flaky tests detector, tests
-    accelerator, and coverage reporter tool.
+    Test-dependency intelligence for RSpec: detect flaky tests, map code
+    coupling, and -- when you are ready -- re-run only what changed.
   SUMMARY
   spec.description = <<-DESCRIPTION.strip.gsub(/\s+/, ' ')
-    RSpec Tracer is a specs dependency analyzer, flaky tests detector, tests
-    accelerator, and coverage reporter tool for RSpec. It maintains a list of
-    files for each test, enabling itself to skip tests in the subsequent runs
-    if none of the dependent files are changed. It uses Ruby's built-in coverage
-    library to keep track of the coverage for each test.
+    RSpec Tracer records the inputs each RSpec example consumes -- using
+    Ruby's built-in coverage library plus explicit declarations -- and turns
+    that record into a flaky-test detector, a per-example dependency map, and
+    optional CI acceleration that skips the examples whose recorded inputs
+    are unchanged. It never skips failed, flaky, or pending examples.
   DESCRIPTION
   spec.license = 'MIT'
 


### PR DESCRIPTION
## Summary

The README becomes an evaluator-first landing page: the tagline and top fold lead with flaky detection + dependency mapping, one fully-attributed measured benchmark (Mastodon spec/lib, 1,234 examples, 6.85x cold-to-warm) bounded by the honest 31%-100% skip range, an explicit safety paragraph with the run-everything escape hatch, and a data-never-leaves-your-infrastructure callout.

Supporting surfaces align with the new positioning: cost framing computed from measured runs with a live-verified illustrative rate, a soundness model in ARCHITECTURE.md classifying every tracked input tier, a Maintenance section with the EOL-plus-6-months policy table, two new COOKBOOK recipes leading the recipe order, and gemspec + docs-site positioning aligned.

## Closes

Closes #223, closes #224, closes #225, closes #226, closes #227, closes #228, closes #229.

## Verification

Three adversarial verification rounds covering:

- Cross-file coherence: ~45 anchors resolve.
- Evidence provenance: every figure traced to a measured source; GitHub per-minute pricing and Ruby EOL dates live-verified 2026-07-12.
- Internal-nomenclature + ASCII sweep, including a built-gem unpack audit: clean.
- CI parity: rubocop, yamllint, actionlint, eslint/prettier, YARD, unit specs, bundle check -- all passing.

## Renegotiated criteria

- #224: prose promotion instead of screenshot reordering -- no screenshots exist in the README today.
- #227: field-test cost table (Mastodon, clearance, publify) replaces the unmeasurable soak-corpus citation.
- #228: doctor-output cross-link deferred to the CLI features bundle; README + COOKBOOK surface docs/CI_RECIPES.md instead.
- #229: Ruby-HEAD badge deferred (no CI job yet); roadmap corrected to best-effort.

## Coordination note

The COOKBOOK renumbering in this PR defines the final recipe order the upcoming CLI features bundle must slot into.
