### PR TITLE
cleanup: make comments self-contained, drop private note references

### DIFF
--- a/.github/workflows/combinations.yml
+++ b/.github/workflows/combinations.yml
@@ -37,10 +37,6 @@ name: combinations
 #
 # Plus 3 single-shot mutation jobs from (2) (no matrix axes; one cell
 # each on Ruby 3.3.10).
-#
-# See docs/revamp/sessions/M3.8-part-c-runtime-dep-matrix.md +
-# docs/revamp/sessions/M8.5-mutation-demote.md (local) for the full
-# design rationale.
 
 on:
   schedule:

--- a/.github/workflows/flake-gate.yml
+++ b/.github/workflows/flake-gate.yml
@@ -16,9 +16,9 @@ name: flake-gate
 # Kept available for on-demand re-targeting any cell when a future flake
 # investigation needs the 100x-iter shape.
 #
-# This is a POST-FIX gate, not the primary investigation tool. Per
-# memory feedback_no_hit_and_trial_ci, reproduce + investigate + fix +
-# verify locally first; this workflow is for ongoing safety-net
+# This is a POST-FIX gate, not the primary investigation tool:
+# reproduce + investigate + fix + verify locally against the gate
+# criterion first; this workflow is for ongoing safety-net
 # verification on the full GHA shared-runner environment, which has
 # different scheduling characteristics than a local M-series Mac.
 

--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -453,8 +453,10 @@ jobs:
     # subjects. Combines original shards 2 + 3 (write-side and
     # init/util) since first CI showed 3-shard split was over-sharded.
     # Includes #initialize and private connection/schema/utility
-    # helpers — these are the structural-ceiling subjects per
-    # feedback_mutant_describe_label_ceiling, which is why the
+    # helpers -- mutant credits kills to the describe block whose
+    # label names the subject, and these helpers have no dedicated
+    # describes (they are exercised only through public callers), so
+    # their kill rate has a structural ceiling. That is why the
     # combined-shard gate sits at 65% (vs read-side 73%). CI wall
     # clock target ~3 min.
     runs-on: ubuntu-latest

--- a/.github/workflows/soak-bump.yml
+++ b/.github/workflows/soak-bump.yml
@@ -15,10 +15,11 @@ name: soak-bump
 # creation, no auto-merge. The report goes to $GITHUB_STEP_SUMMARY
 # (rendered on the workflow run page) and stdout (logged).
 #
-# Per feedback_workflow_dispatch_default_branch_registration: this
-# workflow's first scheduled firing won't happen until the file
-# lands on main. Manual workflow_dispatch via `gh workflow run
-# soak-bump.yml --ref main` works post-merge.
+# GitHub only registers schedule/workflow_dispatch triggers once the
+# workflow file exists on the default branch, so this workflow's
+# first scheduled firing won't happen until the file lands on main.
+# Manual workflow_dispatch via `gh workflow run soak-bump.yml
+# --ref main` works post-merge.
 
 on:
   schedule:

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -8,9 +8,9 @@ name: soak
 # on GHA EPYC (see strategy.matrix comment below). Each cell runs in
 # parallel under fail-fast: false so one cell's failure doesn't cancel
 # the others. Per-cell timeout-minutes: 240 (4 h cap = 50% margin
-# under GHA's 6 h hard limit so the cache post-hook fires reliably
-# even on cold-cache first run, per
-# feedback_actions_cache_post_hook_timeout).
+# under GHA's 6 h hard limit so the actions/cache post-hook save
+# still fires even on a slow cold-cache first run -- a job cancelled
+# at the hard limit skips post-hooks and loses the cache save).
 #
 # 03:00 UTC schedule keeps the run off-peak relative to per-PR CI
 # wall clock + leaves the morning slot open for failure triage.
@@ -23,9 +23,9 @@ name: soak
 # the sha into the matrix cell's checkout ref + cache key. License
 # stability is checked by soak-bump.yml, not here.
 #
-# MRI-only per feedback_jruby_ci_subprocess_floor: JRuby x Rails
-# multi-iter cells would compound to multiple hours each, untenable
-# in nightly cadence.
+# MRI-only: JRuby x Rails cold-boots each subprocess in ~2:30 on CI
+# runners, so multi-iter cells would compound to multiple hours each,
+# untenable in nightly cadence.
 
 on:
   schedule:

--- a/benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb
+++ b/benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb
@@ -11,10 +11,11 @@
 # every shape that actually fires in the wild — not just top-level
 # anonymous it.
 #
-# Six patterns covered + one unicode-description regression case
-# (per M8.2-B kickoff decision (g-yes); construct unicode at runtime
-# so the source stays ASCII-only per feedback_mutant_non_ascii_source
-# discipline, even though spec files aren't in mutant's parser scope).
+# Six patterns covered + one unicode-description regression case.
+# The unicode description is constructed at runtime so the source
+# stays ASCII-only (mutant's parser rejects non-US-ASCII source;
+# spec files aren't in its parser scope today, but keeping the whole
+# tree ASCII avoids surprises if that scope ever widens).
 
 RSpec::Matchers.define :be_a_finite_numeric do
   match { |actual| actual.is_a?(Numeric) && actual.finite? }

--- a/benchmark/harness.rb
+++ b/benchmark/harness.rb
@@ -41,9 +41,11 @@ module BenchmarkHarness
   # which landed coverage_adapter (1.21x) + loaded_files_tracker
   # (1.22x) over the prior 1.20 threshold purely from GHA shared-
   # runner small-sample variance (5 iters per scenario; p50 is
-  # high-variance on microbenches at that sample size). Per
-  # feedback_gha_ratchet_shifts_non_uniform_vs_m2_max + the empirical
-  # WARN/FAIL distribution from the regen baseline. Tightening back
+  # high-variance on microbenches at that sample size). GHA runners
+  # shift non-uniformly per scenario vs the local baseline machine
+  # (Rails-heavy scenarios 3-3.5x slower, pure-Ruby microbenches flat
+  # or faster), so the 1.30 value came from the empirical WARN/FAIL
+  # distribution of the regen baseline. Tightening back
   # toward 1.20 is a 2.x calibration once multiple GHA baselines
   # accumulate enough variance signal to set a defensible per-
   # scenario threshold; tracked as a 2.1 followup.
@@ -201,7 +203,8 @@ module BenchmarkHarness
       # single signal for M8.0's perf payoff. M4.3 handoff target was
       # `<= 1.5x` of stock-rspec; structural Rails-boot floor caps the
       # achievable wall-clock ratio for this per-iter-subprocess shape
-      # at ~1.6x (per feedback_macro_vs_micro_perf_signal). The
+      # at ~1.6x (per-example tracer optimizations barely move a
+      # scenario dominated by boot cost, so Rails boot is the floor). The
       # `cold_rails_v2_warm_iter` companion below measures the
       # amortized-boot variant where Rails loads ONCE in a long-running
       # parent process; that scenario captures the steady-state

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -1023,9 +1023,8 @@ module RSpecTracer
     # module default. 0 disables the respective check.
     #
     # Duplicated body rather than factored to a private helper
-    # because configure's alias loop would wrap the helper as a
-    # public `_name` DSL surface (see
-    # feedback_configure_dsl_private_leak).
+    # because configure's alias loop wraps every instance method --
+    # private helpers included -- as a public `_name` DSL surface.
     # rubocop:disable Metrics/PerceivedComplexity
     def cache_size_warn_per_file_mb(size_mb = nil)
       return @cache_size_warn_per_file_mb if defined?(@cache_size_warn_per_file_mb) && size_mb.nil?

--- a/lib/rspec_tracer/line_stub.rb
+++ b/lib/rspec_tracer/line_stub.rb
@@ -13,8 +13,9 @@ module RSpecTracer
   # on MRI; cross-engine coverage rollup would require fork-per-engine
   # CI work that isn't justified for stub-line generation).
   #
-  # `def self.x` per feedback_mutation_friendly_modules so future
-  # mutation gating maps to the singleton form.
+  # Methods use `def self.x` (not module_function) so future mutation
+  # gating maps to the singleton form -- module_function attaches
+  # methods to an anonymous singleton that mutant cannot observe.
   module LineStub
     # Internal helper for the tracer pipeline.
     # @api private

--- a/lib/rspec_tracer/rspec/metadata.rb
+++ b/lib/rspec_tracer/rspec/metadata.rb
@@ -46,7 +46,7 @@ module RSpecTracer
       # Keep methods module-level via `def self.x` (not module_function)
       # so mutant can observe them - module_function attaches the
       # methods to an anonymous singleton that Method#source_location
-      # can't trace (memory: feedback_mutation_friendly_modules).
+      # can't trace.
       def self.tracks_for(example)
         files = Set.new
         envs = Set.new

--- a/lib/rspec_tracer/source_file.rb
+++ b/lib/rspec_tracer/source_file.rb
@@ -5,9 +5,9 @@ module RSpecTracer
   # Post-coverage-stack retirement, the only caller is example.rb
   # (the legacy CoverageReporter that previously used these is gone).
   #
-  # All methods declared `def self.x` per
-  # feedback_mutation_friendly_modules so mutant observes mutations
-  # through the singleton call path.
+  # All methods declared `def self.x` (not module_function) so mutant
+  # observes mutations through the singleton call path;
+  # module_function's anonymous singleton breaks that observability.
   module SourceFile
     # Internal constant.
     # @api private

--- a/lib/rspec_tracer/tracker/env_matcher.rb
+++ b/lib/rspec_tracer/tracker/env_matcher.rb
@@ -7,11 +7,11 @@ module RSpecTracer
     # Wildcard env matching helper.
     #
     # Lives outside Configuration so configure's alias loop does not
-    # leak its private helpers as public _name DSL surface
-    # (memory: feedback_configure_dsl_private_leak). Pure utility
-    # module; def self.x style for mutant observability
-    # (memory: feedback_mutation_friendly_modules). ASCII-only source
-    # (memory: feedback_mutant_non_ascii_source).
+    # leak its private helpers as public _name DSL surface (the loop
+    # wraps every instance method, private ones included). Pure
+    # utility module; def self.x style keeps methods observable to
+    # mutant (module_function's anonymous singleton is not).
+    # ASCII-only source, since mutant's parser rejects non-US-ASCII.
     #
     # Patterns accepted:
     #   - Literal env name              "AUTH_TOKEN"

--- a/scripts/check_soak_pins.rb
+++ b/scripts/check_soak_pins.rb
@@ -7,8 +7,8 @@
 # stdout (markdown table) + $GITHUB_STEP_SUMMARY when set.
 #
 # Report-only - never opens PRs / issues / modifies pin files.
-# Maintainer reviews the weekly report and opens bump PRs by hand
-# per feedback_never_merge_prs (humans gate every bump).
+# Maintainer reviews the weekly report and opens bump PRs by hand;
+# humans gate every bump.
 #
 # Run via: ruby scripts/check_soak_pins.rb
 #

--- a/spec/README.md
+++ b/spec/README.md
@@ -73,15 +73,14 @@ branch:
 setup raise, every test in the suite is skipped and mutant reports
 100% alive. Fix: set `RSPEC_TRACER_DISABLE=1` in the Taskfile env
 block (every per-module subtask already does); confirm the spec_helper
-honors the flag. See `feedback_mutant_rspec_gotchas` (memory).
+honors the flag.
 
 **2. Subject undefined / `Subjects: 0` in the mutant summary.** Causes:
 the source file uses `module_function` (the singleton + private-instance
-duplication makes mutant mutate the unreachable instance method - see
-`feedback_mutation_friendly_modules`); or the subject is defined inside
-a `Struct.new do ... end` block (mutant rejects - reopen the class via
-`class X < Struct.new(...)`); or non-ASCII bytes in lib/ source crash
-mutant's US-ASCII parser (see `feedback_mutant_non_ascii_source`).
+duplication makes mutant mutate the unreachable instance method); or
+the subject is defined inside a `Struct.new do ... end` block (mutant
+rejects - reopen the class via `class X < Struct.new(...)`); or
+non-ASCII bytes in lib/ source crash mutant's US-ASCII parser.
 Action: refactor lib to `def self.x`, reopen Struct subclasses, ASCII-
 clean comments + string literals.
 
@@ -91,9 +90,8 @@ trailing `rescue StandardError` swallows the same `Errno::ENOENT` the
 guard was preventing. The mutation IS observably equivalent. Action:
 DROP the guard via lib refactor (with the maintainer-articulated
 "guarantee on behavior + perf intact" bar). Code clarity drives the
-refactor; coverage is a side effect. Precedents: M3.3
-`WholeSuiteInvalidators#file_digest`, M8.3-B `RemoteCache::Validator`.
-See `feedback_mutant_equivalent_guards`.
+refactor; coverage is a side effect. Precedents:
+`WholeSuiteInvalidators#file_digest`, `RemoteCache::Validator`.
 
 **4. Mutant first-token describe-mapping ceiling.** Mutant maps tests to
 subjects via the first space-separated token of `full_description`.
@@ -110,7 +108,7 @@ include the alive-but-functionally-tested mutations and document the
 ceiling in an inline Taskfile rationale comment. Do NOT restructure
 describes for coverage - that's the test-organization-for-coverage
 anti-pattern. Restructure ONLY when a describe label honestly belongs
-under a different method. See `feedback_mutant_describe_label_ceiling`.
+under a different method.
 
 **5. `Module#prepend` idempotency.** Ruby has no `unprepend` API. Once
 any prior test triggers `Klass.prepend(Hook)`, subsequent installs
@@ -118,28 +116,26 @@ any prior test triggers `Klass.prepend(Hook)`, subsequent installs
 so prepend-line mutations stay alive in shared-process spec suites.
 rspec-mocks spies don't help (singleton-class inheritance routes the
 spy to the wrong target). Subprocess isolation closes the gap but
-blows up wall-clock budget. Action: ACCEPT VIA CARVE-OUT with
-inline rationale comment referencing the memory. Do NOT add
-prepend-spy tests - they verify nothing real. Precedents:
-`Tracker::IOHooks` (M8.3-A), `Rails::I18nTracking::LoadTranslationsHook`
-(M8.3-C). See `feedback_mutant_prepend_idempotency`.
+blows up wall-clock budget. Action: ACCEPT VIA CARVE-OUT with an
+inline rationale comment explaining the idempotency ceiling. Do NOT
+add prepend-spy tests - they verify nothing real. Precedents:
+`Tracker::IOHooks`, `Rails::I18nTracking::LoadTranslationsHook`.
 
 **6. Local-vs-CI variance ≥ 5 pp.** Same source + same mutant version
 + same gem set produces materially different alive counts between local
 M2 Max and CI ubuntu-latest because of test-ordering shifts (no
-Gemfile.lock per M3.8 Part C), parallelism differences (mutant
+committed Gemfile.lock), parallelism differences (mutant
 `Jobs: 12` on M2 Max vs `Jobs: 4` on CI), and state-leaking
 memoizations (e.g. `@msgpack_loaded` ivar hiding `require 'msgpack'`
 mutations once any prior test trips the memo). Action: SIZE GATES from
 CI numbers + ~3-5 pp margin under, NEVER local. Re-cut the gate
 downward in a follow-up commit if any subject drops materially below
-local on the first CI run. Precedents: M8.3-A `154ec27`, M8.3-B
-`10c0d67`. See `feedback_mutant_local_vs_ci_variance`.
+local on the first CI run. Precedents: `154ec27`, `10c0d67`.
 
 **Genuine gap, not a ceiling?** Add a behavior test under the natural
 describe that asserts the real contract being broken by the mutation.
-Never weaken an existing assertion to make CI green
-(`feedback_never_weaken_tests`). Never add mutation-bait tests that
+Never weaken an existing assertion to make CI green -- diagnose the
+real cause instead. Never add mutation-bait tests that
 exist only to kill mutations - the test should document a real
 contract the lib promises. If the contract is fuzzy (e.g. log-message
 wording), `# mutant:disable - <one-line rationale>` with a

--- a/spec/edge_cases/concurrent_write_spec.rb
+++ b/spec/edge_cases/concurrent_write_spec.rb
@@ -16,10 +16,9 @@
 #     M8.2 alongside this spec).
 #
 # Children exit via `Process.exit!(0)` to bypass SimpleCov's
-# per-process at_exit hook (memory:
-# `feedback_simplecov_fork_poisoning`). Without the bang, the child
-# rewrites the parent's coverage snapshot with its narrow slice and
-# drops effective coverage below the gate.
+# per-process at_exit hook, which forked children inherit. Without
+# the bang, the child rewrites the parent's coverage snapshot with
+# its narrow slice and drops effective coverage below the gate.
 #
 # fork() is MRI-only. Skip the entire spec on JRuby - threaded test
 # runners are out of scope for the storage layer's flock-based model

--- a/spec/edge_cases/unicode_path_spec.rb
+++ b/spec/edge_cases/unicode_path_spec.rb
@@ -8,7 +8,7 @@
 # All Unicode test data is constructed AT RUNTIME from integer
 # codepoints (`pack('U*')` / `chr(Encoding::UTF_8)`) so the spec
 # source itself stays ASCII-only. mutant's parser reads lib/ as
-# US-ASCII (memory: `feedback_mutant_non_ascii_source`); spec files
+# US-ASCII and crashes on non-ASCII bytes; spec files
 # are not subjects, but defensively-ASCII-clean spec sources avoid
 # any future tooling encoding-check surprise. The same posture
 # applies to unicode_path_spec, hardlink_spec, etc.

--- a/spec/integration/env_var_storage_override_spec.rb
+++ b/spec/integration/env_var_storage_override_spec.rb
@@ -18,8 +18,9 @@ require 'tmpdir'
 #              no per-field JSON under `<run_id>/`; the manifest
 #              pointer lives inside the DB).
 #
-# Per `feedback_v2_integration_exit_status`, both contexts assert
-# on the on-disk cache layout (filesystem state), not just exit code.
+# Both contexts assert on the on-disk cache layout (filesystem
+# state), not just exit code -- exit-status-only checks mask
+# cache-persistence bugs.
 #
 # rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
 RSpec.describe 'RSPEC_TRACER_STORAGE env-var override integration' do

--- a/spec/integration/fail_on_duplicates_spec.rb
+++ b/spec/integration/fail_on_duplicates_spec.rb
@@ -29,9 +29,9 @@ require 'tmpdir'
 #   In both cases the rspec-tracer banner reports the surviving
 #   example count - the suite is NOT aborted to zero examples.
 #
-# Assertion shape per `feedback_v2_integration_exit_status`: the
-# load-bearing checks are the exit code, the banner's surviving-
-# example count, and (on the exit-0 path) the written cache.
+# Assertion shape: the load-bearing checks are the exit code, the
+# banner's surviving-example count, and (on the exit-0 path) the
+# written cache -- exit status alone masks cache-persistence bugs.
 #
 # Fixture: a parameterized `.each` loop wrapping a single `it` block
 # produces N examples that share example_group + description +

--- a/spec/integration/remote_cache_local_fs_spec.rb
+++ b/spec/integration/remote_cache_local_fs_spec.rb
@@ -18,8 +18,8 @@ require 'rspec_tracer/storage/schema'
 # closed the parity gap.
 #
 # Asserts on the content of what was uploaded / downloaded
-# (per `feedback_v2_integration_exit_status`: exit-status checks
-# mask cache-persistence bugs). The round-trip proves the two-tier
+# (exit-status checks mask cache-persistence bugs; only content
+# assertions catch them). The round-trip proves the two-tier
 # layout matches S3 semantics + the schema_version envelope is
 # preserved across the archive boundary.
 #

--- a/spec/integration/remote_cache_redis_spec.rb
+++ b/spec/integration/remote_cache_redis_spec.rb
@@ -19,9 +19,8 @@ require 'rspec_tracer/storage/schema'
 # REDIS_URL overrides the default. We use db 15 (an uncommon choice)
 # to isolate from other local tooling on the same Redis instance.
 #
-# Asserts on the content of what was uploaded / downloaded (per the
-# feedback_v2_integration_exit_status memory: exit-status-only checks
-# mask cache-persistence bugs).
+# Asserts on the content of what was uploaded / downloaded
+# (exit-status-only checks mask cache-persistence bugs).
 #
 # rubocop:disable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable
 # rubocop:disable RSpec/LeakyConstantDeclaration, RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/integration/remote_cache_spec.rb
+++ b/spec/integration/remote_cache_spec.rb
@@ -18,9 +18,9 @@ require 'rspec_tracer/storage/schema'
 # is a precondition for `task test:integration:remote-cache` - this
 # spec runs after the ready+smoke probe passes.
 #
-# Asserts on the content of what was uploaded / downloaded (per the
-# feedback_v2_integration_exit_status memory: exit-status checks mask
-# cache-persistence bugs). The round-trip proves the key layout
+# Asserts on the content of what was uploaded / downloaded
+# (exit-status checks mask cache-persistence bugs).
+# The round-trip proves the key layout
 # matches 1.x semantics + the new tier split is coherent.
 #
 # rubocop:disable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable

--- a/spec/integration/schema_version_upgrade_spec.rb
+++ b/spec/integration/schema_version_upgrade_spec.rb
@@ -30,9 +30,9 @@ require 'rspec_tracer/storage/schema'
 #   - save_graph still works after the cold-run fallback (next run
 #     writes a fresh schema_version-tagged manifest)
 #
-# Per `feedback_v2_integration_exit_status`: assert on the contract
-# behavior (logger output + nil return + post-fallback save), not
-# just on absence-of-raise.
+# Assert on the contract behavior (logger output + nil return +
+# post-fallback save), not just on absence-of-raise -- raise-free
+# runs alone mask cache-persistence bugs.
 # rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable, RSpec/ContextWording
 # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
 RSpec.describe 'Storage::JsonBackend 1.x -> 2.0 cache schema cold-run upgrade ceremony (M8.10)' do

--- a/spec/integration/track_env_config_spec.rb
+++ b/spec/integration/track_env_config_spec.rb
@@ -9,9 +9,9 @@
 # rewritten per-example here (config-level DSL is the surface under
 # test) and restored in `after`.
 #
-# Assertion philosophy matches M4.3 / M5.2: assert on the set of
-# examples that re-ran (filter decisions), not exit status
-# (memory: feedback_v2_integration_exit_status).
+# Assertion philosophy matches the other integration specs: assert
+# on the set of examples that re-ran (filter decisions), not exit
+# status -- exit-status-only checks mask cache-persistence bugs.
 
 require 'bundler'
 require 'fileutils'

--- a/spec/integration/wide_ar_schema_db_cleaner_truncation_spec.rb
+++ b/spec/integration/wide_ar_schema_db_cleaner_truncation_spec.rb
@@ -15,8 +15,9 @@
 # suggests silently widens to "all DBC-wrapped examples re-run on
 # schema change."
 #
-# This is SAFE-BUT-WIDE behavior; see
-# `feedback_no_user_surprises` for the trust framing.
+# This is SAFE-BUT-WIDE behavior: over-selection re-runs more than
+# strictly needed but never silently skips an affected example, and
+# the widening is documented rather than left as a silent surprise.
 #
 # Three assertions:
 #   1. (cold) db/schema.rb is in the dependency set of every

--- a/spec/regressions/knapsack_coexistence_spec.rb
+++ b/spec/regressions/knapsack_coexistence_spec.rb
@@ -27,8 +27,9 @@
 # carries knapsack in the :development group (require: false default)
 # so the subprocess can require it on demand.
 #
-# Per `feedback_v2_integration_exit_status`: the cache-state
-# assertion (not just exit-status) is the load-bearing check.
+# The cache-state assertion (not just exit-status) is the
+# load-bearing check; exit-status-only checks mask cache-persistence
+# bugs.
 #
 require 'bundler'
 require 'fileutils'
@@ -72,8 +73,7 @@ RSpec.describe 'knapsack coexistence (smoke; M8.10)' do
       # first run the file doesn't exist; pre-creating an empty
       # report keeps the smoke focused on COMPOSITION (does
       # rspec-tracer + knapsack load + run cleanly?) rather than on
-      # knapsack's own bootstrap ceremony. Per
-      # feedback_v2_integration_exit_status the load-bearing
+      # knapsack's own bootstrap ceremony. The load-bearing
       # assertion is the cache-state, but we still want a clean
       # exit so the smoke is unambiguous.
       File.write(File.join(dir, 'knapsack_rspec_report.json'), '{}')

--- a/spec/regressions/rspec_retry_coexistence_spec.rb
+++ b/spec/regressions/rspec_retry_coexistence_spec.rb
@@ -23,10 +23,10 @@
 # in the :development group (require: false default) so the
 # subprocess can require it on demand.
 #
-# If a real conflict surfaces here, file as M9.0-B follow-up per the
-# brief - smoke specs are non-blocking. Per the
-# `feedback_v2_integration_exit_status` memory, the cache-state
-# assertion (not just exit-status) is the load-bearing check.
+# If a real conflict surfaces here, file a follow-up issue - smoke
+# specs are non-blocking. The cache-state assertion (not just
+# exit-status) is the load-bearing check; exit-status-only checks
+# mask cache-persistence bugs.
 
 require 'bundler'
 require 'fileutils'

--- a/spec/soak/realworld_soak_spec.rb
+++ b/spec/soak/realworld_soak_spec.rb
@@ -39,21 +39,21 @@ require 'pathname'
 #
 # Excluded from the default rspec sweep via .rspec --exclude-pattern.
 #
-# Iteration mechanism: subprocess per iter via Open3.capture2e (M5.1
-# cold-subprocess test-isolation contract preserved per
-# feedback_jruby_ci_subprocess_floor); NO fork() in the spec - if
-# ever introduced, the child must Process.exit!(0) per
-# feedback_simplecov_fork_poisoning. Open3 is wrapped in
-# Bundler.with_unbundled_env per
-# feedback_bundler_unbundled_env_for_fixture_subprocess - the outer
-# `bundle exec rspec` leaks RUBYOPT=-rbundler/setup + BUNDLE_GEMFILE
-# etc. into the child; with_unbundled_env clears those so the child
-# resolves against the fixture's Gemfile cleanly.
+# Iteration mechanism: subprocess per iter via Open3.capture2e,
+# preserving the cold-subprocess test-isolation contract; NO fork()
+# in the spec - if ever introduced, the child must Process.exit!(0)
+# to bypass SimpleCov's inherited at_exit hook, which would rewrite
+# the parent's coverage snapshot. Open3 is wrapped in
+# Bundler.with_unbundled_env - the outer `bundle exec rspec` leaks
+# RUBYOPT=-rbundler/setup + BUNDLE_GEMFILE etc. into the child;
+# with_unbundled_env clears those so the child resolves against the
+# fixture's Gemfile cleanly.
 #
 # Cache state assertions only; no coverage.json byte-equivalence
-# (M8.0 domain - would require CI= empty pinning per
-# feedback_rails_eager_load_coverage_timing). Cleanup-guard hygiene
-# via spec/support/integration_cleanup.rb (M8.2).
+# (that would require pinning CI= empty in the child env, since
+# eager-loading Rails apps load files at boot before Coverage.start
+# fires and shift the coverage shape). Cleanup-guard hygiene
+# via spec/support/integration_cleanup.rb.
 #
 # Per-project layout differs significantly:
 #
@@ -136,9 +136,8 @@ PROJECT_INVOCATIONS = {
     # verified clean locally at the pinned SHA in ~5 min.
     # spec/services explicit dir list with checkout's individual
     # files (minus select_shipping_method) so rspec discovery skips
-    # the flake without an --exclude-pattern (which is silently
-    # ignored when positional paths are passed - per
-    # feedback_rspec_exclude_pattern_positional).
+    # the flake without an --exclude-pattern (which rspec silently
+    # ignores when explicit positional paths are passed).
     rspec_args: %w[
       spec/lib spec/finders spec/helpers spec/jobs spec/presenters spec/validators
       spec/services/spree/account

--- a/spec/support/fixture_bundle_helper.rb
+++ b/spec/support/fixture_bundle_helper.rb
@@ -15,10 +15,10 @@ require 'json'
 # run_rspec_in_fixture variants since the env vars and target spec
 # file differ.
 #
-# `def self.x` (over module_function) per
-# feedback_mutation_friendly_modules: keeps the methods discoverable
-# under mutant should this helper ever be in scope; currently it
-# isn't (test-support code), but the convention is consistent.
+# `def self.x` (over module_function) keeps the methods discoverable
+# under mutant should this helper ever be in scope (module_function's
+# anonymous singleton hides them); currently it isn't (test-support
+# code), but the convention is consistent.
 module FixtureBundleHelper
   FIXTURE_ROOT = File.expand_path('../fixtures/rails_app', __dir__)
   CACHE_DIR = File.join(FIXTURE_ROOT, 'rspec_tracer_cache')
@@ -39,8 +39,7 @@ module FixtureBundleHelper
           # Wipe the lock so Bundler resolves fresh against the
           # current interpreter. Same-interpreter repeats keep
           # `bundle check` green, so this rm only fires on the
-          # exception path. Per M8.1-B's cross-interpreter resilience
-          # work + feedback_cross_interpreter_fixture_helper.
+          # exception path.
           FileUtils.rm_f(File.join(FIXTURE_ROOT, 'Gemfile.lock'))
           system(gemfile_env, 'bundle', 'install', '--quiet') || raise('bundle install failed')
         end

--- a/spec/support/integration_cleanup.rb
+++ b/spec/support/integration_cleanup.rb
@@ -7,9 +7,8 @@ require 'fileutils'
 # before(:all) and after(:all) hooks to scrub cache / report /
 # coverage state between back-to-back runs.
 #
-# Closes synthesis flake Pattern 1 - stale cache-state leak, recurring
-# across the M3.3 / M3.6 / M4.1 / M7.1 retros (see
-# docs/revamp/retro/00-SYNTHESIS.md §Recurring flakes Pattern 1). The
+# Closes a recurring flake pattern: stale cache-state leaking
+# between back-to-back integration runs. The
 # Taskfile does not rm -rf cache/report dirs between tasks, so a spec
 # whose fixture leaks state into the next spec used to surface as
 # flakes that disappeared after a manual `rm -rf`.

--- a/taskfiles/profile.yml
+++ b/taskfiles/profile.yml
@@ -8,9 +8,9 @@ version: '3'
 #   tmp/profile/<scenario>.txt    top-25 text summary
 #   tmp/profile/<scenario>.json   speedscope-loadable flamegraph JSON
 #
-# tmp/ is gitignored; profile output is a local-only reference. The
-# PR commit message + docs/revamp/PERFORMANCE_NOTES.md (M8.4-B)
-# paste relevant excerpts.
+# tmp/ is gitignored; profile output is a local-only reference.
+# Paste relevant excerpts into the PR commit message when a change
+# is motivated by profile data.
 #
 # stackprof is MRI-only (gated in the outer Gemfile via
 # `if RUBY_ENGINE == 'ruby'`). Tasks here will fail-fast on JRuby /

--- a/taskfiles/soak.yml
+++ b/taskfiles/soak.yml
@@ -25,8 +25,8 @@ version: '3'
 # soak:fixture:all regenerates all 3 fixtures locally (sequential)
 # for full pre-PR parity.
 #
-# MRI-only per feedback_jruby_ci_subprocess_floor: JRuby x Rails
-# multi-iter cells would compound past the 4 h cap.
+# MRI-only: JRuby x Rails cold-boots each subprocess in ~2:30 on CI
+# runners, so multi-iter cells would compound past the 4 h cap.
 
 vars:
   RSPEC_TRACER_ROOT:
@@ -143,8 +143,8 @@ tasks:
           # Unset CI for bundle install. Refinery main's Gemfile has
           # `if !ENV['CI']` gating for sqlite3. On GHA, ENV['CI']=true
           # so sqlite3 wouldn't be in the lockfile - but the soak
-          # subprocess sets CI=>nil (per
-          # feedback_env_empty_string_is_truthy), at which point
+          # subprocess sets CI=>nil to delete the var entirely
+          # (CI="" would still be truthy in Ruby), at which point
           # Bundler.setup re-evaluates the Gemfile and demands sqlite3,
           # finding it missing. Match the subprocess runtime by also
           # unsetting CI here.

--- a/taskfiles/test-features.yml
+++ b/taskfiles/test-features.yml
@@ -64,7 +64,8 @@ tasks:
       pure-compute describe (which sets self.use_transactional_fixtures
       = false) is NOT re-run, demonstrating the widening boundary.
       Documents the SAFE-BUT-WIDE schema attribution under the most
-      common Rails setup (memory: feedback_no_user_surprises).
+      common Rails setup: over-selection never skips an affected
+      example, and the widening is documented rather than silent.
     cmds:
       - bundle exec rspec --no-color spec/integration/wide_ar_schema_transactional_spec.rb
 

--- a/taskfiles/test-mutation.yml
+++ b/taskfiles/test-mutation.yml
@@ -174,12 +174,13 @@ tasks:
         # prepended-method entry created equivalent-mutations against
         # the inner `_record` bucket-nil check (mutating either guard
         # alone leaves the other intact, plus the outer rescue
-        # StandardError swallows downstream nil-bucket errors). Per
-        # feedback_mutant_equivalent_guards + feedback_mutant_prepend_idempotency:
-        # accept the structural carve-out instead of tightening tests
-        # against an unobservable difference. CI baseline post-Priority-3
-        # is 75.33%; 72 leaves ~3pp margin under
-        # feedback_mutant_local_vs_ci_variance.
+        # StandardError swallows downstream nil-bucket errors) --
+        # observably-equivalent mutations plus prepend's no-unprepend
+        # idempotency ceiling. Accept the structural carve-out instead
+        # of tightening tests against an unobservable difference.
+        # CI baseline post-carve-out is 75.33%; 72 leaves ~3pp margin
+        # for local-vs-CI run variance (gates are sized from CI
+        # numbers, never local).
         run_mutant_gate "Tracker::IOHooks" \
           "rspec_tracer/tracker/io_hooks" \
           "RSpecTracer::Tracker::IOHooks*" 72 || fail=1
@@ -251,9 +252,10 @@ tasks:
         }
 
         fail=0
-        # Gates preserved verbatim from the M8.3-A storage Taskfile
-        # entry. Msgpack carve-out rationale documented in the M8.3-A
-        # retro + feedback_mutant_local_vs_ci_variance.
+        # Gates preserved verbatim from the original storage Taskfile
+        # entry. Msgpack carve-out absorbs local-vs-CI run variance
+        # (test-ordering + parallelism differences shift alive counts
+        # several pp between machines; gates are sized from CI numbers).
         run_mutant_gate "Storage::LazySnapshot" \
           "rspec_tracer/storage/lazy_snapshot" 85 \
           "RSpecTracer::Storage::LazySnapshot*" || fail=1
@@ -461,8 +463,9 @@ tasks:
         # carry more structural-ceiling mutations (transactional write
         # paths exercised end-to-end through public describes that
         # mutant credits to the public method, not the helper). Local
-        # M2 Max baseline 73.69%; 5pp margin under per
-        # feedback_mutant_local_vs_ci_variance.
+        # M2 Max baseline 73.69%; 5pp margin under absorbs
+        # local-vs-CI run variance (test ordering + parallelism shift
+        # alive counts several pp between machines).
         if awk "BEGIN { exit ($cov >= 68) ? 0 : 1 }"; then
           echo "mutation:storage [Storage::JsonBackend shard-3] PASS (coverage $cov% >= 68%)"
           exit 0
@@ -505,9 +508,8 @@ tasks:
         # prune helpers also concentrate structural-ceiling subjects
         # (private read-side helpers exercised through public describes
         # that mutant credits to the public method). Local M2 Max
-        # baseline 71.93%; ~4pp margin under per
-        # feedback_mutant_local_vs_ci_variance. Same calibration
-        # rationale as shard-3.
+        # baseline 71.93%; ~4pp margin under absorbs local-vs-CI run
+        # variance. Same calibration rationale as shard-3.
         if awk "BEGIN { exit ($cov >= 68) ? 0 : 1 }"; then
           echo "mutation:storage [Storage::JsonBackend shard-4] PASS (coverage $cov% >= 68%)"
           exit 0
@@ -544,11 +546,11 @@ tasks:
         fi
         # Shard-5 gate: 70% (vs whole-JsonBackend 75%). The 2 warn_*
         # methods are file-stat helpers exercised through public
-        # describes (`#save_graph` / `maybe_warn_size_budget`) that
-        # mutant credits to the public method per
-        # feedback_mutant_describe_label_ceiling. CI baseline 74.28%
-        # (105 mutations); 4pp margin per
-        # feedback_mutant_local_vs_ci_variance.
+        # describes (`#save_graph` / `maybe_warn_size_budget`);
+        # mutant credits kills to the describe label's method, so the
+        # helpers get no direct credit. CI baseline 74.28%
+        # (105 mutations); 4pp margin absorbs local-vs-CI run
+        # variance.
         if awk "BEGIN { exit ($cov >= 70) ? 0 : 1 }"; then
           echo "mutation:storage [Storage::JsonBackend shard-5] PASS (coverage $cov% >= 70%)"
           exit 0
@@ -789,9 +791,9 @@ tasks:
         fi
         # Gate is 65% (vs read-side 73%) because this shard
         # concentrates the structural-ceiling subjects:
-        # `#initialize` (exercised through sibling-method describes
-        # per feedback_mutant_describe_label_ceiling — same pattern
-        # as M8.3-A's Tracker::NewFileDetector#initialize) plus the
+        # `#initialize` (exercised through sibling-method describes,
+        # which mutant credits to the sibling, not #initialize --
+        # same pattern as Tracker::NewFileDetector#initialize) plus the
         # private connection / schema / utility helpers (exercised
         # via public describes that mutant credits to the public
         # method, not the helper). The original 3-shard split's
@@ -1036,15 +1038,14 @@ tasks:
 
         fail=0
         # Per-subject gates sized at ~3-5 pp under CI ubuntu-latest
-        # baselines for variance (per memory:
-        # feedback_mutant_local_vs_ci_variance, codified from M8.3-A
-        # retro). Initial cut sized from local M2 Max baselines was
-        # too tight: GitAncestry alone swung from 94.59% local to
+        # baselines for variance -- always size gates from CI numbers,
+        # never local. Initial cut sized from local M2 Max baselines
+        # was too tight: GitAncestry alone swung from 94.59% local to
         # 72.68% CI on the first run because mutant's per-mutation
         # 5 s timeout kills 305 local mutations (git shell-out hangs
         # under M2 Max parallelism 12) but 0 CI mutations (Linux git
         # responds fast enough under ubuntu-latest parallelism 4 that
-        # the same mutations don't hang). Same shape as M8.3-A's
+        # the same mutations don't hang). Same shape as the earlier
         # 154ec27 post-merge widening.
         run_mutant_gate "RemoteCache::Backend" \
           "rspec_tracer/remote_cache/backend" \
@@ -1062,8 +1063,8 @@ tasks:
           "rspec_tracer/remote_cache/git_ancestry" \
           "RSpecTracer::RemoteCache::GitAncestry*" 68 || fail=1
         # UserTasks / LocalFsBackend / RedisBackend / S3Backend share
-        # the M8.3-A Storage::SqliteBackend describe-label ceiling
-        # (memory: feedback_mutant_describe_label_ceiling): 4-7x more
+        # the same describe-label ceiling as Storage::SqliteBackend:
+        # 4-7x more
         # mutant subjects than public describe blocks because private
         # helpers (#build_admin_ancestry, #blank?, #join_key,
         # #object_key_for, #aws_rm_recursive_silent, #log_debug etc.)
@@ -1096,8 +1097,8 @@ tasks:
       mutations stay alive even though functionally tested under the
       combined describe), (b) the `Module#prepend` idempotency ceiling
       on I18nTracking::LoadTranslationsHook prepended onto
-      ::I18n::Backend::Base (per feedback_mutant_prepend_idempotency:
-      Ruby has no unprepend API, prepend-line mutations un-killable in
+      ::I18n::Backend::Base (Ruby has no unprepend API, so
+      prepend-line mutations are un-killable in
       shared-process spec suites), and (c) prose-form integration
       describes (`bucket lifecycle`, `LoadTranslationsHook integration`,
       `render subscriber integration via fake AS::Notifications`) that
@@ -1159,10 +1160,10 @@ tasks:
 
         fail=0
         # Per-subject gates sized at ~3-5 pp under M2 Max local baselines
-        # for CI ubuntu-latest variance per memory:
-        # feedback_mutant_local_vs_ci_variance. Re-cut downward in a
+        # to absorb CI ubuntu-latest variance (test ordering + mutant
+        # parallelism shift alive counts several pp). Re-cut downward in a
         # follow-up commit if any subject drops materially below local on
-        # the first CI run (M8.3-A 154ec27 + M8.3-B 10c0d67 precedent).
+        # the first CI run (154ec27 + 10c0d67 precedent).
         #
         # Notifications local 78.77%: 19 subjects, 48 selected tests; the
         # combined `.install / .installed? / .uninstall` describe credits
@@ -1176,8 +1177,8 @@ tasks:
         # end-to-end via the prose-form integration describes
         # (`render subscriber integration via fake AS::Notifications` /
         # `sql.active_record subscriber integration`). Restructuring
-        # describes for coverage rejected per the M8.3-A no-anti-pattern-
-        # test-org rule.
+        # describes for coverage rejected -- test organization exists to
+        # document behavior, not to satisfy the mutation tool.
         run_mutant_gate "Rails::Notifications" \
           "rspec_tracer/rails/notifications" \
           "RSpecTracer::Rails::Notifications*" 75 || fail=1
@@ -1187,7 +1188,9 @@ tasks:
         # match for `LoadTranslationsHook#load_translations`) PLUS the
         # `Module#prepend(::I18n::Backend::Base, LoadTranslationsHook)` line
         # in `prepend_backend_hook` whose mutations are structurally un-
-        # killable per feedback_mutant_prepend_idempotency. 5 pp margin
+        # killable (Ruby has no unprepend; once any prior test prepends,
+        # re-installs mutated or not leave the ancestor chain unchanged
+        # in a shared-process suite). 5 pp margin
         # rather than 3 pp because the prepend-idempotency ceiling
         # interacts unpredictably with test ordering on CI. Below the
         # canonical brief's 70% best-effort target; carve-out documented.
@@ -1219,9 +1222,10 @@ tasks:
       etc.) that don't map to mutant's first-token Klass#method scheme;
       private projection / formatting / classification helpers exercised
       via the public `#generate` / `.build` / `.emit_all` describes
-      receive no direct credit per feedback_mutant_describe_label_ceiling.
-      Carve-outs sized accordingly; restructuring describes for coverage
-      rejected per the M8.3-A no-anti-pattern-test-org rule.
+      receive no direct credit (mutant credits kills to the describe
+      label's method only). Carve-outs sized accordingly; restructuring
+      describes for coverage rejected -- test organization documents
+      behavior, it is not reshaped to satisfy the mutation tool.
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -1253,10 +1257,10 @@ tasks:
 
         fail=0
         # Per-subject gates sized at ~3 pp under M2 Max local baselines
-        # for CI ubuntu-latest variance per memory:
-        # feedback_mutant_local_vs_ci_variance. Re-cut downward in a
+        # to absorb CI ubuntu-latest variance (test ordering + mutant
+        # parallelism shift alive counts several pp). Re-cut downward in a
         # follow-up commit if any subject drops materially below local on
-        # the first CI run (M8.3-A 154ec27 + M8.3-B 10c0d67 precedent).
+        # the first CI run (154ec27 + 10c0d67 precedent).
         #
         # Base local 96.82%: 3 subjects, 11 selected; clean `#initialize`
         # / `#generate` / `#no_op?` describes map perfectly. The 2 alive
@@ -1288,7 +1292,7 @@ tasks:
         # / `cell` / `cell_code` / `format_duration` / `copy_assets`
         # / `inject` private helpers uncredited under mutant first-token
         # mapping. Behavior IS exercised end-to-end via `#generate` output
-        # assertions; carve-out per feedback_mutant_describe_label_ceiling.
+        # assertions; carve-out for the describe-label ceiling.
         run_mutant_gate "Reporters::HtmlReporter" \
           "rspec_tracer/reporters/html_reporter" \
           "RSpecTracer::Reporters::HtmlReporter*" 80 || fail=1

--- a/taskfiles/test.yml
+++ b/taskfiles/test.yml
@@ -99,7 +99,8 @@ tasks:
     desc: >-
       M8.2 edge case suite — adversarial filesystem + cache + concurrency
       tests under spec/edge_cases/. Excluded from the default rspec sweep
-      via .rspec --exclude-pattern (memory: feedback_rspec_exclude_pattern_positional).
+      via .rspec --exclude-pattern (note rspec silently ignores that flag
+      when explicit positional paths are passed).
       Runs per-PR via lint-and-specs.yml's `Test - Edge cases` step.
     env:
       COVERAGE_SUITE: edge-cases


### PR DESCRIPTION
## Summary

Rewrites comments across lib, spec, taskfiles, and workflows so their technical content stands alone. References to private maintainer note filenames and private planning paths are replaced with the underlying engineering rationale, written inline (mutant observability constraints, exit-status-vs-cache-state assertion rationale, gate-sizing variance margins, subprocess env handling, and similar). 34 files changed; every change is a comment, doc, or task-description edit -- no code semantics change.

## Verification

- Diff audited as comment-only: all changed Ruby lines are `#` comments; all changed YAML lines are `#` comments or `desc:` prose blocks.
- Added lines checked ASCII-clean and free of private-note references.
- `bundle install --quiet` clean.
- `task lint:ruby` -- 227 files inspected, no offenses.
- `task lint:yaml` -- yamllint --strict clean.
- `task lint:actions` -- actionlint clean.

## Merge note

Merge before the leak-check gate PR (that PR stacks on this branch). The two remaining reference removals in docs/CI_RECIPES.md and the example workflow ship in PR #266, which owns those files.
