### PR TITLE
ci(lint): internal-nomenclature leak gate + residual comment cleanup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -67,14 +67,14 @@ runs:
           bin
           .venv
         # Primary key: exact match on Taskfile.yml + .tool-versions hash.
-        # Restore-keys: any prior `tools-${runner.os}-` cache entry. M8.6
-        # retro — Taskfile.yml hash changes on every session that edits
+        # Restore-keys: any prior `tools-${runner.os}-` cache entry.
+        # Taskfile.yml's hash changes on every PR that edits
         # tasks, busting the cache and forcing fresh tool downloads (one
         # of which is the trivy install that hit a 35s GitHub-Releases
         # CDN flake on PR #129's first run). With restore-keys, a
         # busted-primary-key run still gets binaries from the most
         # recent cache; install:tools' version-aware status: guards
-        # (added in M8.6) verify each binary's --version against the
+        # verify each binary's --version against the
         # pinned vars and re-install only what's actually stale.
         key: tools-${{ runner.os }}-${{ hashFiles('Taskfile.yml', '.tool-versions') }}
         restore-keys: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Per-subject mutation flags (M8.6). When a PR's diff doesn't
+          # Per-subject mutation flags. When a PR's diff doesn't
           # touch a subject's lib/+spec/ surface, that subject's
           # mutation gate is skipped on the per-PR run — same coverage
           # signal still runs at merge-to-main (full-matrix path) and
@@ -61,7 +61,7 @@ jobs:
           # silently miss any one of them.
           MUT_TRACKER=0; MUT_STORAGE=0; MUT_RSPEC=0; MUT_TOP_LEVEL=0
           MUT_FORCE_ALL=0
-          # M8.4-B multi-tier granularity: gate the rails fixture cell
+          # Multi-tier granularity: gate the rails fixture cell
           # (the `rails:` job in full-matrix.yml) on tier=test as well
           # as tier=build, so spec-only PRs that touch the rails
           # fixture paths still run the full Rails matrix. Without

--- a/.github/workflows/flake-gate.yml
+++ b/.github/workflows/flake-gate.yml
@@ -1,7 +1,7 @@
 ---
 name: flake-gate
 
-# Post-fix gate workflow shipped with M8.2-B's Example.from /
+# Post-fix gate workflow shipped with the Example.from /
 # parallel_tests determinism work. Drives `task test:integration:parallel`
 # 100 consecutive times on the historical-flake cell (ruby 3.1 +
 # RSPEC_VERSION='~> 3.12.0') and reports the first-fail log if any
@@ -11,7 +11,7 @@ name: flake-gate
 #   - workflow_dispatch (manual; configurable cell + iter count)
 #
 # Demoted to manual-only after 3 consecutive green runs on `main`
-# (1 historical on the M8.2-B feature branch + 2 fresh on main, all
+# (1 historical on the fix's feature branch + 2 fresh on main, all
 # passing) cleared the historical `warm_skipped != cold_examples` shape.
 # Kept available for on-demand re-targeting any cell when a future flake
 # investigation needs the 100x-iter shape.

--- a/.github/workflows/full-matrix.yml
+++ b/.github/workflows/full-matrix.yml
@@ -11,7 +11,7 @@ on:
           spec/spec-floor/ruby-project/ruby-parallel/jruby/
           truffleruby/benchmark. Set by ci.yml when tier=test AND a
           rails-fixture-related path is in the diff (multi-tier
-          granularity refinement, M8.4-B).
+          granularity refinement).
         type: string
         default: build
 
@@ -47,7 +47,7 @@ jobs:
         # (https://github.com/jruby/activerecord-jdbc-adapter), so the
         # JRuby x Rails matrix stays Rails 7.1-only.
         run: |
-          # M8.6-B Lever 5: the JRuby x Rails 7.1 cell fans out across 7
+          # Wall-clock lever: the JRuby x Rails 7.1 cell fans out across 7
           # shards (6 rails_app-N-M shards covering 2 scenarios each from
           # rails_app_spec.rb's 12 scenarios + 1 narrow-schema shard for
           # narrow_ar_schema_spec.rb's 2 scenarios). MRI rows carry
@@ -279,7 +279,7 @@ jobs:
     name: rails (ruby-${{ matrix.ruby }}, rails-${{ matrix.rails }}${{ matrix.shard != '' && format(', {0}', matrix.shard) || '' }})
     needs: matrix-config
     runs-on: ubuntu-latest
-    # M8.6-B PR #130 calibration:
+    # PR #130 timeout calibration:
     #
     #   - v1 push tried 20-min ceiling: cancelled at 20:30 (scenario
     #     7 of 12 finished). Cache post-hook didn't run; nothing
@@ -291,16 +291,16 @@ jobs:
     # on ubuntu-latest under load. The full rspec block (12
     # scenarios * ~2:30 = ~30 min) plus the separate narrow-schema
     # step (~5-6 min for 2 scenarios) puts the cold-cache cell at
-    # ~38-40 min. Brief's 17-20 min baseline was either a different
+    # ~38-40 min. The earlier 17-20 min estimate was either a different
     # runner pool or pre-merge measurement; today's reality is
     # ~2x that. Bumping to 45 lets the cold run actually complete
     # and save the new ~/.m2 + fixture vendor/bundle caches; warm
     # reruns then save ~3 min via the cached Maven + gem set.
     #
     # The remaining wall-clock cut needs a different lever: shard
-    # the 12 scenarios across N parallel matrix jobs (M8.6-C). With
-    # this timeout the cell is mergeable; M8.6-C delivers the <12
-    # min target.
+    # the 12 scenarios across N parallel matrix jobs (since wired
+    # via matrix.shard below). With this timeout the cell is
+    # mergeable; sharding delivers the <12 min target.
     timeout-minutes: 45
     env:
       BRANCH_COVERAGE: 'true'
@@ -335,7 +335,7 @@ jobs:
           version: 3.45.4
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # M8.6-B Lever 1a: cache the JRuby Maven plugin tree. The fixture
+      # Cache the JRuby Maven plugin tree. The fixture
       # Gemfile pulls activerecord-jdbcsqlite3-adapter on JRuby, which
       # downloads ~25 Maven JARs (jdbc-sqlite3 + Maven plugins) on first
       # install. The download is ~30-60s per cold-cache run and is
@@ -352,7 +352,7 @@ jobs:
           restore-keys: |
             m2-${{ runner.os }}-jruby-
 
-      # M8.6-B Lever 1b: cache the fixture's vendor/bundle so warm-cache
+      # Cache the fixture's vendor/bundle so warm-cache
       # runs reuse the gem set across PRs. Same pattern as the
       # `benchmark:` job's fixture-bundle cache (full-matrix.yml's
       # `Cache rails_app fixture bundle` step). Key includes matrix.ruby
@@ -398,7 +398,7 @@ jobs:
           SQLITE3_VERSION: "~> ${{ matrix.sqlite3 }}"
         run: task test:features:rails:narrow-schema
 
-      # M9.0: wide-AR-schema integration specs (4 scenarios:
+      # Wide-AR-schema integration specs (4 scenarios:
       # transactional fixtures + DBC :truncation / :deletion /
       # :transaction). The contract under test is engine-uniform - the
       # widening behavior is the same on every Ruby + Rails cell - so
@@ -415,7 +415,7 @@ jobs:
           SQLITE3_VERSION: "~> ${{ matrix.sqlite3 }}"
         run: task test:features:rails:wide-schema:suite
 
-      # M9.0: Rails-fixture-driving regression spec (upstream issue
+      # Rails-fixture-driving regression spec (upstream issue
       # #66, template change invalidates dependents via the
       # render_template.action_view subscriber). Same canary-cell
       # gate as the wide-schema suite; reuses the rails_app fixture's
@@ -434,7 +434,7 @@ jobs:
       # config/database.yml needs no JRuby-specific tweak. SQLITE3_VERSION
       # is unused on the JRuby branch but passed for symmetry with MRI.
       #
-      # M8.6-B Lever 5: the cell is fanned across 7 shards via
+      # Wall-clock lever: the cell is fanned across 7 shards via
       # matrix.shard (rails_app-N-M for the 12 rails_app_spec.rb
       # scenarios in pairs of 2, plus narrow-schema for
       # narrow_ar_schema_spec.rb). Each shard runs ~5-7 min on warm

--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -4,7 +4,7 @@ name: lint-and-specs
 on:
   workflow_call:
     inputs:
-      # Per-subject mutation gating (M8.6). Caller (ci.yml) computes
+      # Per-subject mutation gating. Caller (ci.yml) computes
       # these from the PR diff; defaults true so non-PR / fallback
       # callers run every gate. Cross-cutting safety net (Gemfile /
       # .ruby-version / Taskfile.yml / lib/rspec_tracer.rb / multi-
@@ -47,6 +47,8 @@ jobs:
         run: task lint:yaml
       - name: Lint — Node (HTML reporter frontend)
         run: task lint:node
+      - name: Lint -- Internal-nomenclature leak check
+        run: task docs:leak-check
       - name: Check — Bundle
         run: task check:bundle
       - name: Check — HTML reporter dist drift
@@ -117,7 +119,7 @@ jobs:
           if-no-files-found: error
           include-hidden-files: true
 
-  # M9.0: non-Rails regression specs (upstream PR #72 phantom file_path
+  # Non-Rails regression specs (upstream PR #72 phantom file_path
   # graceful-degradation + rspec-retry / rspec-rerun coexistence smoke).
   # Pure-Ruby + subprocess-shape - no rails_app fixture bundle install
   # required, so this lives on the per-PR fast-track. The Rails-fixture
@@ -227,7 +229,7 @@ jobs:
         timeout-minutes: 5
         run: task test:mutation:tracker
 
-  # M8.6 — storage mutation split into 4 parallel jobs (rebalanced
+  # Storage mutation split into 4 parallel jobs (rebalanced
   # post-first-CI). Original 3-shard SqliteBackend split was
   # over-sharded (each ~1-2 min CI), and the unsharded `non-sqlite`
   # job hit ~17 min on CI because JsonBackend dominates with 2792
@@ -285,7 +287,7 @@ jobs:
     if: ${{ inputs.mut_storage }}
     # JsonBackend middle-section first half (9 subjects). Originally
     # 18 subjects at 3:52 CI — split for jitter headroom under the
-    # cap (4-min then; bumped to 5-min in M8.6-B). The other 9 land
+    # cap (4-min then; later bumped to 5-min). The other 9 land
     # in shard-7.
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -324,8 +326,8 @@ jobs:
     # file-I/O-dense atomic-write helpers concentrated together.
     # Original alphabetical-shard-3 (22 subjects mixing this with
     # reads + Merger) hit 6:52 M2 Max / ~10 min CI; 5-way split
-    # isolates the heavy writes here so the per-shard cap (5-min as
-    # of M8.6-B; was 4-min when the split was decided) can be enforced.
+    # isolates the heavy writes here so the per-shard cap (5-min now;
+    # was 4-min when the split was decided) can be enforced.
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -415,7 +417,7 @@ jobs:
     # JsonBackend Merger second half (4 subjects): Merger.empty_state,
     # Merger.merge_env_dependency!, Merger.merge_examples_coverage!,
     # Merger.reverse_of. Split out from shard-5 to fit the per-shard
-    # cap (4-min when split, 5-min after M8.6-B's headroom bump).
+    # cap (4-min when split, 5-min after the headroom bump).
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -487,8 +489,8 @@ jobs:
   test-mutation-top-level-a:
     name: test-mutation-top-level-a
     if: ${{ inputs.mut_top_level }}
-    # M8.6: top-level split into 2 alphabetical halves to enforce the
-    # per-shard step cap (4-min when split, 5-min after M8.6-B's
+    # Top-level split into 2 alphabetical halves to enforce the
+    # per-shard step cap (4-min when split, 5-min after the
     # headroom bump). Whole-module run was 14:59 CI at default 5s
     # timeout + jobs=4 because ~95% of mutations are spec_helper boot
     # hangs that always burn the full 5s timeout. Halving the matcher
@@ -547,7 +549,7 @@ jobs:
     timeout-minutes: 20
 
     services:
-      # LocalStack provides a real S3 API surface for the M7.1 remote-cache
+      # LocalStack provides a real S3 API surface for the S3 remote-cache
       # integration spec. We pin a specific image tag so a LocalStack
       # release never silently breaks our CI. The `task ci:localstack:ready`
       # step below layers a health-poll + smoke probe on top of the
@@ -565,7 +567,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
-      # Redis provides the real wire surface for the M7.2 RedisBackend
+      # Redis provides the real wire surface for the RedisBackend
       # integration spec. 7.4 is the current stable; pin the minor to
       # keep CI reproducible across Redis's periodic protocol tweaks.
       redis:
@@ -602,7 +604,7 @@ jobs:
 
   # Consolidator: the single required-status-check that branch
   # protection can gate on. Succeeds iff every parallel job above
-  # succeeded OR was skipped via M8.6 path-gating; fails if any
+  # succeeded OR was skipped via per-subject path-gating; fails if any
   # was 'failure' or 'cancelled'.
   #
   # `if: !cancelled()` ensures this job runs even when one or more
@@ -647,7 +649,7 @@ jobs:
           NEEDS_RESULTS: ${{ toJSON(needs) }}
         run: |
           echo "$NEEDS_RESULTS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
-          # Accept success (job ran and passed) or skipped (M8.6
+          # Accept success (job ran and passed) or skipped (the per-subject
           # path-gate skipped this subject's mutation pass on this
           # PR). Reject failure or cancelled.
           if echo "$NEEDS_RESULTS" | jq -e 'all(.[]; .result == "success" or .result == "skipped")' >/dev/null; then

--- a/.github/workflows/regen-ratchet.yml
+++ b/.github/workflows/regen-ratchet.yml
@@ -4,9 +4,9 @@ name: regen-ratchet
 # One-shot manual workflow to regenerate benchmark/ratchet.json on
 # GHA ubuntu-latest. The committed ratchet has historically been
 # captured on Apple M2 Max + Ruby 3.3.10; ubuntu-latest is ~1.4-1.6x
-# slower per scenario (per the M2.4 retro), so the M2 Max ratchet
-# is unenforceable on CI without `--no-enforce`. M8.4-A's design call
-# is: regenerate the ratchet on the canonical CI hardware so the
+# slower per scenario (measured on prior benchmark runs), so the
+# M2 Max ratchet is unenforceable on CI without `--no-enforce`. The
+# design call is: regenerate the ratchet on the canonical CI hardware so the
 # benchmark gate becomes blocking on per-PR runs.
 #
 # Trigger via:

--- a/.leakcheck-allow
+++ b/.leakcheck-allow
@@ -1,0 +1,19 @@
+# Exemptions for `task docs:leak-check` (scripts/leak_check.rb).
+#
+# One path or glob per line. Every entry MUST carry a trailing
+# `# justification` comment; entries without one fail the gate.
+# Keep this list short: the default treatment for a hit is rewriting
+# the text to be self-contained, not exempting the file.
+#
+# CHANGELOG.md is deliberately NOT listed here. The script applies a
+# section-scoped rule instead: the active [Unreleased] block (above
+# the first released-version heading) is scanned with the full
+# pattern set, and only the shipped-history sections below it are
+# exempt (frozen release text, never rewritten retroactively). A
+# whole-path entry would silently pass fresh leaks written into
+# [Unreleased].
+scripts/leak_check.rb  # gate implementation; spells out the very patterns it scans for
+.gitignore  # the ignore rule must name the local-only planning tree it excludes
+CLAUDE.md  # agent guardrail doc; must name the local-only tree and its vocabulary to ban them
+AGENTS.md  # agent guardrail doc; must name the local-only tree and its vocabulary to ban them
+lib/rspec_tracer/reporters/html/package-lock.json  # npm-generated lockfile; base64 sha512 integrity hashes randomly contain letter+digit runs that collide with tag patterns

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,7 +62,7 @@ Metrics/ClassLength:
 Metrics/CyclomaticComplexity:
   Max: 10
 
-# Edge-case specs (M8.2) drive the storage layer end-to-end - mktmpdir +
+# Edge-case specs drive the storage layer end-to-end - mktmpdir +
 # save + corruption + load + multiple invariant checks. Same posture the
 # fuzz dir already gets via the RSpec block above.
 Metrics/MethodLength:

--- a/Gemfile
+++ b/Gemfile
@@ -125,14 +125,14 @@ group :development do
   # gem is only required there, never by lib/ code.
   gem 'stackprof', '~> 0.2' if RUBY_ENGINE == 'ruby'
 
-  # Coexistence smoke specs (M9.0 + M8.10). Used only by
+  # Coexistence smoke specs. Used only by
   # spec/regressions/*_coexistence_spec.rb to verify that popular
   # RSpec extensions compose with rspec-tracer's Module#prepend chain
   # on RSpec::Core::Runner / Reporter. Installed by default but never
   # required by lib/ or unit specs - the regression specs explicitly
   # require them in subprocess shape, so the outer rspec process is
-  # unaffected. M8.10 adds knapsack (free, local-only test-splitter)
-  # to round out the M9.0 retry+rerun coverage; knapsack_pro shares
+  # unaffected. knapsack (free, local-only test-splitter) rounds
+  # out the retry+rerun coverage; knapsack_pro shares
   # the same RSpec hook surface but requires an API key and a
   # network-bound service, so the smoke uses `knapsack` as the
   # composition fingerprint.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -12,8 +12,8 @@ ratchet to catch performance regressions before they land.
 | `cache_load` | Just `Cache#populate_from_disk` + process exit | same |
 | `cold_rails` | Cold RSpec against the Rails fixture (model specs only) | `spec/fixtures/rails_app` |
 
-`file_read_hook` is in the brief but deferred to M3.2 — 1.x has no I/O
-prepend hooks to measure.
+`file_read_hook` landed later than the other scenarios -- 1.x had no
+I/O prepend hooks to measure.
 
 ## Running
 
@@ -105,8 +105,8 @@ The committed `ratchet.json` was generated on Ruby 3.3.10 / Apple M2 Max
 / macOS. **CI runs on GHA `ubuntu-latest` (~2-core VMs) are 3-5× slower
 — the CI benchmark job posts a PR comment but does NOT enforce the
 ratchet until a CI-generated baseline is committed.** Regenerating the
-ratchet on a GHA runner is a followup (touched in the M2.4 handoff
-notes).
+ratchet on a GHA runner is a followup; the manual `regen-ratchet`
+workflow is the tool for it.
 
 ## Adding a scenario
 

--- a/benchmark/fixtures/ruby_app/.rspec-tracer
+++ b/benchmark/fixtures/ruby_app/.rspec-tracer
@@ -3,7 +3,7 @@
 RSpecTracer.configure do
   coverage_track_files 'app/**/*.rb'
 
-  # M5.3 config-level wildcard env tracking. The wildcard expands to
+  # Config-level wildcard env tracking. The wildcard expands to
   # concrete env keys matching the prefix at run start; the
   # `track_env_warm_mismatch` benchmark scenario flips
   # `RSPEC_TRACER_BENCH_CONFIG_KEY` between iterations to exercise the

--- a/benchmark/fixtures/ruby_app/spec/calculator_spec.rb
+++ b/benchmark/fixtures/ruby_app/spec/calculator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M5.2 benchmark: annotate one describe block with `tracks: { env: ... }`
+# Env-tracking benchmark shape: annotate one describe block with `tracks: { env: ... }`
 # so the env-snapshot code path is exercised by every benchmark scenario
 # that runs this fixture. Holds the steady-state env-tracking overhead
 # on the benchmark ratchet so regressions show up during `task benchmark:*`.

--- a/benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb
+++ b/benchmark/fixtures/ruby_app/spec/shared_examples_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M8.2-B variance fixture. The original 3 spec files (calculator,
+# Example-identity variance fixture. The original 3 spec files (calculator,
 # discount, inventory) only exercise top-level `it { }` patterns under
 # a single describe. Real users hit the same Example.from identity-hash
 # surface via shared examples (re-included from multiple hosts), shared
@@ -39,7 +39,7 @@ RSpec.shared_context 'with prepared inventory' do
   it { expect(inv).not_to be_empty }
 end
 
-RSpec.describe 'M8.2-B anonymous-block variance fixture' do
+RSpec.describe 'anonymous-block variance fixture' do
   # Pattern 1 — shared examples re-included from host A.
   describe Calculator do
     describe '.add (sum of positive ints)' do

--- a/benchmark/harness.rb
+++ b/benchmark/harness.rb
@@ -5,7 +5,7 @@
 # Measures rspec-tracer overhead across 4 scenarios and compares
 # against a committed ratchet file. Builds fail if any scenario's
 # median time exceeds the ratchet's P50 by > REGRESSION_FAIL_RATIO
-# (30% by default; 20% pre-M8.4-B before per-PR enforcement on the
+# (30% by default; 20% before per-PR enforcement on the
 # GHA baseline surfaced empirical small-sample variance in the
 # 1.20-1.22x band on microbenches). Warnings are emitted between
 # REGRESSION_WARN_RATIO (10%) and REGRESSION_FAIL_RATIO.
@@ -37,7 +37,7 @@ module BenchmarkHarness
   RAILS_FIXTURE = File.join(REPO_ROOT, 'spec/fixtures/rails_app')
 
   REGRESSION_WARN_RATIO = 1.10
-  # Bumped from 1.20 to 1.30 at M8.4-B's first per-PR GHA-gated run,
+  # Bumped from 1.20 to 1.30 at the first per-PR GHA-gated run,
   # which landed coverage_adapter (1.21x) + loaded_files_tracker
   # (1.22x) over the prior 1.20 threshold purely from GHA shared-
   # runner small-sample variance (5 iters per scenario; p50 is
@@ -130,7 +130,7 @@ module BenchmarkHarness
       smoke: true
     },
     'warm_env_mismatch' => {
-      # M5.2 env-snapshot mismatch: warmup primes the cache with the
+      # Per-example env-snapshot mismatch: warmup primes the cache with the
       # tracked env = 'baseline'; iterations run with the tracked env
       # flipped to 'changed', which forces the env-annotated describe
       # block (Calculator in calculator_spec.rb) through the env_changed
@@ -138,7 +138,7 @@ module BenchmarkHarness
       # iterations see env match the last cached value and fall back to
       # warm_noop. Scenario pinned to smoke:false so `task check`
       # stays under its fast-feedback budget.
-      desc: 'Warm run with env_snapshot mismatch on the first iteration (M5.2 overhead floor)',
+      desc: 'Warm run with env_snapshot mismatch on the first iteration (env-tracking overhead floor)',
       cwd: RUBY_FIXTURE,
       cmd: %w[bundle exec rspec --no-color],
       env: { 'RSPEC_TRACER_BENCH_ENV' => 'changed' },
@@ -146,7 +146,7 @@ module BenchmarkHarness
       smoke: false
     },
     'track_env_warm_mismatch' => {
-      # M5.3 config-level + wildcard env-snapshot mismatch. The fixture's
+      # Config-level + wildcard env-snapshot mismatch. The fixture's
       # .rspec-tracer declares `track_env 'RSPEC_TRACER_BENCH_CONFIG_*'`
       # at config level. Warmup primes the cache with
       # RSPEC_TRACER_BENCH_CONFIG_KEY = 'baseline' (matched by the
@@ -156,10 +156,10 @@ module BenchmarkHarness
       # (apply_env_filter_decisions's invalidated.intersect?(@config_*)
       # branch). Holds the steady-state config-level wildcard expansion
       # + global mark-every-example overhead on the ratchet so
-      # regressions in the M5.3 hot-path show up. smoke:false matches
+      # regressions in that hot-path show up. smoke:false matches
       # warm_env_mismatch's shape (subprocess boot dominates 3-iter
       # variance against own ratchet).
-      desc: 'Warm run with config-level wildcard env_snapshot mismatch on first iteration (M5.3)',
+      desc: 'Warm run with config-level wildcard env_snapshot mismatch on first iteration',
       cwd: RUBY_FIXTURE,
       cmd: %w[bundle exec rspec --no-color],
       env: { 'RSPEC_TRACER_BENCH_CONFIG_KEY' => 'changed' },
@@ -196,12 +196,12 @@ module BenchmarkHarness
     },
     'cold_rails_v2' => {
       # Broader Rails fixture cold-start (full spec/ tree). Eager-loads
-      # ~300+ initializer files through the coverage stack; pre-M8.0
-      # this exercised both the legacy CoverageReporter peek+diff per
-      # example AND the Engine peek+diff. Post-retirement only Engine
+      # ~300+ initializer files through the coverage stack; before the
+      # legacy-reporter retirement this exercised both the legacy
+      # CoverageReporter peek+diff per example AND the Engine peek+diff. Post-retirement only Engine
       # peeks. The wall-clock delta on this scenario is the largest
-      # single signal for M8.0's perf payoff. M4.3 handoff target was
-      # `<= 1.5x` of stock-rspec; structural Rails-boot floor caps the
+      # single signal for the retirement's perf payoff. The original
+      # target was `<= 1.5x` of stock-rspec; structural Rails-boot floor caps the
       # achievable wall-clock ratio for this per-iter-subprocess shape
       # at ~1.6x (per-example tracer optimizations barely move a
       # scenario dominated by boot cost, so Rails boot is the floor). The
@@ -266,7 +266,7 @@ module BenchmarkHarness
       smoke: false
     },
     'cache_load' => {
-      # M3.8 AC #1: 500-example cache loads fast under the lazy +
+      # Contract: 500-example cache loads fast under the lazy +
       # string-interning path. Times N Storage::JsonBackend#load_graph
       # + full field materialization against a representative
       # populated cache. smoke:false because subprocess boot dominates
@@ -478,7 +478,7 @@ module BenchmarkHarness
 
       # Effective threshold is the canonical MRI ratchet scaled by the
       # current interpreter's multiplier. On MRI multiplier=1.0 so the
-      # behavior is byte-identical to the pre-M8.1-A code; on JRuby /
+      # behavior is byte-identical to the pre-multiplier code; on JRuby /
       # TruffleRuby the threshold is scaled up to absorb interpreter
       # overhead without requiring per-interpreter ratchet entries.
       threshold = base * multiplier

--- a/benchmark/scenarios/loaded_files_tracker.rb
+++ b/benchmark/scenarios/loaded_files_tracker.rb
@@ -2,7 +2,7 @@
 
 # Microbenchmark for RSpecTracer::Tracker::LoadedFilesTracker#stop_example.
 #
-# M3.7 AC: `stop_example` overhead stays <= 1 ms per example including
+# Contract: `stop_example` overhead stays <= 1 ms per example including
 # loaded-files attribution.
 #
 # Scenarios measured, all against an in-root fixture of FILE_COUNT Ruby

--- a/scripts/check_bundle_drift.rb
+++ b/scripts/check_bundle_drift.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 # Bundle-drift check: verify every Gemfile in the repo resolves
-# cleanly via a fresh `bundle install`. Closes the M2.1-M2.4
-# absorbed orphan "Proper lockfile-drift check for `task check:bundle`".
+# cleanly via a fresh `bundle install`. Closes a long-standing gap:
+# a proper lockfile-drift check for `task check:bundle`.
 #
 # Original framing was "diff against committed Gemfile.lock" but every
 # Gemfile.lock in this repo is gitignored (outer is library-style;

--- a/scripts/leak_check.rb
+++ b/scripts/leak_check.rb
@@ -1,0 +1,167 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Internal-nomenclature leak gate: scans every tracked file for
+# private planning vocabulary that must not ship in the public repo
+# (milestone tags, private note names, local-only doc-tree paths).
+#
+# Two passes:
+#   1. `git grep -nEI <pattern>` over all tracked files for the
+#      single-line patterns below.
+#   2. A split-rendering pass over tracked *.md files that catches
+#      directory-tree drawings where `docs/` and `revamp` land on
+#      neighboring lines (within 2 lines) and therefore dodge the
+#      single-line pattern.
+#
+# Exemptions live in .leakcheck-allow at the repo root: one path or
+# glob per line, each with a MANDATORY trailing `# justification`
+# comment. Entries without a justification fail the gate.
+#
+# CHANGELOG.md gets a section-scoped rule instead of a whole-path
+# exemption: everything above the first released-version heading
+# (the active [Unreleased] block, where new text lands) is scanned
+# with the full pattern set; only the shipped-history sections below
+# it are exempt, because released entries are frozen text that is
+# never rewritten retroactively.
+#
+# Run via: task docs:leak-check
+#
+# Exits 0 when clean, 1 on any unallowed hit or malformed allowlist.
+
+require 'open3'
+require 'pathname'
+
+ROOT = Pathname(File.expand_path('..', __dir__))
+ALLOWLIST_PATH = ROOT.join('.leakcheck-allow')
+
+# Single-line leak patterns, joined into one alternation for
+# `git grep -E`. This file is itself exempted in .leakcheck-allow:
+# the gate has to spell out the patterns it hunts.
+LEAK_PATTERN = [
+  'M[0-9]+\.[0-9]+(-[A-Z])?', # milestone tags from the private plan
+  'docs/revamp',              # local-only planning tree
+  'kickoff',                  # session-planning vocabulary
+  'feedback_[a-z_]+',         # private maintainer-note names
+  'personal-install',         # private distribution vocabulary
+  # Private bug/question/followup/criterion tags (B10, Q6, F4, C3).
+  # Word boundaries are spelled as character classes, NOT \b: BSD
+  # regex (git grep -E on macOS) has no \b, so a \b-based pattern
+  # silently matches nothing locally while GNU regex on Linux CI
+  # matches -- exactly the local/CI divergence this gate exists to
+  # prevent. `#` is excluded from the left boundary so CSS hex
+  # colors (e.g. #B00100 in fixture error pages) cannot match.
+  '(^|[^[:alnum:]_#])[BQFC][0-9]+([^[:alnum:]_]|$)'
+].join('|').freeze
+
+def load_allowlist
+  entries = []
+  errors = []
+  return [entries, errors] unless ALLOWLIST_PATH.file?
+
+  ALLOWLIST_PATH.each_line.with_index(1) do |line, lineno|
+    stripped = line.strip
+    next if stripped.empty? || stripped.start_with?('#')
+
+    match = stripped.match(/\A(?<glob>\S+)\s+#\s*\S.*\z/)
+    if match
+      entries << match[:glob]
+    else
+      errors << ".leakcheck-allow:#{lineno}: entry needs a trailing '# justification' comment: #{stripped}"
+    end
+  end
+  [entries, errors]
+end
+
+ALLOW, ALLOWLIST_ERRORS = load_allowlist
+
+def allowed?(path)
+  ALLOW.any? do |glob|
+    path == glob ||
+      path.start_with?("#{glob}/") ||
+      File.fnmatch?(glob, path, File::FNM_PATHNAME | File::FNM_DOTMATCH) ||
+      File.fnmatch?(glob, path, File::FNM_DOTMATCH)
+  end
+end
+
+CHANGELOG_PATH = 'CHANGELOG.md'
+
+# Line number (1-indexed) of the first released-version heading in
+# CHANGELOG.md, e.g. `## [2.0.0.pre.2] - 2026-05-16`. Everything
+# above it is the active [Unreleased] block and is scanned; the
+# heading and everything below it are frozen shipped-history text
+# and exempt. When no released heading exists yet, the whole file
+# is live and gets scanned.
+def changelog_frozen_from
+  @changelog_frozen_from ||= begin
+    changelog = ROOT.join(CHANGELOG_PATH)
+    # Explicit encoding + scrub: with no locale in the environment the
+    # default external encoding is US-ASCII, and match? raises on the
+    # changelog's UTF-8 punctuation.
+    lines = (File.foreach(changelog, encoding: 'UTF-8').map(&:scrub) if changelog.file?)
+    index = lines&.find_index { |line| line.match?(/\A##\s+\[\d/) }
+    index ? index + 1 : Float::INFINITY
+  end
+end
+
+def frozen_changelog_line?(path, lineno)
+  path == CHANGELOG_PATH && lineno >= changelog_frozen_from
+end
+
+def single_line_hits
+  out, err, status = Open3.capture3(
+    'git', 'grep', '-nEI', LEAK_PATTERN, '--', '.', chdir: ROOT.to_s
+  )
+  # git grep exits 0 on hits, 1 on no hits, >1 on real errors.
+  abort "leak-check: git grep failed (exit #{status.exitstatus}): #{err}" if status.exitstatus > 1
+
+  out.each_line.with_object([]) do |line, hits|
+    line = line.scrub
+    path, lineno, = line.split(':', 3)
+    next if allowed?(path) || frozen_changelog_line?(path, lineno.to_i)
+
+    hits << line.chomp
+  end
+end
+
+def tracked_markdown_files
+  out, err, status = Open3.capture3('git', 'ls-files', '--', '*.md', chdir: ROOT.to_s)
+  abort "leak-check: git ls-files failed (exit #{status.exitstatus}): #{err}" unless status.success?
+
+  out.split("\n")
+end
+
+# Catches directory-tree drawings that split the local-only doc tree
+# across lines, e.g. a `docs/` branch line followed by a `revamp/`
+# leaf line one or two lines below.
+def split_rendering_hits
+  tracked_markdown_files.each_with_object([]) do |file, hits|
+    next if allowed?(file)
+
+    hits.concat(split_rendering_hits_in(file))
+  end
+end
+
+def split_rendering_hits_in(file)
+  lines = File.readlines(ROOT.join(file), chomp: true, encoding: 'UTF-8').map(&:scrub)
+  lines.each_index.filter_map do |idx|
+    next if frozen_changelog_line?(file, idx + 1)
+    next unless lines[idx].include?('docs/')
+    next if lines[idx, 3].none? { |nearby| nearby.include?('revamp') }
+
+    "#{file}:#{idx + 1}: 'docs/' with 'revamp' within 2 lines (split tree rendering)"
+  end
+end
+
+failures = ALLOWLIST_ERRORS + single_line_hits + split_rendering_hits
+
+if failures.empty?
+  puts 'leak check clean: no internal nomenclature in tracked files.'
+  exit 0
+end
+
+warn "leak check found #{failures.length} unallowed hit(s):"
+failures.each { |failure| warn "  #{failure}" }
+warn ''
+warn 'Rewrite the text to be self-contained, or (only with a real'
+warn 'justification) add a path exemption to .leakcheck-allow.'
+exit 1

--- a/scripts/mine_ratchet_history.rb
+++ b/scripts/mine_ratchet_history.rb
@@ -17,7 +17,7 @@
 #      the multi-run baseline.
 #
 # Cutoff: only mine runs with head_sha at or after the perf-stable
-# cutoff (default: e574f6f, M8.4-A merge 2026-04-29). Earlier runs
+# cutoff (default: e574f6f, merged 2026-04-29). Earlier runs
 # represent different lib perf shape and would mis-calibrate.
 #
 # Usage:
@@ -40,7 +40,7 @@ require 'optparse'
 require 'time'
 require 'tmpdir'
 
-DEFAULT_CUTOFF_SHA = 'e574f6f' # M8.4-A merge — perf-stable baseline
+DEFAULT_CUTOFF_SHA = 'e574f6f' # perf-stable baseline merge
 DEFAULT_TARGET_RUNS = 30
 WORKFLOW_FILE = 'ci.yml'
 BENCHMARK_JOB_NAME = 'full-matrix / benchmark'

--- a/spec/cli/doctor_spec.rb
+++ b/spec/cli/doctor_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe RSpecTracer::CLI::Doctor do
     end
   end
 
-  # M8.9: doctor deepening - schema-version compat, remote-cache
+  # Deeper doctor checks - schema-version compat, remote-cache
   # backend reachability, and AR-schema narrow-attribution config
   # detection. Tests use focused stubs over the live RSpecTracer
   # module since the CLI dispatches against the global module.
-  describe '.cache_schema_version_check (M8.9)' do
+  describe '.cache_schema_version_check' do
     it 'returns INFO when no last_run.json exists yet' do
       Dir.mktmpdir do |dir|
         allow(RSpecTracer).to receive(:cache_path).and_return(dir)
@@ -125,7 +125,7 @@ RSpec.describe RSpecTracer::CLI::Doctor do
     end
   end
 
-  describe '.remote_cache_check (M8.9)' do
+  describe '.remote_cache_check' do
     it 'returns INFO when no remote_cache backend is configured' do
       allow(RSpecTracer).to receive(:respond_to?).and_call_original
       allow(RSpecTracer).to receive(:respond_to?).with(:remote_cache_backend_entry).and_return(true)
@@ -150,7 +150,7 @@ RSpec.describe RSpecTracer::CLI::Doctor do
     end
   end
 
-  describe '.ar_schema_narrow_attribution_check (M8.9)' do
+  describe '.ar_schema_narrow_attribution_check' do
     before do
       allow(RSpecTracer).to receive(:respond_to?).and_call_original
       allow(RSpecTracer).to receive(:respond_to?).with(:track_ar_schema_notifications?).and_return(true)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe RSpecTracer::Configuration do
 
   describe '#configure DSL wrapper' do
     # The DSL wrapper aliases every private setter to `_name`, then
-    # redefines the public name as a thin forwarder. Before M4.1 the
-    # forwarder stripped keyword arguments silently; M4.1 threads
-    # `**kwargs` through so `track_rails_defaults except: [:views]`
-    # (and the deferred M3.4/M3.8 `storage_backend` opts) work.
+    # redefines the public name as a thin forwarder. An early version
+    # of the forwarder stripped keyword arguments silently; it now
+    # threads `**kwargs` through so `track_rails_defaults except:
+    # [:views]` (and the `storage_backend` opts) work.
     it 'forwards keyword arguments through to the underlying setter' do
       params = described_class
         .instance_method(:track_rails_defaults)
@@ -32,7 +32,7 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
-  describe 'unknown DSL method handling (M8.9)' do
+  describe 'unknown DSL method handling' do
     # Typos in `.rspec-tracer` previously raised bare `NoMethodError`
     # with a Ruby backtrace. Now they raise `InvalidUsageError` with
     # a stdlib `DidYouMean` suggestion when the typo is close to a
@@ -701,7 +701,7 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
-  describe '#add_reporter / #reporters (M6.1)' do
+  describe '#add_reporter / #reporters' do
     before { require 'rspec_tracer/reporters/registry' }
 
     it 'returns nil for reporters when never configured' do
@@ -978,7 +978,7 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
-  describe '#cache_retention_local_count (M3.8)' do
+  describe '#cache_retention_local_count' do
     it 'defaults to DEFAULT_CACHE_RETENTION_LOCAL_COUNT when never set' do
       expect(config.cache_retention_local_count)
         .to eq(RSpecTracer::Configuration::DEFAULT_CACHE_RETENTION_LOCAL_COUNT)
@@ -1016,7 +1016,7 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
-  describe '#cache_size_warn_per_file_mb (M3.8)' do
+  describe '#cache_size_warn_per_file_mb' do
     it 'defaults to DEFAULT_CACHE_SIZE_WARN_PER_FILE_MB when never set' do
       expect(config.cache_size_warn_per_file_mb)
         .to eq(RSpecTracer::Configuration::DEFAULT_CACHE_SIZE_WARN_PER_FILE_MB)
@@ -1048,7 +1048,7 @@ RSpec.describe RSpecTracer::Configuration do
     end
   end
 
-  describe '#cache_size_warn_total_mb (M3.8)' do
+  describe '#cache_size_warn_total_mb' do
     it 'defaults to DEFAULT_CACHE_SIZE_WARN_TOTAL_MB when never set' do
       expect(config.cache_size_warn_total_mb)
         .to eq(RSpecTracer::Configuration::DEFAULT_CACHE_SIZE_WARN_TOTAL_MB)

--- a/spec/contracts/storage_backend.rb
+++ b/spec/contracts/storage_backend.rb
@@ -15,7 +15,7 @@ require 'rspec_tracer/storage/snapshot'
 #
 # New backends that break these assertions are not conformant even if
 # their own unit tests pass. The contract is behavioral, not
-# bytewise - SqliteBackend (M3.8) will include these same examples
+# bytewise - SqliteBackend includes these same examples
 # with a very different on-disk layout.
 # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
 RSpec.shared_examples 'a Storage::Backend' do

--- a/spec/edge_cases/cache_corruption_spec.rb
+++ b/spec/edge_cases/cache_corruption_spec.rb
@@ -20,7 +20,7 @@
 #     .sqlite3 file.
 #
 # JsonBackend :json property fuzz already lives at
-# spec/fuzz/json_backend_corruption_spec.rb (M3.4 1000-iter Rantly).
+# spec/fuzz/json_backend_corruption_spec.rb (1000-iter Rantly).
 # Not duplicated here - this spec extends the pattern, doesn't repeat
 # it.
 

--- a/spec/edge_cases/concurrent_write_spec.rb
+++ b/spec/edge_cases/concurrent_write_spec.rb
@@ -12,8 +12,8 @@
 #   - SqliteBackend: `BEGIN IMMEDIATE` acquires SQLite's RESERVED
 #     write lock. Without a busy_timeout configured, the second
 #     `BEGIN IMMEDIATE` returns SQLITE_BUSY immediately. The fix
-#     belongs in SqliteBackend's configure_connection (added in
-#     M8.2 alongside this spec).
+#     belongs in SqliteBackend's configure_connection (added
+#     alongside this spec).
 #
 # Children exit via `Process.exit!(0)` to bypass SimpleCov's
 # per-process at_exit hook, which forked children inherit. Without

--- a/spec/edge_cases/readonly_fs_spec.rb
+++ b/spec/edge_cases/readonly_fs_spec.rb
@@ -11,7 +11,7 @@
 #     cache_path. Reads work fine; the prior valid run stays
 #     loadable.
 #   - Engine integration (RSpecTracer.run_finalize): the rescue
-#     added in M8.2 logs + returns nil instead of propagating, so
+#     added alongside this spec logs + returns nil instead of propagating, so
 #     the at_exit pipeline downstream skips reports and the test
 #     suite exits cleanly.
 #

--- a/spec/edge_cases/symlink_spec.rb
+++ b/spec/edge_cases/symlink_spec.rb
@@ -4,7 +4,7 @@
 # path is a distinct entry in all_files / dependency from its
 # resolved target. The storage layer treats path strings as opaque
 # keys; resolution semantics live in Tracker::CoverageAdapter
-# (M3.1) and Tracker::DependencyGraph (M3.5). This spec asserts:
+# and Tracker::DependencyGraph. This spec asserts:
 #
 #   - Storage round-trip preserves symlink + target as two distinct
 #     all_files keys (the tracker's choice of which to record is

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe RSpecTracer::Engine do
       expect(snapshot.env_snapshot).to eq({})
     end
 
-    it 'persists env_dependency per example (M6.1 - reporter input)' do
+    it 'persists env_dependency per example (reporter input)' do
       tracker.register_tracks('ex1', files: Set.new, env: Set.new(%w[API_KEY ROLE]))
       tracker.register_tracks('ex2', files: Set.new, env: Set.new(['API_KEY']))
 
@@ -486,7 +486,7 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
-  describe 'examples_coverage finalize-time merge (M3.8 Part B)' do
+  describe 'examples_coverage finalize-time merge' do
     let(:previous_coverage) do
       { 'prev_only' => { '/lib/a.rb' => { '0' => 1, '1' => 2 } },
         'overwritten' => { '/lib/a.rb' => { '0' => 9 } } }
@@ -548,7 +548,7 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
-  describe '#register_tracks (M5.2 DSL hook)' do
+  describe '#register_tracks (DSL hook)' do
     subject(:tracker) { build_tracker.tap(&:setup) }
 
     it 'adds declared-kind inputs for each tracked glob to the example dep set' do
@@ -591,7 +591,7 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
-  describe '#apply_env_filter_decisions (M5.2)' do
+  describe '#apply_env_filter_decisions' do
     let(:prev_cache_path) { File.join(tmp_base, 'cache') }
     # Pre-seed wsi_snapshot with a digest matching the current project's
     # WholeSuiteInvalidators output so the engine's whole_suite_changed?
@@ -677,7 +677,7 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
-  describe 'M5.3 config-level track_env DSL' do
+  describe 'config-level track_env DSL' do
     let(:prev_cache_path) { File.join(tmp_base, 'cache') }
     let(:current_wsi) do
       RSpecTracer::Tracker::WholeSuiteInvalidators.new(root: root).digest_snapshot
@@ -805,7 +805,7 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
-  describe 'M5.3 per-example wildcard expansion' do
+  describe 'per-example wildcard expansion' do
     subject(:tracker) { build_tracker.tap(&:setup) }
 
     it 'expands wildcard patterns in tracks: { env: ... } against the live ENV' do
@@ -1222,13 +1222,13 @@ RSpec.describe RSpecTracer::Engine do
     end
   end
 
-  # M8.0 acceptance criterion #4: per-example hot path invokes
+  # Hot-path contract: per-example flow invokes
   # ::Coverage.peek_result exactly twice (once at example_started for
   # the baseline, once at example_finished for the diff). The legacy
   # CoverageReporter previously double-peeked via reporter_hook.rb's
-  # record_coverage / compute_diff calls; M8.0's retirement reduces
+  # record_coverage / compute_diff calls; its retirement reduces
   # the per-example peek count from 4 to 2.
-  describe '#example_started + #example_finished peek count (M8.0 AC #4)' do
+  describe '#example_started + #example_finished peek count' do
     it 'invokes ::Coverage.peek_result exactly twice across one example lifecycle' do
       tracker = build_tracker.tap(&:setup)
       allow(Coverage).to receive(:peek_result).and_return({})

--- a/spec/fixtures/rails_app/.gitignore
+++ b/spec/fixtures/rails_app/.gitignore
@@ -17,7 +17,7 @@
 /db/*.sqlite3
 /db/*.sqlite3-*
 
-# SimpleCov + rspec-tracer artefacts. Populated by the M4.3
+# SimpleCov + rspec-tracer artefacts. Populated by the
 # integration matrix (RSPEC_TRACER=1 runs) + the cold_rails_v2
 # benchmark scenario; never hand-committed.
 /coverage/

--- a/spec/fixtures/rails_app/.rspec-tracer
+++ b/spec/fixtures/rails_app/.rspec-tracer
@@ -1,12 +1,12 @@
 # rspec-tracer configuration for the reference Rails 7.2+ fixture.
-# M4.3 integration matrix runs this fixture under rspec-tracer and
+# The integration matrix runs this fixture under rspec-tracer and
 # asserts the behavior matrix from docs. The :views and :schema
 # opt-outs plus `track_ar_schema_notifications` are what drive the
 # narrower "only renderers" / "only DB-touchers" semantics the
 # behavior-matrix scenarios require:
 #
-#   :views    - dropped from declared-globs; ActionView notifications
-#               (M4.2 subscribers) emit :template Inputs per rendered
+#   :views    - dropped from declared-globs; ActionView notification
+#               subscribers emit :template Inputs per rendered
 #               template, so a template edit re-runs only the examples
 #               that actually rendered it.
 #   :schema   - dropped from declared-globs; the sql.active_record
@@ -18,8 +18,8 @@
 #
 # :locales, :fixtures, :factories, :helpers, :config stay in the
 # declared-glob set - their edits fall back to the coarse-safe
-# whole-suite path, which is the conservative default until M5.2's
-# per-example metadata DSL ships.
+# whole-suite path, which is the conservative default unless the
+# per-example metadata DSL narrows it.
 RSpecTracer.configure do
   track_rails_defaults except: [:views, :schema]
   track_ar_schema_notifications

--- a/spec/fixtures/rails_app/app/services/editorial_checker.rb
+++ b/spec/fixtures/rails_app/app/services/editorial_checker.rb
@@ -44,7 +44,7 @@ class EditorialChecker
   end
   # The IO.read blind-spot variant (distinct from File.read under 2.0's
   # prepend-hook architecture) is exercised in tracker unit specs
-  # (M3.2 territory), not here. CodeQL's taint tracker flags any
+  # (tracker territory), not here. CodeQL's taint tracker flags any
   # IO.read whose arg derives from Rails.root, even through a frozen
   # constant — noisy in fixture code that exists precisely to cross
   # those patterns.

--- a/spec/fixtures/rails_app/spec/fixture_consumer_spec.rb
+++ b/spec/fixtures/rails_app/spec/fixture_consumer_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-# Anchor spec for the M4.3 behavior-matrix row
+# Anchor spec for the behavior-matrix row
 # "spec/fixtures/users.yml → only fixture-using examples." The fixture's
 # other specs rely on FactoryBot rather than AR fixtures, so without
 # this spec no example would have users.yml in its dependency set and

--- a/spec/fixtures/rails_app/spec/narrow_schema_spec.rb
+++ b/spec/fixtures/rails_app/spec/narrow_schema_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-# M8.2-B narrow-AR-schema fixture spec. Two examples:
+# Narrow-AR-schema fixture spec. Two examples:
 #   - one issues an AR query (User.create!) so the sql.active_record
 #     subscriber fires and rspec-tracer's record_ar_schema attributes
 #     `db/schema.rb` to this example_id;
@@ -18,7 +18,7 @@ RSpec.describe "narrow AR schema attribution" do
   it "creates a user (touches AR)" do
     # Time-suffixed email so re-runs under non-transactional fixtures
     # don't collide on the email uniqueness index even without
-    # DatabaseCleaner. (DatabaseCleaner was tried in M8.2-B and rejected:
+    # DatabaseCleaner. (DatabaseCleaner was tried here and rejected:
     # its TRUNCATE / DELETE queries fire inside the per-example bucket,
     # which then attributes db/schema.rb to *every* example via the
     # sql.active_record subscriber - completely defeating the test of

--- a/spec/fixtures/rails_app/spec/rails_helper.rb
+++ b/spec/fixtures/rails_app/spec/rails_helper.rb
@@ -3,7 +3,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 
 # Enable rspec-tracer for this fixture when RSPEC_TRACER=1 is set (the
-# M4.3 integration matrix + the benchmark harness cold_rails_v2 both
+# integration matrix + the benchmark harness cold_rails_v2 both
 # flip this on). Load order matters:
 #
 #   1. SimpleCov.start (Coverage.start) BEFORE Rails loads, so every
@@ -75,7 +75,7 @@ RSpec.configure do |config|
   end
 
   # Default: transactional fixtures on (matches Rails idiomatic test
-  # setup; covered by `task test:features:rails`). When the M8.2-B
+  # setup; covered by `task test:features:rails`). When the
   # narrow-AR-schema scenario flips RSPEC_TRACER_RAILS_TRANSACTIONAL=false,
   # each example commits its writes to the test DB and the per-example
   # schema-subscriber attribution path (Tracker::Notifications) becomes

--- a/spec/fixtures/rails_app/spec/services/feature_flags_spec.rb
+++ b/spec/fixtures/rails_app/spec/services/feature_flags_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe FeatureFlags do
     end
   end
 
-  # M5.2 per-example DSL: this describe's examples depend on the
+  # Per-example DSL: this describe's examples depend on the
   # `RAILS_APP_FORCE_REVIEW` env var (via FeatureFlags#require_review?)
   # — invisible to Coverage / IO observation because the env read
   # happens inside pure Ruby. Declaring `tracks: { env: ... }` teaches
@@ -97,14 +97,14 @@ RSpec.describe FeatureFlags do
     end
   end
 
-  # M5.3 per-example wildcard DSL: same env-branch blind spot as the
-  # M5.2 describe above, but the tracks declaration is `RAILS_APP_*`
+  # Per-example wildcard DSL: same env-branch blind spot as the
+  # literal-tracks describe above, but the declaration is `RAILS_APP_*`
   # (wildcard) rather than the literal name. EnvMatcher.expand resolves
   # the pattern at register_tracks time; the persisted env_snapshot
   # carries the concrete `RAILS_APP_FORCE_REVIEW` key (no wildcard
   # leak). The integration spec at spec/integration/per_example_dsl_spec.rb
   # asserts these examples re-run when RAILS_APP_FORCE_REVIEW flips.
-  describe '.require_review? wildcard exercise (M5.3)',
+  describe '.require_review? wildcard exercise',
            tracks: { env: 'RAILS_APP_*' } do
     around do |example|
       before = ENV['RAILS_APP_FORCE_REVIEW']

--- a/spec/fixtures/rails_app/spec/wide_schema_spec.rb
+++ b/spec/fixtures/rails_app/spec/wide_schema_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-# M9.0 wide-AR-schema fixture spec. Three AR-touching examples + one
+# Wide-AR-schema fixture spec. Three AR-touching examples + one
 # pure-compute example designed to exercise the SAFE-BUT-WIDE schema
 # attribution under common Rails AR-cleanup setups (transactional
 # fixtures = true OR DatabaseCleaner :truncation / :deletion /

--- a/spec/fuzz/README.md
+++ b/spec/fuzz/README.md
@@ -31,9 +31,9 @@ Every run prints the PRNG seed. To replay:
 | `coverage_adapter_fuzz.rb` | `Tracker::CoverageAdapter#compute_diff` against pathological coverage maps — mixed nil / huge counts / negative ints / Hash vs Array shapes / mode flips. |
 
 `json_backend_fuzz.rb` stays focused on the `:json` decode path; it is
-the historical harness from M2.5 and runs with the highest iteration
+the original harness and runs with the highest iteration
 budget per backend. `cache_loader_fuzz.rb` extends fuzz coverage to
-the post-M3.8 backend surface (msgpack + sqlite). `coverage_adapter_fuzz.rb`
+the full backend surface (msgpack + sqlite). `coverage_adapter_fuzz.rb`
 broadens beyond storage into the tracker hot path - exercises
 `compute_diff`'s nil-tolerant + length-divergent branches that load_graph
 fuzz cannot reach.

--- a/spec/fuzz/json_backend_corruption_spec.rb
+++ b/spec/fuzz/json_backend_corruption_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # Fuzz-style spec proving the storage load path is crash-proof under
-# arbitrary byte corruption. 1000 iterations per the M3.4 acceptance
-# criterion.
+# arbitrary byte corruption. 1000 iterations per the original
+# acceptance criterion.
 #
 # Runs as RSpec (not a standalone harness like the legacy
 # `spec/fuzz/cache_loader_fuzz.rb`) so it lands in `task test:property`

--- a/spec/fuzz/json_backend_fuzz.rb
+++ b/spec/fuzz/json_backend_fuzz.rb
@@ -11,9 +11,9 @@
 # byte inputs. Any escape that isn't the expected nil / Snapshot pair
 # is a failure mode worth investigating.
 #
-# Replaces the pre-M5.1 `cache_loader_fuzz.rb` which targeted
+# Replaces an earlier `cache_loader_fuzz.rb` which targeted
 # `RSpecTracer::Cache#load_all_examples_cache` (retired with the
-# legacy reporter stack in M6.2).
+# legacy reporter stack).
 #
 # Usage:
 #   ITERATIONS=100   bundle exec ruby spec/fuzz/json_backend_fuzz.rb

--- a/spec/integration/constants_regression_spec.rb
+++ b/spec/integration/constants_regression_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Regression spec for KNOWN_ISSUES B10: the constants-lookup blind spot
-# in the diff-based coverage model.
+# Regression spec for the constants-lookup blind spot in the
+# diff-based coverage model.
 #
 # Scenario
 # --------
@@ -23,8 +23,9 @@
 #
 # Drives the pipeline in-process (LoadedFilesTracker + DependencyGraph +
 # ExampleRegistry + Filter) with a stubbed peek. The full end-to-end
-# test (subprocess + Open3 against a real fixture) waits for M3.6,
-# where Tracker.setup exists to orchestrate the observers.
+# test (subprocess + Open3 against a real fixture) lives in
+# spec/integration/ruby_app_spec.rb, where Tracker.setup
+# orchestrates the observers.
 require 'fileutils'
 require 'set'
 require 'tmpdir'
@@ -36,7 +37,7 @@ require 'rspec_tracer/tracker/loaded_files_tracker'
 # Composition scenarios operate on whole pipelines; splitting to
 # satisfy metric cops scatters the narrative.
 # rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength
-RSpec.describe 'constants regression (KNOWN_ISSUES B10)' do
+RSpec.describe 'constants-lookup blind-spot regression' do
   let(:tmp_base) { Dir.mktmpdir }
   let(:root) { File.join(tmp_base, 'project').tap { |p| FileUtils.mkdir_p(p) } }
 
@@ -66,7 +67,7 @@ RSpec.describe 'constants regression (KNOWN_ISSUES B10)' do
     )
   end
 
-  # Simulates what M3.6 will wire: at start_example time, the caller
+  # Simulates what the engine wires in production: at start_example time, the caller
   # snapshots loaded_set_inputs; at stop_example time, stop_example's
   # return value is the delta; union is the example's Input set.
   def simulate_run(tracker)
@@ -141,7 +142,7 @@ RSpec.describe 'constants regression (KNOWN_ISSUES B10)' do
       expect(graph.paths_for('ex_reader')).not_to include(constants_path)
     end
 
-    it 'Filter skips ex_reader when only constants.rb changes (the B10 blind spot)' do
+    it 'Filter skips ex_reader when only constants.rb changes (the constants blind spot)' do
       tracker = build_tracker(enabled: false)
       graph, registry = simulate_run(tracker)
       result = filter_result(graph, registry, change_set: Set[constants_path])

--- a/spec/integration/coverage_json_round_trip_spec.rb
+++ b/spec/integration/coverage_json_round_trip_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M8.0 byte-equivalence assertion: the post-retirement
+# Byte-equivalence assertion: the post-retirement
 # Reporters::CoverageJsonReporter must produce coverage.json that
 # matches the pre-retirement legacy CoverageReporter / CoverageWriter
 # output (byte-for-byte modulo the per-run timestamp + machine-local
@@ -78,7 +78,7 @@ RSpec.describe 'coverage.json byte-equivalence round-trip vs golden' do
         "#{JSON.pretty_generate(RSpecTracer: { coverage: actual_relativized, timestamp: 0 })}\n",
         encoding: 'UTF-8'
       )
-      warn "[M8.0 golden capture] wrote #{actual_relativized.size} keys -> #{golden_path}"
+      warn "[coverage.json golden capture] wrote #{actual_relativized.size} keys -> #{golden_path}"
       next
     end
 
@@ -87,7 +87,7 @@ RSpec.describe 'coverage.json byte-equivalence round-trip vs golden' do
     expect(actual_payload['RSpecTracer']['timestamp']).to be_a(Integer)
     expect(actual_relativized).not_to be_empty
     if actual_relativized != golden_payload['RSpecTracer']['coverage']
-      warn "[M8.0 round-trip diff debug] inner rspec output:\n#{@rspec_out}"
+      warn "[coverage.json round-trip diff debug] inner rspec output:\n#{@rspec_out}"
     end
     expect(actual_relativized).to eq(golden_payload['RSpecTracer']['coverage'])
   end

--- a/spec/integration/dogfood_spec.rb
+++ b/spec/integration/dogfood_spec.rb
@@ -5,9 +5,9 @@
 # cold-then-warm behaviour. This is the "our gem runs our gem's tests"
 # smoke test — the ultimate integration check.
 #
-# Reuses `benchmark/fixtures/ruby_app/`: M2.4 already built a self-
-# contained fixture with tracer wired in, so M2.5 points at it rather
-# than duplicating the same 3 app files + 3 spec files under
+# Reuses `benchmark/fixtures/ruby_app/`: the benchmark work already
+# built a self-contained fixture with tracer wired in, so this spec
+# points at it rather than duplicating the same 3 app files + 3 spec files under
 # `spec/fixtures/`.
 
 require 'bundler'

--- a/spec/integration/leak_check_spec.rb
+++ b/spec/integration/leak_check_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'open3'
+require 'pathname'
+require 'tmpdir'
+
+# Verifies the contract of `task docs:leak-check`
+# (scripts/leak_check.rb): exit zero on a clean tree, non-zero on a
+# leaked internal-nomenclature token, and -- the CHANGELOG-specific
+# section rule -- non-zero on a leak in the active [Unreleased]
+# block while shipped-history sections below the first
+# released-version heading stay exempt.
+#
+# The script resolves its repo root relative to its own location, so
+# each example copies it into a throwaway git repo and runs it
+# there; the real repo's allowlist and content never interfere.
+#
+# The leak tokens planted in fixture files are built with string
+# interpolation (never written literally) so this spec file itself
+# stays clean under the real gate's scan.
+#
+# rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe 'scripts/leak_check.rb' do
+  # A milestone-style tag, assembled so the literal never appears in
+  # this file: "M" + digits + "." + digits.
+  let(:major) { 4 }
+  let(:minor) { 2 }
+  let(:milestone_token) { "M#{major}.#{minor}" }
+
+  let(:script) { Pathname(__dir__).join('../../scripts/leak_check.rb').expand_path }
+
+  let(:allowlist) do
+    "scripts/leak_check.rb  # gate implementation; spells out the patterns it scans for\n"
+  end
+
+  # Suppress git background maintenance in the throwaway repo:
+  # transient maintenance files (commit-graph, bitmap ref tips) race
+  # with Dir.mktmpdir cleanup and raise ENOENT/ENOTEMPTY.
+  def git_quiet_config
+    %w[
+      -c gc.auto=0 -c maintenance.auto=false
+      -c core.commitGraph=false -c pack.writeBitmaps=false
+    ]
+  end
+
+  def build_repo(dir, files)
+    root = Pathname(dir)
+    root.join('scripts').mkpath
+    FileUtils.cp(script, root.join('scripts/leak_check.rb'))
+    files.each do |path, content|
+      target = root.join(path)
+      target.dirname.mkpath
+      target.write(content)
+    end
+    system('git', *git_quiet_config, 'init', '-q', chdir: dir) or raise 'git init failed'
+    system('git', *git_quiet_config, 'add', '-A', chdir: dir) or raise 'git add failed'
+    root
+  end
+
+  def run_gate(dir, files)
+    root = build_repo(dir, files)
+    Open3.capture2e('ruby', root.join('scripts/leak_check.rb').to_s)
+  end
+
+  around do |example|
+    Dir.mktmpdir do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  attr_reader :tmpdir
+
+  it 'exits zero on a clean tree' do
+    output, status = run_gate(tmpdir, {
+                                '.leakcheck-allow' => allowlist,
+                                'README.md' => "A clean readme.\n"
+                              })
+
+    expect(status.exitstatus).to eq(0), "expected clean gate; got:\n#{output}"
+    expect(output).to include('leak check clean')
+  end
+
+  it 'fails on a leaked token in an ordinary tracked file' do
+    output, status = run_gate(tmpdir, {
+                                '.leakcheck-allow' => allowlist,
+                                'README.md' => "Shipped in #{milestone_token}.\n"
+                              })
+
+    expect(status.exitstatus).to eq(1)
+    expect(output).to include('README.md:1')
+  end
+
+  it 'fails on a leak in the CHANGELOG [Unreleased] block' do
+    changelog = <<~MD
+      ## [Unreleased]
+
+      - New thing (#{milestone_token}).
+
+      ## [1.0.0] - 2021-10-21
+
+      - Old release notes.
+    MD
+    output, status = run_gate(tmpdir, {
+                                '.leakcheck-allow' => allowlist,
+                                'CHANGELOG.md' => changelog
+                              })
+
+    expect(status.exitstatus).to eq(1)
+    expect(output).to include('CHANGELOG.md:3')
+  end
+
+  it 'exempts shipped-history sections below the first released heading' do
+    changelog = <<~MD
+      ## [Unreleased]
+
+      - Nothing yet.
+
+      ## [1.0.0] - 2021-10-21
+
+      - Old release notes mentioning #{milestone_token}.
+    MD
+    output, status = run_gate(tmpdir, {
+                                '.leakcheck-allow' => allowlist,
+                                'CHANGELOG.md' => changelog
+                              })
+
+    expect(status.exitstatus).to eq(0), "expected frozen history exempt; got:\n#{output}"
+  end
+
+  it 'fails on an allowlist entry without a justification comment' do
+    output, status = run_gate(tmpdir, {
+                                '.leakcheck-allow' => "#{allowlist}README.md\n",
+                                'README.md' => "A clean readme.\n"
+                              })
+
+    expect(status.exitstatus).to eq(1)
+    expect(output).to include("needs a trailing '# justification' comment")
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/MultipleExpectations
+# rubocop:enable RSpec/ExampleLength

--- a/spec/integration/narrow_ar_schema_spec.rb
+++ b/spec/integration/narrow_ar_schema_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# M8.2-B narrow-AR-schema integration spec. Drives the rails fixture
+# Narrow-AR-schema integration spec. Drives the rails fixture
 # (spec/fixtures/rails_app/spec/narrow_schema_spec.rb) under
-# RSPEC_TRACER_RAILS_TRANSACTIONAL=false (M8.2-shipped env toggle in
+# RSPEC_TRACER_RAILS_TRANSACTIONAL=false (env toggle in
 # the fixture rails_helper.rb). With transactional fixtures off,
 # rspec-tracer's per-example schema-subscriber attribution path
 # (lib/rspec_tracer/rails/notifications.rb #record_ar_schema) becomes
@@ -23,12 +23,12 @@
 #
 # Per-example commit cleanup: sequence-based unique factories
 # (Time.now.to_f + pid suffix on User.email). DatabaseCleaner was
-# rejected in M8.2-B because its TRUNCATE / DELETE queries fire
+# rejected because its TRUNCATE / DELETE queries fire
 # sql.active_record events INSIDE the per-example bucket, which
 # would attribute db/schema.rb to every example via the subscriber -
-# defeating the very narrow-attribution behavior under test. Decision
-# revised from kickoff (d-i DatabaseCleaner) to (d-ii sequence
-# factories) once empirical evidence showed (d-i) was incompatible.
+# defeating the very narrow-attribution behavior under test. The
+# original DatabaseCleaner plan was revised to sequence factories
+# once empirical evidence showed it was incompatible.
 
 require 'bundler'
 require 'open3'
@@ -47,12 +47,12 @@ module NarrowArSchemaSpecHelpers
   }.freeze
   # See rails_app_spec.rb's SUBPROCESS_BUNDLE_ENV for rationale —
   # BUNDLE_FROZEN skips per-`bundle exec` lockfile resolve in the
-  # subprocess. Matches the M8.6-B Lever 2 pattern.
+  # subprocess. Matches rails_app_spec.rb's pattern.
   SUBPROCESS_BUNDLE_ENV = { 'BUNDLE_FROZEN' => '1' }.freeze
   NARROW_SPEC = 'spec/narrow_schema_spec.rb'
   SCHEMA_FILE_NAME = '/db/schema.rb'
 
-  MUTATION_MARKER = "\n# rspec-tracer M8.2-B narrow-schema mutation marker\n"
+  MUTATION_MARKER = "\n# rspec-tracer narrow-schema mutation marker\n"
 
   module_function
 

--- a/spec/integration/non_git_repo_spec.rb
+++ b/spec/integration/non_git_repo_spec.rb
@@ -7,7 +7,7 @@ require 'json'
 require 'open3'
 require 'tmpdir'
 
-# M8.10: rspec-tracer in a non-git directory (graceful degradation).
+# rspec-tracer in a non-git directory (graceful degradation).
 #
 # Real-world scenarios where this happens:
 #   - User runs rspec in a tarball-extracted source dir.
@@ -30,7 +30,7 @@ require 'tmpdir'
 # parent directory; verifies the run produces a usable cache.
 #
 # rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength
-RSpec.describe 'rspec-tracer in a non-git working directory (M8.10)' do
+RSpec.describe 'rspec-tracer in a non-git working directory' do
   let(:project_root) { File.expand_path('../..', __dir__) }
   let(:gemfile_path) { File.join(project_root, 'Gemfile') }
 

--- a/spec/integration/parallel_tests_spec.rb
+++ b/spec/integration/parallel_tests_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# End-to-end integration for parallel_tests + the M5.1 hook rework.
+# End-to-end integration for parallel_tests + the v2 hook chain.
 # Drives the benchmark ruby_app fixture via `parallel_rspec spec` in a
 # subprocess, then asserts that:
 #
@@ -10,7 +10,7 @@
 #     all example ids the workers observed (union-of-peers merge)
 #   - the lock file is cleaned up after the last worker finishes
 #   - a warm run produces a zero-re-run filter decision
-#     (M4.3-style filter assertion, not just exit status)
+#     (filter-decision assertion, not just exit status)
 #
 # Depends on the `parallel_tests` gem being in the fixture's Gemfile.
 
@@ -20,8 +20,8 @@ require 'json'
 require 'open3'
 require 'set'
 
-# Module-scoped fixture constants + helpers (mirrors RailsAppSpecHelpers
-# from M4.3). Keeps `let` out of the before(:all) hook that installs the
+# Module-scoped fixture constants + helpers (mirrors
+# RailsAppSpecHelpers from rails_app_spec.rb). Keeps `let` out of the before(:all) hook that installs the
 # fixture's bundle - RSpec disallows memoized accessors there.
 module ParallelTestsSpecHelpers
   FIXTURE_ROOT = File.expand_path('../../benchmark/fixtures/ruby_app', __dir__)
@@ -117,14 +117,14 @@ RSpec.describe 'parallel_tests v2 engine integration' do
       expect(all_examples.keys.size).to be >= 3
     end
 
-    # M8.10: pre-fix, every worker emitted reports into per-worker
+    # Pre-fix, every worker emitted reports into per-worker
     # `parallel_tests_N` dirs and then `purge_worker_dirs!` deleted
     # them, leaving zero usable output for the user. Now the
     # last-process merge emits reporters ONCE at the top-level
     # location BEFORE the purge, so the user sees one HTML report,
     # one JSON report, and zero leftover per-worker report dirs.
     # rubocop:disable RSpec/ExampleLength
-    it 'writes a single merged HTML + JSON report at the top-level report dir (M8.10)' do
+    it 'writes a single merged HTML + JSON report at the top-level report dir' do
       run_parallel
 
       report_root = ParallelTestsSpecHelpers::REPORT_ROOT

--- a/spec/integration/per_example_dsl_spec.rb
+++ b/spec/integration/per_example_dsl_spec.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-# M5.2 end-to-end integration for the per-example `tracks:` DSL.
+# End-to-end integration for the per-example `tracks:` DSL.
 # Drives the reference Rails fixture at `spec/fixtures/rails_app/`
 # via subprocess RSpec. The fixture's feature_flags_spec declares
 # `tracks: { env: 'RAILS_APP_FORCE_REVIEW' }` on the
 # `.require_review?` describe block (an ENV-branch blind spot that
 # Coverage / IO observation cannot see).
 #
-# Assertion philosophy matches M4.3's behavior-matrix pattern:
+# Assertion philosophy matches rails_app_spec.rb's behavior-matrix pattern:
 # assert on the set of examples that re-ran on warm (all_examples
 # minus skipped_examples), not just exit status. An env mutation
 # between cold and warm must re-run exactly the three
@@ -79,7 +79,7 @@ module PerExampleDslSpecHelpers
     ]
   end
 
-  # M5.3 wildcard exercise: the same fixture spec also has a separate
+  # Wildcard exercise: the same fixture spec also has a separate
   # describe with `tracks: { env: 'RAILS_APP_*' }`. Its two examples
   # depend on RAILS_APP_FORCE_REVIEW via the wildcard expansion path,
   # not the literal name path.
@@ -112,7 +112,7 @@ end
 
 # rubocop:disable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/InstanceVariable
 # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
-RSpec.describe 'M5.2 per-example tracks DSL integration' do
+RSpec.describe 'per-example tracks DSL integration' do
   include PerExampleDslSpecHelpers
 
   before(:all) do
@@ -158,8 +158,8 @@ RSpec.describe 'M5.2 per-example tracks DSL integration' do
                                                "expected 3 env-branch examples, got #{@expected_env_branch_ids.size}"
     end
 
-    # M5.3: re-run set is the union of M5.2's literal-tracks describe
-    # (3 examples) + M5.3's wildcard-tracks describe (2 examples). Both
+    # The re-run set is the union of the literal-tracks describe
+    # (3 examples) + the wildcard-tracks describe (2 examples). Both
     # depend on RAILS_APP_FORCE_REVIEW; the wildcard `RAILS_APP_*`
     # expands to the same concrete env name at register_tracks time.
     it 're-runs exactly the literal + wildcard env-branch examples, skipping everything else' do

--- a/spec/integration/rails_app_spec.rb
+++ b/spec/integration/rails_app_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M4.3 behavior-matrix integration test. Drives the reference Rails
+# Behavior-matrix integration test. Drives the reference Rails
 # fixture at `spec/fixtures/rails_app/` via subprocess RSpec runs
 # with rspec-tracer's v2 engine enabled, then mutates specific files
 # and asserts which examples the filter re-runs on the next warm run.
@@ -39,8 +39,8 @@ module RailsAppSpecHelpers
   # before any subprocess fires.
   SUBPROCESS_BUNDLE_ENV = { 'BUNDLE_FROZEN' => '1' }.freeze
 
-  MUTATION_MARKER = "\n# rspec-tracer M4.3 behavior-matrix mutation marker\n"
-  MUTATION_MARKER_VIEW = "\n<!-- rspec-tracer M4.3 behavior-matrix mutation marker -->\n"
+  MUTATION_MARKER = "\n# rspec-tracer behavior-matrix mutation marker\n"
+  MUTATION_MARKER_VIEW = "\n<!-- rspec-tracer behavior-matrix mutation marker -->\n"
 
   module_function
 
@@ -74,7 +74,7 @@ RSpec.describe 'rails_app behavior matrix' do
     @show_erb_renderers = reverse_deps.fetch('/app/views/users/show.html.erb', []).to_set
     raise 'expected show.html.erb to have cold renderers' if @show_erb_renderers.empty?
 
-    # M9.0: wide_schema_spec.rb's pure-compute describe sets
+    # wide_schema_spec.rb's pure-compute describe sets
     # `self.use_transactional_tests = false` and skips the
     # :db_cleaned around hook, so its example fires no
     # sql.active_record events and db/schema.rb is NOT in its
@@ -135,9 +135,9 @@ RSpec.describe 'rails_app behavior matrix' do
       mutate('app/models/user.rb') do
         result = warm_run
         # user.rb is pulled into every example's @loaded_set after the
-        # first factory/query fires, so the M3.7 transitive-load path
-        # attributes it broadly. Per-example narrowing waits for
-        # M5.2's `tracks:` DSL.
+        # first factory/query fires, so the transitive-load path
+        # attributes it broadly. Per-example narrowing is what the
+        # `tracks:` DSL is for.
         expect(result[:re_run].size).to be >= (all_example_ids.size * 0.9).to_i
       end
     end
@@ -170,7 +170,7 @@ RSpec.describe 'rails_app behavior matrix' do
         # use_transactional_fixtures wraps every example in an AR
         # transaction; the sql.active_record subscriber emits
         # schema.rb for every example on first query. The
-        # M9.0 wide_schema_spec.rb pure-compute describe explicitly
+        # wide_schema_spec.rb pure-compute describe explicitly
         # opts out of transactional fixtures + the :db_cleaned around
         # hook, so its example genuinely doesn't depend on the
         # schema and isn't re-run on schema mutation. Asserting
@@ -236,7 +236,7 @@ RSpec.describe 'rails_app behavior matrix' do
     it 'triggers zero re-runs (:views is not declared; NewFileDetector does not flag the add)' do
       new_template = File.join(FixtureBundleHelper::FIXTURE_ROOT, 'app/views/users/_m43_new.html.erb')
       begin
-        File.write(new_template, "<span class=\"m43\">M4.3 new template</span>\n")
+        File.write(new_template, "<span class=\"m43\">new template</span>\n")
         result = warm_run
         expect(result[:re_run]).to(be_empty, -> { diff_message(expected: Set.new, actual: result[:re_run]) })
       ensure

--- a/spec/integration/remote_cache_local_fs_spec.rb
+++ b/spec/integration/remote_cache_local_fs_spec.rb
@@ -9,13 +9,13 @@ require 'tmpdir'
 require 'rspec_tracer/remote_cache/local_fs_backend'
 require 'rspec_tracer/storage/schema'
 
-# M8.10: Local-FS remote-cache integration spec.
+# Local-FS remote-cache integration spec.
 #
 # Mirrors `spec/integration/remote_cache_spec.rb`'s S3Backend
 # round-trip shape against a tmpdir-backed Local-FS root. The S3 +
 # Redis backends had integration coverage; LocalFs only had unit
-# tests in `spec/remote_cache/local_fs_backend_spec.rb` until M8.10
-# closed the parity gap.
+# tests in `spec/remote_cache/local_fs_backend_spec.rb` until this
+# spec closed the parity gap.
 #
 # Asserts on the content of what was uploaded / downloaded
 # (exit-status checks mask cache-persistence bugs; only content
@@ -26,7 +26,7 @@ require 'rspec_tracer/storage/schema'
 # rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable
 # rubocop:disable RSpec/BeforeAfterAll, RSpec/MultipleExpectations
 # rubocop:disable RSpec/ExampleLength
-RSpec.describe 'RemoteCache::LocalFsBackend round-trip integration (M8.10)' do
+RSpec.describe 'RemoteCache::LocalFsBackend round-trip integration' do
   let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
 
   before(:all) do

--- a/spec/integration/remote_cache_spec.rb
+++ b/spec/integration/remote_cache_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe 'RemoteCache::S3Backend against LocalStack', :integration, :local
     end
   end
 
-  describe 'B8 fix: TEST_SUITE_ID alone is valid' do
+  describe 'regression: TEST_SUITE_ID alone is valid' do
     it 'scopes uploads under <ref>/<test_suite_id>/ when TEST_SUITE_ID is set without TEST_SUITES' do
       backend = build_backend(branch: 'main', default_branch: 'main', test_suite_id: '3')
       write_local_cache(run_id: 'run-suite-3')
@@ -231,7 +231,7 @@ RSpec.describe 'RemoteCache::S3Backend against LocalStack', :integration, :local
     end
   end
 
-  # M8.4-B tree-SHA secondary index: rebase + revert commits produce
+  # Tree-SHA secondary index: rebase + revert commits produce
   # a different commit-SHA but the SAME tree-SHA. The standard
   # `<tier>/<ref>/cache.tar.gz` layout misses on those scenarios; the
   # tree-SHA pointer at `<tier>/by_tree/<tree_sha>` resolves the tree
@@ -300,7 +300,7 @@ RSpec.describe 'RemoteCache::S3Backend against LocalStack', :integration, :local
       backend = build_backend(branch: 'main', default_branch: 'main', prefix: prefix)
       write_local_cache(run_id: 'run-tree-4')
 
-      # No tree_sha kwarg = pre-M8.4-B behavior; works exactly as before.
+      # No tree_sha kwarg = pre-index behavior; works exactly as before.
       backend.upload('commit-Y')
 
       FileUtils.rm_rf(Dir.glob(File.join(@cache_path, '*')))

--- a/spec/integration/ruby_app_spec.rb
+++ b/spec/integration/ruby_app_spec.rb
@@ -8,7 +8,7 @@
 #     current schema_version in last_run.json
 #   - dependency + boot_set maps are populated
 #
-# Post-M5.1 there is no "legacy engine" path to compare against -
+# There is no "legacy engine" path to compare against anymore -
 # `use_v2_tracker` is gone and the v2 engine is the only engine. The
 # previous "parity with legacy" scenarios have been retired.
 

--- a/spec/integration/schema_version_upgrade_spec.rb
+++ b/spec/integration/schema_version_upgrade_spec.rb
@@ -8,7 +8,7 @@ require 'tmpdir'
 require 'rspec_tracer/storage/json_backend'
 require 'rspec_tracer/storage/schema'
 
-# M8.10: 1.x -> 2.0 cache schema-version cold-run integration spec.
+# 1.x -> 2.0 cache schema-version cold-run integration spec.
 #
 # The 1.x cache shape on disk wrote `last_run.json` WITHOUT a
 # `schema_version` field (or under an older numeric value); the 2.0
@@ -17,8 +17,8 @@ require 'rspec_tracer/storage/schema'
 # info-level log when the stored shape is incompatible.
 #
 # Every existing 1.x user hits this code path on first 2.0 upgrade.
-# Pre-M8.10 the path was wired but no integration spec exercised the
-# actual upgrade ceremony; M8.9 doctor's `cache_schema_version_check`
+# Previously the path was wired but no integration spec exercised the
+# actual upgrade ceremony; doctor's `cache_schema_version_check`
 # surfaces the state at diagnostic time, but the lib-level handling
 # was unverified at integration level. This spec drives the
 # JsonBackend with three concrete 1.x-shaped cache fixtures (no
@@ -35,7 +35,7 @@ require 'rspec_tracer/storage/schema'
 # runs alone mask cache-persistence bugs.
 # rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable, RSpec/ContextWording
 # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
-RSpec.describe 'Storage::JsonBackend 1.x -> 2.0 cache schema cold-run upgrade ceremony (M8.10)' do
+RSpec.describe 'Storage::JsonBackend 1.x -> 2.0 cache schema cold-run upgrade ceremony' do
   let(:logger) { instance_double(RSpecTracer::Logger, debug: nil, info: nil, warn: nil, error: nil) }
   let(:current_schema) { RSpecTracer::Storage::Schema::CURRENT }
 

--- a/spec/integration/track_env_config_spec.rb
+++ b/spec/integration/track_env_config_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M5.3 end-to-end integration for the config-level `track_env(*names)`
+# End-to-end integration for the config-level `track_env(*names)`
 # DSL + wildcard env matching. Drives the reference Rails fixture at
 # `spec/fixtures/rails_app/` via subprocess RSpec.
 #
@@ -70,7 +70,7 @@ end
 
 # rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable, RSpec/BeforeAfterAll
 # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
-RSpec.describe 'M5.3 config-level track_env DSL integration' do
+RSpec.describe 'config-level track_env DSL integration' do
   include TrackEnvConfigSpecHelpers
 
   before(:all) { TrackEnvConfigSpecHelpers.ensure_bundle_and_db }

--- a/spec/integration/wide_ar_schema_db_cleaner_deletion_spec.rb
+++ b/spec/integration/wide_ar_schema_db_cleaner_deletion_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M9.0 widening-assertion spec for the
+# Widening-assertion spec for the
 # `DatabaseCleaner :deletion` strategy in an around hook.
 #
 # Real-user setup under test: a Rails project running the rspec-tracer
@@ -38,7 +38,7 @@ module WideArSchemaDbCleanerDeletionSpecHelpers
   WIDE_SPEC = 'spec/wide_schema_spec.rb'
   SCHEMA_FILE_NAME = '/db/schema.rb'
 
-  MUTATION_MARKER = "\n# rspec-tracer M9.0 wide-schema mutation marker\n"
+  MUTATION_MARKER = "\n# rspec-tracer wide-schema mutation marker\n"
 
   AR_DESCRIPTIONS = ['creates user A', 'creates user B', 'creates user C and counts'].freeze
   PURE_DESCRIPTION = 'performs only pure-Ruby computation'

--- a/spec/integration/wide_ar_schema_db_cleaner_transaction_spec.rb
+++ b/spec/integration/wide_ar_schema_db_cleaner_transaction_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M9.0 widening-assertion spec for the
+# Widening-assertion spec for the
 # `DatabaseCleaner :transaction` strategy in an around hook.
 #
 # Real-user setup under test: a Rails project running the rspec-tracer
@@ -40,7 +40,7 @@ module WideArSchemaDbCleanerTransactionSpecHelpers
   WIDE_SPEC = 'spec/wide_schema_spec.rb'
   SCHEMA_FILE_NAME = '/db/schema.rb'
 
-  MUTATION_MARKER = "\n# rspec-tracer M9.0 wide-schema mutation marker\n"
+  MUTATION_MARKER = "\n# rspec-tracer wide-schema mutation marker\n"
 
   AR_DESCRIPTIONS = ['creates user A', 'creates user B', 'creates user C and counts'].freeze
   PURE_DESCRIPTION = 'performs only pure-Ruby computation'

--- a/spec/integration/wide_ar_schema_db_cleaner_truncation_spec.rb
+++ b/spec/integration/wide_ar_schema_db_cleaner_truncation_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M9.0 widening-assertion spec for the
+# Widening-assertion spec for the
 # `DatabaseCleaner :truncation` strategy in an around hook.
 #
 # Real-user setup under test: a Rails project running the rspec-tracer
@@ -44,7 +44,7 @@ module WideArSchemaDbCleanerTruncationSpecHelpers
   WIDE_SPEC = 'spec/wide_schema_spec.rb'
   SCHEMA_FILE_NAME = '/db/schema.rb'
 
-  MUTATION_MARKER = "\n# rspec-tracer M9.0 wide-schema mutation marker\n"
+  MUTATION_MARKER = "\n# rspec-tracer wide-schema mutation marker\n"
 
   AR_DESCRIPTIONS = ['creates user A', 'creates user B', 'creates user C and counts'].freeze
   PURE_DESCRIPTION = 'performs only pure-Ruby computation'

--- a/spec/integration/wide_ar_schema_transactional_spec.rb
+++ b/spec/integration/wide_ar_schema_transactional_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# M9.0 widening-assertion spec for the Rails-default
+# Widening-assertion spec for the Rails-default
 # `use_transactional_fixtures = true` setup.
 #
 # Real-user setup under test: a Rails project running the rspec-tracer
@@ -48,7 +48,7 @@ module WideArSchemaTransactionalSpecHelpers
   WIDE_SPEC = 'spec/wide_schema_spec.rb'
   SCHEMA_FILE_NAME = '/db/schema.rb'
 
-  MUTATION_MARKER = "\n# rspec-tracer M9.0 wide-schema mutation marker\n"
+  MUTATION_MARKER = "\n# rspec-tracer wide-schema mutation marker\n"
 
   AR_DESCRIPTIONS = ['creates user A', 'creates user B', 'creates user C and counts'].freeze
   PURE_DESCRIPTION = 'performs only pure-Ruby computation'

--- a/spec/lib/rspec_tracer/source_file_spec.rb
+++ b/spec/lib/rspec_tracer/source_file_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe RSpecTracer::SourceFile do
     # where Encoding.default_external resolves to US-ASCII.
     context 'when the source file contains UTF-8 bytes under US-ASCII default external' do
       let(:path) { File.join(tmp, 'unicode.rb') }
-      let(:content) { "# KNOWN_ISSUES \u00A7B5\n" }
+      let(:content) { "# section \u00A7 marker\n" }
 
       around do |example|
         original_external = Encoding.default_external

--- a/spec/load_order_spec.rb
+++ b/spec/load_order_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rspec_tracer'
 
-# M8.9: SimpleCov load-order is part of the documented contract -
+# SimpleCov load-order is part of the documented contract -
 # SimpleCov.start MUST run before RSpecTracer.start when both are
 # used. When the user has SimpleCov loaded but not started, we'd
 # silently call ::Coverage.start and SimpleCov's later setup would

--- a/spec/properties/filter_invariants_spec.rb
+++ b/spec/properties/filter_invariants_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Property-based invariants for Tracker::Filter. Runs 500 iterations
-# per property per the M3.5 acceptance criterion. Generators are
+# per property per the original acceptance criterion. Generators are
 # pulled into a helper module because Rantly's property_of block
 # evaluates in Rantly's instance context - closure-captured lets
 # are not visible (same pattern as invalidation_monotonic_spec.rb

--- a/spec/properties/metadata_inheritance_spec.rb
+++ b/spec/properties/metadata_inheritance_spec.rb
@@ -20,7 +20,7 @@ PROPERTY_FILES_POOL = %w[
   app/**/*.rb config/**/*.yml lib/tasks/*.rake db/schema.rb
   app/policies/**/*.rb app/helpers/*.rb
 ].freeze
-# Wildcard entries (M5.3) are opaque strings to Metadata.tracks_for —
+# Wildcard entries are opaque strings to Metadata.tracks_for --
 # the cascade walker just unions them; expansion happens downstream in
 # Engine#register_tracks via Tracker::EnvMatcher.expand. Mixing
 # literals + wildcards in the property pool asserts the walker stays

--- a/spec/rails/factory_tracking_spec.rb
+++ b/spec/rails/factory_tracking_spec.rb
@@ -8,7 +8,7 @@ require 'rspec_tracer/rails/preset'
 require 'rspec_tracer/tracker/declared_globs'
 require 'rspec_tracer/tracker/loaded_files_tracker'
 
-# Regression spec for the factory blind-spot (KNOWN_ISSUES F4). Factory
+# Regression spec for the factory blind-spot. Factory
 # files live under `spec/factories/**/*.rb` and are plain Ruby, so they
 # ride two tracker pipes:
 #
@@ -19,7 +19,7 @@ require 'rspec_tracer/tracker/loaded_files_tracker'
 #
 # This spec does not introduce a new lib file - it documents and
 # asserts that the existing mechanisms see factory files on mutation,
-# so the F4 path is mechanically verifiable without reopening M4.2.
+# so the factory-file path is mechanically verifiable end-to-end.
 # rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength
 RSpec.describe 'Factory tracking regression' do
   let(:tmpdir) { Dir.mktmpdir('rspec-tracer-factory') }

--- a/spec/rails/fixture_tracking_spec.rb
+++ b/spec/rails/fixture_tracking_spec.rb
@@ -9,17 +9,17 @@ require 'rspec_tracer/rails/preset'
 require 'rspec_tracer/tracker/declared_globs'
 require 'rspec_tracer/tracker/io_hooks'
 
-# Regression spec for the YAML-fixture blind-spot (KNOWN_ISSUES F4).
+# Regression spec for the YAML-fixture blind-spot.
 # Rails fixtures (spec/fixtures/**/*.{yml,yaml}) are loaded via
-# ActiveRecord::FixtureSet, which funnels through YAML.load_file. M3.2's
+# ActiveRecord::FixtureSet, which funnels through YAML.load_file. The
 # IOHooks YAML hook catches every read, so the fixture file gets
 # attributed as a :data Input on every example that loads it. In
 # parallel, Preset's `:fixtures` glob declared-walks the same files at
 # boot for a conservative suite-wide fallback.
 #
 # This spec does not introduce a new lib file - it asserts both
-# pipes see a fixture change after mutation, so the F4 regression
-# path is mechanically verifiable without reopening M4.2.
+# pipes see a fixture change after mutation, so the regression
+# path is mechanically verifiable end-to-end.
 # rubocop:disable RSpec/DescribeClass, RSpec/ExampleLength
 RSpec.describe 'Fixture tracking regression' do
   let(:tmpdir) { Dir.mktmpdir('rspec-tracer-fixture') }

--- a/spec/rails/notifications_spec.rb
+++ b/spec/rails/notifications_spec.rb
@@ -10,7 +10,7 @@ require 'rspec_tracer/rails/notifications'
 # Unit spec for RSpecTracer::Rails::Notifications. The dev Gemfile does
 # not carry Rails / ActiveSupport, so this spec stubs a minimal
 # AS::Notifications surface that records subscribe / unsubscribe /
-# publish calls. Full real-Rails fixture boot is M4.3 territory.
+# publish calls. Full real-Rails fixture boot is integration-matrix territory.
 # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
 RSpec.describe RSpecTracer::Rails::Notifications do
   let(:tmpdir) { Dir.mktmpdir('rspec-tracer-notifications') }

--- a/spec/rails/railtie_spec.rb
+++ b/spec/rails/railtie_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'RSpecTracer::Rails::Railtie' do
   # is not in the object graph. Provide a minimal stand-in that records
   # every `initializer(name, &block)` call so the spec can inspect what
   # the loaded railtie.rb registered. Full fixture-level boot happens
-  # in M4.3's integration matrix.
+  # in the Rails integration matrix.
   let(:railtie_base) do
     Class.new do
       class << self

--- a/spec/regressions/knapsack_coexistence_spec.rb
+++ b/spec/regressions/knapsack_coexistence_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-# M8.10: knapsack composition smoke spec.
+# knapsack composition smoke spec.
 #
 # knapsack (https://github.com/KnapsackPro/knapsack) is the dominant
 # free test-splitter on production Rails CI - it pre-filters which
 # spec files run on each CI node so the suite parallelizes across
-# machines. M9.0 shipped coexistence smokes for rspec-retry +
+# machines. We ship coexistence smokes for rspec-retry +
 # rspec-rerun (which prepend RSpec::Core::Example / register a
 # Formatter); knapsack hooks into RSpec.configure callbacks +
 # logs example timings. Different surface from retry/rerun but the
@@ -39,7 +39,7 @@ require 'tmpdir'
 
 # rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations
 # rubocop:disable RSpec/ExampleLength
-RSpec.describe 'knapsack coexistence (smoke; M8.10)' do
+RSpec.describe 'knapsack coexistence (smoke)' do
   let(:project_root) { File.expand_path('../..', __dir__) }
   let(:gemfile_path) { File.join(project_root, 'Gemfile') }
 

--- a/spec/regressions/rspec_rerun_coexistence_spec.rb
+++ b/spec/regressions/rspec_rerun_coexistence_spec.rb
@@ -24,8 +24,8 @@
 # rspec-rerun in the :development group (require: false default) so
 # the subprocess can require it on demand.
 #
-# If a real conflict surfaces here, file as M9.0-B follow-up per the
-# brief - smoke specs are non-blocking.
+# If a real conflict surfaces here, file a follow-up issue - smoke
+# specs are non-blocking.
 
 require 'bundler'
 require 'fileutils'

--- a/spec/regressions/rspec_retry_coexistence_spec.rb
+++ b/spec/regressions/rspec_retry_coexistence_spec.rb
@@ -4,7 +4,7 @@
 #
 # rspec-retry (https://github.com/NoRedInk/rspec-retry) wraps
 # RSpec::Core::Example via Module#prepend to retry failing examples up
-# to N times. rspec-tracer's M5.1 hook chain prepends
+# to N times. rspec-tracer's hook chain prepends
 # RSpec::Core::Runner (RunnerHook) and RSpec::Core::Reporter
 # (ReporterHook) - DIFFERENT MRO points than rspec-retry's prepend on
 # Example. The two extensions should compose without conflict.

--- a/spec/remote_cache/user_tasks_spec.rb
+++ b/spec/remote_cache/user_tasks_spec.rb
@@ -155,13 +155,13 @@ RSpec.describe RSpecTracer::RemoteCache::UserTasks do
     end
   end
 
-  # M8.10: missing GIT_DEFAULT_BRANCH degrades gracefully (per the
+  # Missing GIT_DEFAULT_BRANCH degrades gracefully (per the
   # `Never propagate storage errors` contract) - the remote-cache
   # rake-task surface returns false + logs a clear, actionable
   # message at warn level, rather than letting the require_env raise
   # propagate up into `bundle exec rake` as a non-zero exit. The user
   # sees the env-name in the log line and knows what to fix.
-  describe 'missing GIT_DEFAULT_BRANCH (M8.10)' do
+  describe 'missing GIT_DEFAULT_BRANCH' do
     let(:config) { build_config(remote_cache_backend_entry: [fake_backend_class, {}]) }
 
     def warn_messages

--- a/spec/reporters/coverage_json_reporter_spec.rb
+++ b/spec/reporters/coverage_json_reporter_spec.rb
@@ -10,7 +10,7 @@ require 'rspec_tracer/reporters/coverage_json_reporter'
 
 require_relative '../contracts/reporter'
 
-# Unit + structural coverage for the M8.0 coverage.json emitter.
+# Unit + structural coverage for the coverage.json emitter.
 # Round-trip byte-equivalence vs the rails_app fixture's golden
 # lives in spec/integration/coverage_json_round_trip_spec.rb (driven
 # end-to-end through a subprocess); this file exercises the emitter

--- a/spec/reporters/json_reporter_spec.rb
+++ b/spec/reporters/json_reporter_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe RSpecTracer::Reporters::JsonReporter do
         .to eq(RSpecTracer::Reporters::PayloadBuilder::SCHEMA_VERSION)
     end
 
-    it 'is pinned to 1 for M6.1' do
+    it 'is pinned to 1 for the initial reporter schema' do
       expect(described_class::SCHEMA_VERSION).to eq(1)
     end
   end

--- a/spec/rspec/parallel_tests_spec.rb
+++ b/spec/rspec/parallel_tests_spec.rb
@@ -438,11 +438,11 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       expect(ordering).to eq(%i[pid_wait peer_wait merge])
     end
 
-    # M8.10: emit_merged_reporters! must run BEFORE purge_worker_dirs!
+    # emit_merged_reporters! must run BEFORE purge_worker_dirs!
     # so the reporter Registry consumes the merged top-level snapshot
     # AND writes its terminal/JSON/HTML output before the per-worker
     # parallel_tests_N dirs are removed.
-    it 'emits merged reporters before purging the per-worker dirs (M8.10)' do
+    it 'emits merged reporters before purging the per-worker dirs' do
       ordering = []
       allow(described_class).to receive(:emit_merged_reporters!) { ordering << :emit }
       allow(described_class).to receive(:purge_worker_dirs!) { ordering << :purge }
@@ -473,7 +473,7 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
     end
   end
 
-  describe '.emit_merged_reporters! (M8.10)' do
+  describe '.emit_merged_reporters!' do
     let(:base_dir) { File.dirname(cache_path) }
     let(:top_report_dir) { File.dirname(report_path) }
     let(:merged_snapshot) { instance_double(RSpecTracer::Storage::Snapshot) }
@@ -484,7 +484,7 @@ RSpec.describe RSpecTracer::RSpec::ParallelTests do
       allow(RSpecTracer).to receive(:rails?).and_return(false)
     end
 
-    it 'is a no-op for non-:json storage backends (M3.8 SqliteBackend)' do
+    it 'is a no-op for non-:json storage backends (SqliteBackend)' do
       allow(RSpecTracer).to receive(:storage_backend).and_return(:sqlite)
       expect(RSpecTracer::Reporters::Registry).not_to receive(:emit_all)
 

--- a/spec/rspec/runner_hook_spec.rb
+++ b/spec/rspec/runner_hook_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe RSpecTracer::RSpec::RunnerHook do
       end
     end
 
-    context 'when per-example tracks metadata is present (M5.2)' do
+    context 'when per-example tracks metadata is present' do
       before do
         allow(world).to receive(:example_count).and_return(1, 1)
         allow(world).to receive(:filtered_examples).and_return(example_group => [example])

--- a/spec/storage/json_backend_spec.rb
+++ b/spec/storage/json_backend_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(JSON.parse(File.read(path))).to eq('Files changed' => 3, 'No cache' => 1)
     end
 
-    it 'coerces a missing cache_hit_reason.json to {} (load tolerant of pre-M8.11 caches)' do
+    it 'coerces a missing cache_hit_reason.json to {} (load tolerant of caches predating the field)' do
       backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
       File.delete(File.join(cache_path, sample_snapshot.run_id, 'cache_hit_reason.json'))
       loaded = backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
@@ -175,7 +175,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
     end
   end
 
-  describe 'env_snapshot round-trip (M5.2)' do
+  describe 'env_snapshot round-trip' do
     it 'persists and reloads a non-empty env_snapshot' do
       backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
       loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
@@ -210,7 +210,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
     end
   end
 
-  describe 'env_dependency round-trip (M6.1)' do
+  describe 'env_dependency round-trip' do
     it 'persists and reloads a non-empty env_dependency' do
       backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
       loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
@@ -244,7 +244,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(loaded.env_dependency).to eq({})
     end
 
-    it 'survives a pre-M6.1 cache (missing env_dependency.json) without a cold re-run signal' do
+    it 'survives a cache predating env_dependency.json without a cold re-run signal' do
       backend.save_graph(sample_snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT)
       File.delete(File.join(cache_path, sample_snapshot.run_id, 'env_dependency.json'))
       loaded = other_backend.load_graph(schema_version: RSpecTracer::Storage::Schema::CURRENT)
@@ -296,7 +296,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
     end
   end
 
-  describe 'UTF-8 encoding (regression for M3.1 Encoding::InvalidByteSequenceError)' do
+  describe 'UTF-8 encoding (regression for Encoding::InvalidByteSequenceError)' do
     it 'round-trips example titles containing non-ASCII bytes' do
       snap = build_sample_snapshot('run-utf8')
       snap.all_examples = { 'ex-utf8' => { id: 'ex-utf8', description: "naïve café – \u{1F600}" } }
@@ -724,7 +724,7 @@ RSpec.describe RSpecTracer::Storage::JsonBackend do
       expect(merged.env_snapshot.keys).to include('ENV_EX1', 'ENV_EX2')
     end
 
-    it 'unions env_dependency entries per-example across peers (M6.1)' do
+    it 'unions env_dependency entries per-example across peers' do
       write_peer(peer_one_path, peer_snapshot('p1', 'ex1', '/lib/a.rb', 'digest-a'))
       write_peer(peer_two_path, peer_snapshot('p2', 'ex2', '/lib/b.rb', 'digest-b'))
 

--- a/spec/storage/snapshot_spec.rb
+++ b/spec/storage/snapshot_spec.rb
@@ -31,15 +31,15 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
       expect(snapshot.boot_set).to eq({})
     end
 
-    it 'defaults wsi_snapshot to an empty Hash (M4.3 field)' do
+    it 'defaults wsi_snapshot to an empty Hash' do
       expect(snapshot.wsi_snapshot).to eq({})
     end
 
-    it 'defaults env_snapshot to an empty Hash (M5.2 field)' do
+    it 'defaults env_snapshot to an empty Hash' do
       expect(snapshot.env_snapshot).to eq({})
     end
 
-    it 'defaults env_dependency to an empty Hash (M6.1 field)' do
+    it 'defaults env_dependency to an empty Hash' do
       expect(snapshot.env_dependency).to eq({})
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe RSpecTracer::Storage::Snapshot do
       expect(a).not_to eq(b)
     end
 
-    it 'differs when env_dependency differs (M6.1)' do
+    it 'differs when env_dependency differs' do
       a = described_class.empty(schema_version: 3, run_id: 'x')
       b = described_class.empty(schema_version: 3, run_id: 'x')
       b.env_dependency = { 'ex1' => ['API_KEY'] }

--- a/spec/support/tracker_coverage_gate.rb
+++ b/spec/support/tracker_coverage_gate.rb
@@ -2,7 +2,7 @@
 
 # 100%-line + 100%-branch coverage gate scoped to the lib/rspec_tracer
 # subdirectories listed in GATED_SUBDIRS. Legacy files get no retroactive
-# pressure; mutation is the stronger signal for those (M8.3).
+# pressure; mutation is the stronger signal for those.
 #
 # Activation is per-file, keyed on the lib/spec pairing convention
 # (lib/rspec_tracer/<subdir>/X.rb <-> spec/<subdir>/X_spec.rb). Running
@@ -42,7 +42,7 @@ module TrackerCoverageGate
   # covered by the `require` side-effect and the gate would fire inside
   # mutant's forked test subprocess, which mutant interprets as "the
   # mutation survived" (exit 1 ⟹ 0% mutation coverage). Same dogfood
-  # spirit as spec_helper's RSPEC_TRACER_DISABLE guard in M2.5: the
+  # spirit as spec_helper's RSPEC_TRACER_DISABLE guard: the
   # gate is a full-suite assertion, not something mutant cares about.
   def self.skip?
     defined?(::Mutant) || ENV['RSPEC_TRACER_DISABLE'] == '1'

--- a/spec/tracker/declared_globs_spec.rb
+++ b/spec/tracker/declared_globs_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe RSpecTracer::Tracker::DeclaredGlobs do
   describe 'end-to-end change detection' do
     # Proves AC: a declared file's digest changes when its contents
     # change - the signal that drives "re-run everything depending on
-    # this input" in M3.5/M3.6.
+    # this input" in the filter.
     it 'returns a new digest when the declared file is modified between runs' do
       path = write_file('db/schema.rb', "v1\n")
       v1_digest = described_class.new(root: root, globs: ['db/schema.rb']).walk.first.digest

--- a/spec/tracker/env_snapshot_spec.rb
+++ b/spec/tracker/env_snapshot_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe RSpecTracer::Tracker::EnvSnapshot do
     end
   end
 
-  describe 'M5.3 union of config-level + per-example concrete names' do
+  describe 'union of config-level + per-example concrete names' do
     let(:env) do
       {
         'AUTH_TOKEN' => 'literal-config',
@@ -118,8 +118,8 @@ RSpec.describe RSpecTracer::Tracker::EnvSnapshot do
 
     # Engine expands "RAILS_*" via EnvMatcher.expand before reaching
     # digest_snapshot — the persisted snapshot carries env keys, not
-    # patterns, so the shape stays Hash[name => md5_hex] per the M5.2
-    # schema (no wildcard literal survives across runs).
+    # patterns, so the shape stays Hash[name => md5_hex] per the
+    # snapshot schema (no wildcard literal survives across runs).
     it 'persists wildcard-expanded names as concrete keys' do
       result = observer.digest_snapshot(%w[RAILS_ENV RAILS_MAX_THREADS])
 

--- a/spec/tracker/io_hooks_spec.rb
+++ b/spec/tracker/io_hooks_spec.rb
@@ -146,8 +146,8 @@ RSpec.describe RSpecTracer::Tracker::IOHooks do
 
   describe '.with_bucket / .current_bucket' do
     # The outer suite's Engine#example_started sets a bucket via
-    # ReporterHook on every example - post-M5.1, there is no
-    # use_v2_tracker gate. Explicitly clear before asserting the
+    # ReporterHook on every example - there is no
+    # use_v2_tracker gate anymore. Explicitly clear before asserting the
     # with_bucket lifecycle so `current_bucket` reads as `nil` when
     # nothing else has touched it inside the test.
     before { described_class.clear_bucket }

--- a/spec/tracker/new_file_detector_spec.rb
+++ b/spec/tracker/new_file_detector_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe RSpecTracer::Tracker::NewFileDetector do
     end
   end
 
-  describe '#new_files regression for KNOWN_ISSUES §B5' do
+  describe '#new_files regression: files added between runs were invisible in 1.x' do
     # The bug: 1.x only diffs files already in cache.all_files, so a
     # newly-added source file is invisible to the invalidation path.
     # The fix: walk declared + default globs and emit Inputs for any

--- a/spec/tracker/whole_suite_invalidators_spec.rb
+++ b/spec/tracker/whole_suite_invalidators_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe RSpecTracer::Tracker::WholeSuiteInvalidators do
 
   describe 'end-to-end Gemfile.lock invalidation' do
     # Proves AC: modifying Gemfile.lock invalidates the snapshot,
-    # which is the signal M3.5/M3.6 will translate into "re-run
+    # which is the signal the filter translates into "re-run
     # every example, regardless of any other config."
     it 'fires on Gemfile.lock modification between runs' do
       write_watch('Gemfile.lock', "run1\n")

--- a/taskfiles/benchmark.yml
+++ b/taskfiles/benchmark.yml
@@ -28,7 +28,7 @@ tasks:
     # Smoke uses cold_ruby + warm_noop only — both run in the ruby_app
     # fixture. Narrowing the dep to bundle:ruby (vs bundle) lets non-MRI
     # cells run smoke without bundling the rails_app fixture. The
-    # fixture Gemfile DOES support JRuby/TruffleRuby (M8.1-B JDBC adapter
+    # fixture Gemfile DOES support JRuby/TruffleRuby (via its JDBC adapter
     # branch), but the smoke step would pay Maven download + JDBC native
     # ext build cost on first run — keeping smoke ruby_app-only on
     # non-MRI cells preserves the ~3s budget.

--- a/taskfiles/docs.yml
+++ b/taskfiles/docs.yml
@@ -27,6 +27,17 @@ tasks:
     cmds:
       - bundle exec yard stats --list-undoc
 
+  docs:leak-check:
+    desc: >-
+      Scan every tracked file for internal planning vocabulary that
+      must not ship in the public repo (milestone tags, private note
+      names, local-only doc-tree paths), including split
+      directory-tree renderings in Markdown. Exemptions live in
+      .leakcheck-allow at the repo root; every entry needs a trailing
+      justification comment. Nonzero exit on any unallowed hit.
+    cmds:
+      - ruby scripts/leak_check.rb
+
   docs:wcag:
     desc: >-
       Run WCAG 2.1 AA accessibility audit on the HTML reporter via

--- a/taskfiles/setup.yml
+++ b/taskfiles/setup.yml
@@ -39,7 +39,7 @@ tasks:
       - sh: command -v python3 >/dev/null 2>&1
         msg: "python3 not found; install: 'brew install python@3.12' (mac) — Ubuntu ships it"
     # Status guards skip install when each binary is present AT THE
-    # PINNED VERSION. M8.6 retro: previous `test -x` checks let cache
+    # PINNED VERSION. Previously, plain `test -x` checks let cache
     # restore-keys hits (which may carry a stale binary from a prior
     # session with a different version pin) skip install incorrectly.
     # Version-aware grep against each tool's --version output ensures
@@ -59,12 +59,12 @@ tasks:
         #
         # Two-layer retry: inner curl `--retry 5` (covers ~10s of 5xx
         # blips) + outer 3-attempt loop with 5s/10s/20s exponential
-        # backoff (covers ~35s of CDN unavailability). M8.3-A (PR #122)
-        # / M8.3-B (PR #124) / M8.6 v5 (PR #129) all hit GitHub-Releases
-        # 5xx flakes during cold-cache install:tools. Same outer-loop
-        # shape was already on trivy install before M8.6 v3 bypassed
-        # install.sh; M8.6 v5 retro promoted the pattern to actionlint
-        # + shellcheck after a 6-consecutive-502 burst broke shellcheck.
+        # backoff (covers ~35s of CDN unavailability). PRs #122, #124,
+        # and #129 all hit GitHub-Releases 5xx flakes during
+        # cold-cache install:tools. Same outer-loop shape was already
+        # on trivy install before we bypassed install.sh; the pattern
+        # was promoted to actionlint + shellcheck after a
+        # 6-consecutive-502 burst broke shellcheck.
         mkdir -p bin
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         case "$(uname -m)" in
@@ -125,7 +125,7 @@ tasks:
         ln -sf "$(pwd)/.venv/yamllint/bin/yamllint" bin/yamllint
       - |
         # trivy: direct binary download (matches actionlint/shellcheck
-        # pattern). M8.6 retro: PR #129 first CI run had all 3 attempts
+        # pattern). PR #129's first CI run had all 3 attempts
         # of the official install.sh wrapper fail in a 35s window —
         # install.sh shells out to its own curl + tar internally that
         # our outer retry can't see, so the loop just hits the same
@@ -133,7 +133,7 @@ tasks:
         # standard `--retry 5 --retry-all-errors --retry-connrefused`
         # gives us the same retry semantics as actionlint/shellcheck.
         # Same two-layer retry (inner curl --retry 5 + outer 3-attempt
-        # loop) as actionlint/shellcheck since M8.6 v6. Trivy release
+        # loop) as actionlint/shellcheck. Trivy release
         # naming: trivy_<NUMBER>_<OS>-<ARCH>.tar.gz where NUMBER strips
         # the leading 'v' and ARCH uses 64bit/ARM64 (not x86_64/aarch64).
         mkdir -p bin

--- a/taskfiles/test-features.yml
+++ b/taskfiles/test-features.yml
@@ -10,24 +10,24 @@ version: '3'
 tasks:
   test:features:ruby:
     desc: >-
-      M5.1 ruby_app integration test (swapped from cucumber; the legacy
+      ruby_app integration test (swapped from cucumber; the legacy
       cucumber scenarios asserted on 1.x cache layout - 10 files, spec_helper
-      in all_files - that v2 no longer produces). Same M4.3 c2 precedent as
+      in all_files - that v2 no longer produces). Same swap precedent as
       test:features:rails.
     cmds:
       - bundle exec rspec --no-color spec/integration/ruby_app_spec.rb spec/integration/dogfood_spec.rb
 
   test:features:ruby-parallel:
     desc: >-
-      M5.1 parallel_tests integration test (swapped from cucumber; the legacy
+      parallel_tests integration test (swapped from cucumber; the legacy
       cucumber scenarios asserted on 1.x cache layout that v2 no longer writes).
     cmds:
       - task: test:integration:parallel
 
   test:features:rails:
     desc: >-
-      M4.3 Rails integration test against the reference Rails app. Also
-      includes the M8.0 coverage.json byte-equivalence round-trip spec
+      Rails integration test against the reference Rails app. Also
+      includes the coverage.json byte-equivalence round-trip spec
       (drives the same fixture; opts out of SimpleCov via
       RSPEC_TRACER_FIXTURE_NO_SIMPLECOV=1 inside the spec). Excluded
       from the default rspec sweep (via .rspec --exclude-pattern) because
@@ -38,7 +38,7 @@ tasks:
 
   test:features:rails:narrow-schema:
     desc: >-
-      M8.2-B narrow-AR-schema integration test. Drives the rails fixture
+      Narrow-AR-schema integration test. Drives the rails fixture
       with use_transactional_fixtures = false
       (RSPEC_TRACER_RAILS_TRANSACTIONAL=false) and asserts the per-example
       schema-subscriber attribution path
@@ -55,7 +55,7 @@ tasks:
 
   test:features:rails:wide-schema:transactional:
     desc: >-
-      M9.0 wide-AR-schema integration test under the Rails-default
+      Wide-AR-schema integration test under the Rails-default
       `use_transactional_fixtures = true`. Drives spec/wide_schema_spec.rb
       (3 AR-touching examples + 1 pure-compute) and asserts: (1) cold
       attributes db/schema.rb to every AR-touching example because the
@@ -71,7 +71,7 @@ tasks:
 
   test:features:rails:wide-schema:db-cleaner-truncation:
     desc: >-
-      M9.0 wide-AR-schema integration test under the
+      Wide-AR-schema integration test under the
       `database_cleaner-active_record :truncation` strategy in an around
       hook. Drives spec/wide_schema_spec.rb with
       RSPEC_TRACER_RAILS_TRANSACTIONAL=false +
@@ -85,7 +85,7 @@ tasks:
 
   test:features:rails:wide-schema:db-cleaner-deletion:
     desc: >-
-      M9.0 wide-AR-schema integration test under the
+      Wide-AR-schema integration test under the
       `database_cleaner-active_record :deletion` strategy. Same shape as
       wide-schema:db-cleaner-truncation; DELETE queries fire
       sql.active_record inside the bucket instead of TRUNCATE.
@@ -94,7 +94,7 @@ tasks:
 
   test:features:rails:wide-schema:db-cleaner-transaction:
     desc: >-
-      M9.0 wide-AR-schema integration test under the
+      Wide-AR-schema integration test under the
       `database_cleaner-active_record :transaction` strategy. Same shape
       as wide-schema:db-cleaner-truncation; BEGIN / SAVEPOINT / ROLLBACK
       queries fire sql.active_record inside the bucket. Distinct from
@@ -105,7 +105,7 @@ tasks:
 
   test:features:rails:wide-schema:suite:
     desc: >-
-      M9.0 aggregator: runs all four wide-AR-schema integration specs
+      Aggregator: runs all four wide-AR-schema integration specs
       back-to-back. Used by the canary CI cell to wire one workflow step
       instead of four. Per-spec wall clock ~2-3 min; suite total ~10-12
       min on the canary `ruby-3.3 x Rails 7.1` MRI cell.
@@ -117,7 +117,7 @@ tasks:
 
   test:features:rails:jruby:
     desc: >-
-      M8.1-B Rails integration test on JRuby 9.4. Same shape as
+      Rails integration test on JRuby 9.4. Same shape as
       test:features:rails (drives the rails_app fixture via subprocess),
       with JRUBY_OPTS for the v2 engine's observer install. The fixture
       Gemfile branches on RUBY_ENGINE (activerecord-jdbcsqlite3-adapter
@@ -129,7 +129,7 @@ tasks:
       step env block.
       Local-dev convenience task: runs all 12 scenarios in one rspec
       process. CI uses the sharded variant `test:features:rails:jruby:shard`
-      (M8.6-B Lever 5) to fan the 12 scenarios across 6 parallel matrix
+      to fan the 12 scenarios across 6 parallel matrix
       jobs.
     env:
       JRUBY_OPTS: "--debug -X+O"
@@ -141,7 +141,7 @@ tasks:
 
   test:features:rails:jruby:shard:
     desc: >-
-      M8.6-B Lever 5 JRuby x Rails sharded variant. Reads SHARD env
+      JRuby x Rails sharded variant. Reads SHARD env
       (e.g. SHARD=rails_app-1-2) and runs only the specified 2 scenarios
       from rails_app_spec.rb via rspec --example filtering. Six shards
       (rails_app-1-2, rails_app-3-4, rails_app-5-6, rails_app-7-8,
@@ -176,7 +176,7 @@ tasks:
 
   test:features:rails:narrow-schema:jruby:
     desc: >-
-      M8.1-B narrow-AR-schema integration test on JRuby 9.4. Same shape
+      Narrow-AR-schema integration test on JRuby 9.4. Same shape
       as test:features:rails:narrow-schema; JRUBY_OPTS + the same Rails
       7.1 default pair as test:features:rails:jruby.
     env:
@@ -189,7 +189,7 @@ tasks:
 
   test:features:jruby:
     desc: >-
-      M5.1 ruby_app integration test on JRuby (swapped from cucumber for the
+      ruby_app integration test on JRuby (swapped from cucumber for the
       same reason as test:features:ruby). JRUBY_OPTS keeps the debug + object-
       space flags required for the v2 engine's observer install on JRuby 9.4.
     env:

--- a/taskfiles/test-mutation.yml
+++ b/taskfiles/test-mutation.yml
@@ -1,10 +1,10 @@
 version: '3'
 
 # Test::Mutation tasks: per-subject mutation gates + per-shard splits.
-# Owns the M8.3 family + M8.6-A 18-shard layout for the per-PR
+# Owns the per-subject gates + the 18-shard layout for the per-PR
 # lint-and-specs.yml mutation surface. Cross-file dep-free; the
-# inline rationale comments reference 'M8.6-A' (work-as-shipped
-# label) and post-M8.6-B '5-min cap' value (Lever 4).
+# inline rationale comments carry the '5-min cap' value that the
+# CI per-shard step timeouts enforce.
 
 # mutant reads each subject's source with Encoding.default_external.
 # On a shell with no locale (LANG / LC_ALL empty - common in fresh
@@ -107,19 +107,19 @@ tasks:
         run_mutant_subject "Tracker::EnvMatcher" \
           "rspec_tracer/tracker/env_matcher" \
           "RSpecTracer::Tracker::EnvMatcher*" || fail=1
-        # Rails::Notifications deferred to M8.3 - the subscribe-side
+        # Rails::Notifications deferred from this gate - the subscribe-side
         # surface (ActiveSupport::Notifications stubs + thread-local
         # bucket lifecycle) yields a large population of alive
         # mutations that are either equivalents or subscribe-call
         # shape. Baseline is 78.77% (594/754 kills); narrowing to
         # pure-logic methods (record_template / record_ar_schema /
-        # build_schema_inputs) is an M8.3 task, not M4.2 scope.
+        # build_schema_inputs) is a follow-up task, out of scope here.
         # Rails::I18nTracking follows the same rationale.
         exit "$fail"
 
   test:mutation:tracker:
     desc: >-
-      M8.3-A mutation pass on tracker/ net-new subjects (CoverageAdapter,
+      Mutation pass on tracker/ net-new subjects (CoverageAdapter,
       NewFileDetector, IOHooks). Per-subject gates reflect a maintainer-
       approved carve-out for structural mutation-tooling ceilings:
       IOHooks (Module#prepend idempotency + no unprepend API; rspec-mocks
@@ -169,7 +169,7 @@ tasks:
         run_mutant_gate "Tracker::NewFileDetector" \
           "rspec_tracer/tracker/new_file_detector" \
           "RSpecTracer::Tracker::NewFileDetector*" 82 || fail=1
-        # IOHooks gate dropped from 77 to 72 in M8.4-A: Priority 3's
+        # IOHooks gate dropped from 77 to 72 after the hot-path
         # inline `if Thread.current[BUCKET_KEY]` guard at each
         # prepended-method entry created equivalent-mutations against
         # the inner `_record` bucket-nil check (mutating either guard
@@ -188,7 +188,7 @@ tasks:
 
   test:mutation:storage:
     desc: >-
-      M8.3-A mutation pass on storage/ net-new subjects (LazySnapshot,
+      Mutation pass on storage/ net-new subjects (LazySnapshot,
       Serializer::Json, Serializer::Msgpack, JsonBackend, SqliteBackend).
       SqliteBackend carve-out (>= 73%) for prose-label describes that
       don't map cleanly into mutant's first-token Klass#method scheme.
@@ -196,7 +196,7 @@ tasks:
       test:mutation:smoke.
 
       Local single-command surface — runs all storage shards in
-      sequence. M8.6 split the storage mutation surface into 5 parallel
+      sequence. CI splits the storage mutation surface into 5 parallel
       CI jobs (refined post-first-CI to balance honest signal with
       wall-clock budget):
         - misc: 3 small subjects (LazySnapshot + Serializer::Json/Msgpack)
@@ -217,10 +217,10 @@ tasks:
 
   test:mutation:storage:misc:
     desc: >-
-      M8.6 storage shard — small non-JsonBackend / non-SqliteBackend
+      Storage shard -- small non-JsonBackend / non-SqliteBackend
       subjects (LazySnapshot, Serializer::Json, Serializer::Msgpack).
-      Combined CI wall clock under 2 min. Same gates as the M8.3-A
-      Taskfile entry.
+      Combined CI wall clock under 2 min. Same gates as the parent
+      test:mutation:storage entry.
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -269,7 +269,7 @@ tasks:
 
   test:mutation:storage:json-backend:
     desc: >-
-      M8.6 storage aggregate — Storage::JsonBackend split into 9
+      Storage aggregate -- Storage::JsonBackend split into 9
       sibling shards (`json-backend-shard-{1..9}`) that run as
       separate parallel CI jobs. JsonBackend has 50 mutant subjects
       (43 instance methods + FieldReader nested class + Merger nested
@@ -281,7 +281,7 @@ tasks:
       shard-3 has been further split into 3 sub-shards (now shard-3 /
       shard-4 / shard-5) by I/O density to enforce the per-shard
       step cap (currently 5-minute via `timeout-minutes: 5` after
-      M8.6-B's headroom bump from 4-minute).
+      the headroom bump from 4-minute).
 
       Earlier attempt with `--mutation-timeout 1` was reverted because
       shorter timeout silently shifts undetected mutations (test would
@@ -301,7 +301,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-1:
     desc: >-
-      M8.6 JsonBackend shard 1 of 3 — alphabetical first third: clear!
+      JsonBackend shard 1 of 3 -- alphabetical first third: clear!
       through field_filename (10 subjects: reads, deserializers,
       formatters). Lighter-weight read/parse helpers; default
       `--mutation-timeout 5` with `--jobs 8`.
@@ -342,7 +342,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-2:
     desc: >-
-      M8.6 JsonBackend shard 2 of 8 — middle-section first half
+      JsonBackend shard 2 of 8 -- middle-section first half
       (9 subjects): format_mib, info, initialize, last_run_id,
       last_run_path, load_graph, lock_path, maybe_prune_after_save,
       maybe_warn_size_budget. Originally an 18-subject shard at
@@ -384,7 +384,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-7:
     desc: >-
-      M8.6 JsonBackend shard 7 of 8 — middle-section second half
+      JsonBackend shard 7 of 8 -- middle-section second half
       (9 subjects): merge_from_peers, msgpack_unavailable_fallback,
       partition_dirs_to_prune, per_file_glob, positive_threshold?,
       read_field, resolve_serializer + FieldReader nested class
@@ -425,14 +425,14 @@ tasks:
 
   test:mutation:storage:json-backend-shard-3:
     desc: >-
-      M8.6 JsonBackend shard 3 of 5 — heavy write core (7 subjects):
+      JsonBackend shard 3 of 5 -- heavy write core (7 subjects):
       save_graph, transactional_save, write_json_atomic,
       write_last_run_atomic, write_payload_atomic, write_run_field,
       write_run_files. The file-I/O-dense atomic-write helpers that
       drove the original alphabetical-shard-3 to 6:52 M2 Max are
       isolated here; further sharding may be needed if this shard
       itself drifts past the per-shard step cap (5-min after
-      M8.6-B's bump).
+      the headroom bump).
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -475,7 +475,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-4:
     desc: >-
-      M8.6 JsonBackend shard 4 of 5 — reads + serializers + prune
+      JsonBackend shard 4 of 5 -- reads + serializers + prune
       (7 subjects): prune_run_dirs!, read_json, read_last_run_manifest,
       read_run_file, serialize_dependency, serialize_id_set,
       total_cache_size_bytes. Mixed I/O density.
@@ -519,7 +519,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-5:
     desc: >-
-      M8.6 JsonBackend shard 5 of 8 — warn helpers (2 subjects):
+      JsonBackend shard 5 of 8 -- warn helpers (2 subjects):
       warn_oversized_cache_total, warn_oversized_run_files.
       Originally a 4-subject shard at 4:46 CI (over the 4-min cap);
       split into 5 + 8 isolating Merger.absorb/call (which have
@@ -560,7 +560,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-8:
     desc: >-
-      M8.6 JsonBackend shard 8 of 9 — Merger.absorb (1 subject).
+      JsonBackend shard 8 of 9 -- Merger.absorb (1 subject).
       Originally a 2-subject shard with Merger.call; split into 1+1
       because the 2-subject shard hit 4:36 CI (over the 4-min cap).
       Merger.absorb does the actual hash absorption — many mutations
@@ -639,7 +639,7 @@ tasks:
       filtered_examples.values.tally produces correct totals, not the
       N-fold inflated sum of identical per-worker tallies). Split out
       from shard-5 to enforce the per-shard step cap (4-min when
-      decided, 5-min after M8.6-B's bump).
+      decided, 5-min after the headroom bump).
     env:
       RSPEC_TRACER_DISABLE: '1'
     cmds:
@@ -672,7 +672,7 @@ tasks:
 
   test:mutation:storage:sqlite-read:
     desc: >-
-      M8.6 SqliteBackend shard — read-side (15 subjects): last_run_id,
+      SqliteBackend shard -- read-side (15 subjects): last_run_id,
       load_graph, read_field, read_all_examples, read_all_files,
       read_dependency, read_digest_map, read_duplicate_examples,
       read_env_dependency, read_examples_coverage, read_id_set,
@@ -683,7 +683,7 @@ tasks:
       has near-zero timeouts in mutation runs (mostly cleanly killed
       mutations against the unit specs), so default `--mutation-
       timeout 5s` stays. CI wall clock target ~3 min per shard.
-      Original M8.6 split into 3 shards was over-sharded post-first-CI
+      The original split into 3 shards was over-sharded post-first-CI
       (each ~1-2 min); collapsed to 2 balanced shards (read / write+util).
     env:
       RSPEC_TRACER_DISABLE: '1'
@@ -726,7 +726,7 @@ tasks:
 
   test:mutation:storage:sqlite-write:
     desc: >-
-      M8.6 SqliteBackend shard — write-side + connection / schema /
+      SqliteBackend shard -- write-side + connection / schema /
       utility (30 subjects). Combines the original shards 2 + 3 since
       first CI showed the 3-shard split was over-sharded
       (each 1-2 min). Includes:
@@ -810,7 +810,7 @@ tasks:
 
   test:mutation:rspec:
     desc: >-
-      M8.3-A mutation pass on rspec/ subjects (Installation, ParallelTests,
+      Mutation pass on rspec/ subjects (Installation, ParallelTests,
       Metadata, RunnerHook, ReporterHook). Installation (>= 73%) and
       ParallelTests (>= 78%) carve-out for module-helper describe
       mapping (mutant credits only `.method` describes).
@@ -865,8 +865,8 @@ tasks:
 
   test:mutation:top-level:
     desc: >-
-      M8.3-A mutation pass on top-level RSpecTracer module's 17 class
-      methods. M8.6 split into 3 shards to enforce the 4-min per-shard
+      Mutation pass on top-level RSpecTracer module's 17 class
+      methods. Split into 3 shards to enforce the 4-min per-shard
       hard cap (initial 2-way split had top-level-b at 4:43 CI because
       its setup-path methods like `start` / `setup_coverage` /
       `run_finalize` all hang spec_helper boot, packing more 5s
@@ -879,7 +879,7 @@ tasks:
 
   test:mutation:top-level-a:
     desc: >-
-      M8.6 top-level shard A — alphabetical first half (8 methods):
+      Top-level shard A -- alphabetical first half (8 methods):
       at_exit_behavior, build_run_metadata, coverage_reporter,
       emit_reporters, engine, initial_setup, parallel_tests?, rails?.
       Default `--mutation-timeout 5` with `--jobs 8`. Wall clock
@@ -921,7 +921,7 @@ tasks:
 
   test:mutation:top-level-b:
     desc: >-
-      M8.6 top-level shard B — exit/finalize methods (5 methods):
+      Top-level shard B -- exit/finalize methods (5 methods):
       run_coverage_exit_task, run_elapsed_seconds, run_exit_tasks,
       run_finalize, run_simplecov_exit_task. Originally 9 methods
       (paired with -c which has setup/start) — split because the
@@ -961,7 +961,7 @@ tasks:
 
   test:mutation:top-level-c:
     desc: >-
-      M8.6 top-level shard C — setup/start methods (4 methods):
+      Top-level shard C -- setup/start methods (4 methods):
       setup_coverage, setup_rails, simplecov?, start. Split out from
       top-level-b after the 9-method shard hit the 4-min cap on CI.
     env:
@@ -996,16 +996,16 @@ tasks:
 
   test:mutation:remote-cache:
     desc: >-
-      M8.3-B mutation pass on remote_cache/ (8 subjects: Backend,
+      Mutation pass on remote_cache/ (8 subjects: Backend,
       Validator, Archive, GitAncestry, UserTasks, LocalFsBackend,
       RedisBackend, S3Backend). Per-subject gates carve out the same
-      structural describe-label ceiling as M8.3-A's Storage::SqliteBackend
+      structural describe-label ceiling as Storage::SqliteBackend
       (mutant maps tests via first-token of full_description; private
       helpers exercised only through public-method describes show as
       alive). UserTasks / LocalFsBackend / RedisBackend / S3Backend
       have 4-7x more mutant subjects than public describe blocks
       (private-helper density), driving the carve-outs. No spec
-      restructuring or mutation-bait additions per the M8.3-A
+      restructuring or mutation-bait additions per the standing
       no-anti-pattern-test-org rule.
     env:
       RSPEC_TRACER_DISABLE: '1'
@@ -1089,9 +1089,9 @@ tasks:
 
   test:mutation:rails:
     desc: >-
-      M8.3-C mutation pass on rails/ net-new subjects (Notifications,
-      I18nTracking, Railtie). Best-effort >= 70% per the canonical M8.3
-      brief. Per-subject gates carve out (a) the combined-describe
+      Mutation pass on rails/ net-new subjects (Notifications,
+      I18nTracking, Railtie). Best-effort >= 70% per the canonical
+      mutation-gate policy. Per-subject gates carve out (a) the combined-describe
       ceiling on `.install / .installed? / .uninstall` (mutant credits
       only the first-token `.install`; `.installed?` + `.uninstall`
       mutations stay alive even though functionally tested under the
@@ -1213,9 +1213,9 @@ tasks:
 
   test:mutation:reporters:
     desc: >-
-      M8.3-C mutation pass on reporters/ subjects (Base, JsonReporter,
+      Mutation pass on reporters/ subjects (Base, JsonReporter,
       TerminalReporter, HtmlReporter, PayloadBuilder, Registry).
-      Best-effort >= 70% per the canonical M8.3 brief. Reporters specs
+      Best-effort >= 70% per the canonical mutation-gate policy. Reporters specs
       lean on prose-form describes (`fallback rendering` / `graceful
       degradation` / `payload embedding` / `envelope` / `summary block` /
       `all_examples report` / `default resolution` / `BUILT_INS constant`
@@ -1321,11 +1321,11 @@ tasks:
 
   test:mutation:full:
     desc: >-
-      Full mutation pass - test:mutation:smoke + the M8.3-A per-module
-      subtasks (tracker / storage / rspec / top-level) + the M8.3-B
-      :remote-cache subtask + the M8.3-C :rails / :reporters subtasks.
+      Full mutation pass - test:mutation:smoke + the per-module
+      subtasks (tracker / storage / rspec / top-level) + the
+      :remote-cache subtask + the :rails / :reporters subtasks.
       Runs per-PR + per-main via lint-and-specs.yml's parallel mutation
-      jobs (M3.8 Part C migration from the deleted nightly.yml).
+      jobs (migrated from the deleted nightly.yml).
     cmds:
       - task: test:mutation:smoke
       - task: test:mutation:tracker

--- a/taskfiles/test.yml
+++ b/taskfiles/test.yml
@@ -41,7 +41,7 @@ tasks:
 
   test:integration:check-bundle-drift:
     desc: >-
-      M8.4-B drift task contract spec. Verifies
+      Drift task contract spec. Verifies
       scripts/check_bundle_drift.rb exits zero on a known-good
       Gemfile and non-zero on a fixture Gemfile with an
       unsatisfiable constraint. Excluded from the default rspec
@@ -54,7 +54,7 @@ tasks:
 
   test:integration:parallel:
     desc: >-
-      M5.1 parallel_tests integration test. Drives the benchmark ruby_app fixture
+      parallel_tests integration test. Drives the benchmark ruby_app fixture
       under `parallel_rspec spec` and asserts the merged top-level cache shape.
       Excluded from the default rspec sweep (via .rspec --exclude-pattern) because
       each example spawns worker subprocesses.
@@ -87,7 +87,7 @@ tasks:
       (json_backend, multi-backend cache_loader spread across :json /
       :msgpack / sqlite, coverage_adapter pathological shapes). Runs
       per-PR + per-main via `lint-and-specs.yml`'s `Test - Fuzz (full)`
-      step (M3.8 Part C migration from the deleted nightly.yml).
+      step (migrated from the deleted nightly.yml).
     env:
       COVERAGE_SUITE: fuzz-full
     cmds:
@@ -97,7 +97,7 @@ tasks:
 
   test:edge-cases:
     desc: >-
-      M8.2 edge case suite — adversarial filesystem + cache + concurrency
+      Edge case suite -- adversarial filesystem + cache + concurrency
       tests under spec/edge_cases/. Excluded from the default rspec sweep
       via .rspec --exclude-pattern (note rspec silently ignores that flag
       when explicit positional paths are passed).
@@ -131,7 +131,7 @@ tasks:
 
   test:integration:per-example-dsl:
     desc: >-
-      M5.2 per-example tracks DSL integration test. Drives the Rails fixture
+      Per-example tracks DSL integration test. Drives the Rails fixture
       with a feature_flags_spec annotated with tracks: { env: ... }, cold/warm
       with the tracked env flipped, asserts only the env-branch examples
       re-run. Excluded from the default rspec sweep (subprocess, ~45s).
@@ -142,7 +142,7 @@ tasks:
 
   test:integration:track-env-config:
     desc: >-
-      M5.3 config-level track_env(*names) DSL + wildcard env matching.
+      Config-level track_env(*names) DSL + wildcard env matching.
       Drives the Rails fixture with a synthesized .rspec-tracer that
       declares `track_env 'AUTH_TOKEN'` (literal) or `track_env 'M53_PROBE_*'`
       (wildcard). Asserts every previously-seen example re-runs when a
@@ -156,7 +156,7 @@ tasks:
 
   test:integration:remote-cache:
     desc: >-
-      M7.1 S3Backend integration test against LocalStack. End-to-end
+      S3Backend integration test against LocalStack. End-to-end
       round-trip (upload + download + branch_refs + retention) against
       the real S3 API surface via awslocal. Excluded from the default
       rspec sweep. Depends on ci:localstack:ready so CI fails fast with
@@ -169,7 +169,7 @@ tasks:
 
   test:integration:remote-cache:redis:
     desc: >-
-      M7.2 RedisBackend integration test against a real Redis server.
+      RedisBackend integration test against a real Redis server.
       End-to-end round-trip (upload + download + branch_refs + retention
       + prune_all) against localhost:6379 (override via REDIS_URL).
       Depends on ci:redis:ready so CI fails fast if Redis is not reachable.
@@ -181,7 +181,7 @@ tasks:
 
   test:regressions:plain:
     desc: >-
-      M9.0 plain (non-Rails) regression specs at spec/regressions/.
+      Plain (non-Rails) regression specs at spec/regressions/.
       Covers upstream PR #72 (gem-generated examples with phantom
       file_path - rswag-shape - graceful degradation in Example.from
       and SourceFile.file_path) plus the rspec-retry + rspec-rerun
@@ -194,7 +194,7 @@ tasks:
 
   test:regressions:rails:
     desc: >-
-      M9.0 Rails-fixture-driving regression specs at spec/regressions/.
+      Rails-fixture-driving regression specs at spec/regressions/.
       Covers upstream issue #66 (template-change invalidates dependents
       via the render_template.action_view subscriber). Drives the
       rails_app fixture; same bundle-install + db:test:prepare ladder
@@ -208,7 +208,7 @@ tasks:
 
   test:regressions:
     desc: >-
-      M9.0 aggregate regression suite. Runs both test:regressions:plain
+      Aggregate regression suite. Runs both test:regressions:plain
       (non-Rails) and test:regressions:rails (drives rails_app
       fixture). Excluded from the default rspec sweep via
       .rspec --exclude-pattern.


### PR DESCRIPTION
## Summary

- New grep-based gate (`scripts/leak_check.rb`, run via `task docs:leak-check`) that scans every tracked file for internal planning vocabulary that must not ship in the public repo.
- Exemptions live in `.leakcheck-allow`; every entry requires a trailing justification comment, and entries without one fail the gate.
- `CHANGELOG.md` gets section-scoped scanning instead of a whole-path exemption: the active unreleased block is checked with the full pattern set, while frozen release history below the first released-version heading is exempt.
- A second, multiline pass over tracked Markdown catches directory-tree drawings that split a banned path across neighboring lines and would dodge single-line grep.
- Remaining comments and spec/scenario labels carrying internal work-labels are rewritten to state what shipped in self-contained words (text-only, no behavior change).

## Verification

- Gate self-test: `spec/integration/leak_check_spec.rb` (5 examples, 0 failures) plus a manual negative test -- injecting a leak into the changelog's active unreleased section fails the gate (both the single-line pattern and the split-rendering pass flag it), while the same text injected below the first released-version heading is correctly exempt; restoring the file returns the gate to clean.
- `task docs:leak-check` exits 0 on the committed tree, under both UTF-8 and no-locale (US-ASCII default encoding) environments.
- Lint suite: `task lint:ruby` (229 files, no offenses), `task lint:yaml` (strict), `task lint:actions` -- all clean.
- Unit specs: `task test:unit` -- 2061 examples, 0 failures.

The gate runs in the per-PR lint job from this PR onward.
