### PR TITLE
feat(cli): blast-radius + explain --not-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       mut_storage: ${{ steps.detect.outputs.mut_storage }}
       mut_rspec: ${{ steps.detect.outputs.mut_rspec }}
       mut_top_level: ${{ steps.detect.outputs.mut_top_level }}
+      mut_cli: ${{ steps.detect.outputs.mut_cli }}
       run_rails: ${{ steps.detect.outputs.run_rails }}
     steps:
       - name: Checkout
@@ -83,6 +84,7 @@ jobs:
               echo "mut_storage=true"
               echo "mut_rspec=true"
               echo "mut_top_level=true"
+              echo "mut_cli=true"
               echo "run_rails=false"
             } >> "$GITHUB_OUTPUT"
             echo "Non-PR event ($EVENT): tier=build (full matrix); all mutation subjects enabled"
@@ -98,6 +100,7 @@ jobs:
               echo "mut_storage=false"
               echo "mut_rspec=false"
               echo "mut_top_level=false"
+              echo "mut_cli=false"
               echo "run_rails=false"
             } >> "$GITHUB_OUTPUT"
             echo "No changed files: tier=skip"
@@ -125,6 +128,9 @@ jobs:
                 ;;
               lib/rspec_tracer/configuration.rb|lib/rspec_tracer/version.rb|lib/rspec_tracer/errors.rb|lib/rspec_tracer/time_formatter.rb|spec/top_level/*|spec/configuration_spec.rb|spec/rspec_tracer_spec.rb)
                 MUT_TOP_LEVEL=1
+                ;;
+              lib/rspec_tracer/cli.rb|lib/rspec_tracer/cli/*|spec/cli/*)
+                MUT_CLI=1
                 ;;
             esac
 
@@ -181,15 +187,15 @@ jobs:
           done <<< "$FILES"
 
           # Multi-subject diff is also a cross-cutting signal — if a
-          # PR touches 2+ subjects' lib/+spec/ surfaces we run all 4
+          # PR touches 2+ subjects' lib/+spec/ surfaces we run all 5
           # (refactors often miss a subject otherwise).
-          touched=$((MUT_TRACKER + MUT_STORAGE + MUT_RSPEC + MUT_TOP_LEVEL))
+          touched=$((MUT_TRACKER + MUT_STORAGE + MUT_RSPEC + MUT_TOP_LEVEL + MUT_CLI))
           if [ "$touched" -ge 2 ]; then
             MUT_FORCE_ALL=1
           fi
 
           if [ "$MUT_FORCE_ALL" = "1" ]; then
-            MUT_TRACKER=1; MUT_STORAGE=1; MUT_RSPEC=1; MUT_TOP_LEVEL=1
+            MUT_TRACKER=1; MUT_STORAGE=1; MUT_RSPEC=1; MUT_TOP_LEVEL=1; MUT_CLI=1
           fi
 
           to_bool() { [ "$1" = "1" ] && echo "true" || echo "false"; }
@@ -197,6 +203,7 @@ jobs:
           MS=$(to_bool "$MUT_STORAGE")
           MR=$(to_bool "$MUT_RSPEC")
           MTL=$(to_bool "$MUT_TOP_LEVEL")
+          MC=$(to_bool "$MUT_CLI")
           RR=$(to_bool "$RUN_RAILS")
 
           {
@@ -205,10 +212,11 @@ jobs:
             echo "mut_storage=${MS}"
             echo "mut_rspec=${MR}"
             echo "mut_top_level=${MTL}"
+            echo "mut_cli=${MC}"
             echo "run_rails=${RR}"
           } >> "$GITHUB_OUTPUT"
           echo "Detected tier: ${TIER}"
-          echo "Mutation subjects: tracker=${MT} storage=${MS} rspec=${MR} top_level=${MTL} (force_all=${MUT_FORCE_ALL})"
+          echo "Mutation subjects: tracker=${MT} storage=${MS} rspec=${MR} top_level=${MTL} cli=${MC} (force_all=${MUT_FORCE_ALL})"
           echo "Run rails fixture cell: ${RR}"
           echo "Changed files:"
           echo "$FILES"
@@ -223,6 +231,7 @@ jobs:
       mut_storage: ${{ needs.tier.outputs.mut_storage == 'true' }}
       mut_rspec: ${{ needs.tier.outputs.mut_rspec == 'true' }}
       mut_top_level: ${{ needs.tier.outputs.mut_top_level == 'true' }}
+      mut_cli: ${{ needs.tier.outputs.mut_cli == 'true' }}
     secrets: inherit
 
   full-matrix:

--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -25,6 +25,10 @@ on:
         type: boolean
         required: false
         default: true
+      mut_cli:
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -543,6 +547,25 @@ jobs:
         timeout-minutes: 5
         run: task test:mutation:top-level-c
 
+  test-mutation-cli:
+    name: test-mutation-cli
+    if: ${{ inputs.mut_cli }}
+    # CLI snapshot-reading surface: BlastRadius + the shared
+    # SnapshotHelpers module (26 subjects, ~20s local; single
+    # combined mutant run, gate 87%). The other CLI sub-commands are
+    # line-coverage-only; see taskfiles/test-mutation.yml for the
+    # gating rationale.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Test -- Mutation (cli)
+        timeout-minutes: 5
+        run: task test:mutation:cli
+
   test-integration-remote:
     name: test-integration-remote
     runs-on: ubuntu-latest
@@ -641,6 +664,7 @@ jobs:
       - test-mutation-top-level-a
       - test-mutation-top-level-b
       - test-mutation-top-level-c
+      - test-mutation-cli
       - test-integration-remote
       - test-regressions-plain
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@
 - **COOKBOOK recipes for flaky-test detection and file-to-test
   dependency mapping**, placed ahead of the acceleration recipes
   ([#224](https://github.com/avmnu-sng/rspec-tracer/issues/224)).
+- **`blast-radius` CLI sub-command.** `bundle exec rspec-tracer
+  blast-radius <file> [<file> ...]` reports how many examples a
+  change to each file would re-run (`450 examples across 12 spec
+  files`), with `--list` to enumerate them (location + description)
+  and `--json` for tooling. Multiple files compose with a
+  deduplicated total, so `git diff --name-only main | xargs bundle
+  exec rspec-tracer blast-radius` shows what a PR invalidates;
+  untracked paths report as such and exit 0 to keep that pipeline
+  unbroken. Whole-suite invalidators and boot-set files report
+  `re-runs all N examples`
+  ([#230](https://github.com/avmnu-sng/rspec-tracer/issues/230)).
+- **`explain --not-run` flag.** The skip-side view of `explain`:
+  whether the example was skipped on the last run (and the
+  derivation of why no run trigger fired), its last recorded
+  status, and what would make it run on the next invocation, plus
+  the tracked dependency files
+  ([#231](https://github.com/avmnu-sng/rspec-tracer/issues/231)).
+- **Doctor CI-environment line.** `rspec-tracer doctor` prints an
+  INFO line naming the CI env var it detected and pointing at the
+  cache-persistence recipes in
+  [`docs/CI_RECIPES.md`](docs/CI_RECIPES.md); never affects the
+  exit status
+  ([#228](https://github.com/avmnu-sng/rspec-tracer/issues/228)).
 
 ### Changed
 
@@ -38,6 +61,15 @@
   ([#224](https://github.com/avmnu-sng/rspec-tracer/issues/224)).
 
 ### Fixed
+
+- **CLI degrades cleanly when the project config itself is broken.**
+  A `.rspec-tracer` that raises at load time (including a
+  `SyntaxError`, which is not a `StandardError`) used to crash every
+  `rspec-tracer` sub-command with the raw backtrace plus a second
+  `NoMethodError` backtrace from the library's `at_exit` hook firing
+  against the half-loaded module. The binary now prints a one-line
+  `could not load configuration` message and exits 1, and `--help` /
+  `--version` answer without booting the config at all.
 
 - **Duplicate-example drop no longer discards nested spec files**
   ([#262](https://github.com/avmnu-sng/rspec-tracer/issues/262)).

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -24,6 +24,7 @@ from 1.x see [`UPGRADING.md`](UPGRADING.md). For internals see
 13. [Compose with Knapsack / RSpec::Retry / RSpec::Rerun](#13-compose-with-knapsack--rspecretry--rspecrerun)
 14. [Write a custom storage backend](#14-write-a-custom-storage-backend)
 15. [Write a custom reporter](#15-write-a-custom-reporter)
+16. [Measure a file's blast radius](#16-measure-a-files-blast-radius)
 
 ---
 
@@ -583,9 +584,11 @@ bundle exec rspec-tracer explain 'AdminController#create'
 ```
 
 Prints the example's last-run status, dependency set, and the run-
-decision reason (e.g. `"Files changed: app/controllers/admin_controller.rb"`,
-`"Whole-suite invalidator changed: Gemfile.lock"`,
-`"Failed previously"`).
+decision reason (e.g. `"Files changed"`,
+`"Whole-suite invalidator changed"`,
+`"Failed previously"`). The reason names the trigger category only;
+the `dependencies:` listing underneath shows which tracked files
+are involved.
 
 For a suite-wide breakdown, the terminal output already shows the
 top-level reasons after each run:
@@ -598,6 +601,23 @@ by reason: 38 Files changed · 4 Failed previously
 For deeper config-level debugging, `bundle exec rspec-tracer doctor`
 diagnoses the boot-time state of every contract (SimpleCov load
 order, schema version, remote-cache reachability, AR-schema config).
+
+### And why did it NOT run?
+
+`--not-run` flips `explain` to the skip-side view:
+
+```sh
+bundle exec rspec-tracer explain --not-run 'AdminController#create'
+```
+
+Prints whether the example was skipped on the last run -- and if
+so, the derivation of why no run trigger fired (no whole-suite
+invalidator, no boot-file change, no failed / flaky / pending /
+interrupted status, no changed dependency file, unchanged env
+snapshot) -- plus its last recorded status, the condition under
+which it runs next time, and its tracked dependency files. The
+cache keeps only the most recent snapshot, so "last status"
+reflects the last run, not a run history.
 
 ---
 
@@ -739,6 +759,67 @@ end
 Errors inside `generate` are caught by the Registry's per-reporter
 rescue + warn — a buggy custom reporter never breaks the test
 suite. Same graceful-degradation contract as Storage backends.
+
+---
+
+## 16. Measure a file's blast radius
+
+Goal: answer "if I change this file, how much of the suite re-runs?"
+from the command line, before you change it.
+
+After at least one traced run:
+
+```sh
+bundle exec rspec-tracer blast-radius app/models/user.rb
+```
+
+```
+/app/models/user.rb: 450 examples across 12 spec files
+```
+
+`--list` enumerates the affected examples (location + description);
+`--json` emits one machine-readable JSON document to stdout for
+tooling:
+
+```sh
+bundle exec rspec-tracer blast-radius --list app/models/user.rb
+bundle exec rspec-tracer blast-radius --json app/models/user.rb
+```
+
+Multiple files compose, with a deduplicated `total:` line -- so you
+can pipe a branch diff through it and see what a PR invalidates
+before review:
+
+```sh
+git diff --name-only main | xargs bundle exec rspec-tracer blast-radius
+```
+
+Files the cache never saw (docs, CI config) report
+`not tracked in cache` and still exit 0, so the git pipeline never
+breaks on non-Ruby paths. `not tracked` means the tracer never
+observed the file as an input -- NOT that the file never loaded.
+Files consumed outside the hooked surface land here too:
+`spec/spec_helper.rb` itself (it executes before coverage tracking
+starts), reads via unhooked APIs or C extensions, and the other
+blind spots listed in
+[ARCHITECTURE.md's soundness model](ARCHITECTURE.md#soundness-model).
+
+Reading the output:
+
+- Whole-suite invalidators (`Gemfile.lock`, `.ruby-version`,
+  `.rspec-tracer`) and boot-set files report
+  `re-runs all N examples`: a change to them invalidates every
+  cached example, not just tracked dependents. The boot-set row in
+  [ARCHITECTURE.md's soundness model](ARCHITECTURE.md#soundness-model)
+  explains why.
+- The count reflects the file-change trigger only; examples that
+  always re-run for status reasons (failed / flaky / pending /
+  interrupted) are not included.
+
+A blast radius that keeps growing is architectural drift made
+visible. For the same data as a browsable per-file HTML view, see
+the Files Dependency report in recipe
+[#4](#4-map-file-to-test-dependencies-files-dependency).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -396,16 +396,17 @@ Or override per-run via env: `RSPEC_TRACER_STORAGE=sqlite`.
 
 ## Command-line tools
 
-`rspec-tracer` exposes five sub-commands. Run them via Bundler so the
+`rspec-tracer` exposes six sub-commands. Run them via Bundler so the
 gem's executable resolves cleanly without needing `bundle binstubs
 rspec-tracer` first:
 
 ```sh
-bundle exec rspec-tracer doctor         # diagnose config + environment
-bundle exec rspec-tracer cache:info     # size, last run, invalidation stats
-bundle exec rspec-tracer cache:clear    # rm cache dirs
-bundle exec rspec-tracer report:open    # open the HTML report
-bundle exec rspec-tracer explain <id>   # why is <example_id> scheduled to (re-)run?
+bundle exec rspec-tracer doctor               # diagnose config + environment
+bundle exec rspec-tracer cache:info           # size, last run, invalidation stats
+bundle exec rspec-tracer cache:clear          # rm cache dirs
+bundle exec rspec-tracer report:open          # open the HTML report
+bundle exec rspec-tracer explain <id>         # why is <example_id> scheduled to (re-)run?
+bundle exec rspec-tracer blast-radius <file>  # which examples re-run if <file> changes?
 ```
 
 Generated binstubs (`bin/rspec-tracer …`) work too once you've run

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -89,10 +89,12 @@ Items:
   `explain`. Outputs *"if you modify this file, it triggers N examples
   across M files."* Lets developers spot architectural drift before
   the PR review; turns the dependency graph from invisible infra into
-  inspectable insight.
+  inspectable insight. Shipped -- see
+  [COOKBOOK.md](COOKBOOK.md#16-measure-a-files-blast-radius).
 - **`bin/rspec-tracer explain --not-run <example_id>`.** The "why
   did this NOT run?" inverse of the existing `explain`. Closes the
-  most-requested observability gap from pre-release.
+  most-requested observability gap from pre-release. Shipped -- see
+  [COOKBOOK.md](COOKBOOK.md#12-debug-why-did-this-test-re-run).
 - **Confidence scoring on per-run summary.** Terminal output extends
   to show what proportion of selection decisions came from explicit
   vs inferred dependencies; surfaces invalidation hotspots.

--- a/lib/rspec_tracer/cli.rb
+++ b/lib/rspec_tracer/cli.rb
@@ -2,23 +2,28 @@
 
 require 'optparse'
 
-# Require the top-level entry to pull in `docile` (used by
-# `Configuration#configure`) plus the autoloads sub-commands rely on.
-# Loading `rspec_tracer` does NOT call `RSpecTracer.start` - the engine
-# stays inert until a user invokes it explicitly.
-require 'rspec_tracer'
+# Only the Logger class -- NOT the full library, whose boot would
+# `load` the project config. {CLI.with_default_logger_out} needs the
+# class defined before that boot so the config-load window cannot
+# construct a stdout-bound logger.
+require_relative 'logger'
 
 module RSpecTracer
-  # Command-line entry for the `rspec-tracer` binary. Five sub-commands
-  # per USER_FACING_SURFACE.md §10: `doctor`, `cache:info`, `cache:clear`,
-  # `report:open`, `explain <example>`.
+  # Command-line entry for the `rspec-tracer` binary. Six sub-commands
+  # per USER_FACING_SURFACE.md section 10: `doctor`, `cache:info`,
+  # `cache:clear`, `report:open`, `explain <example>`,
+  # `blast-radius <file>`.
   #
   # The CLI is opt-in — the canonical CI flow continues to go through
   # `rake rspec_tracer:remote_cache:*` tasks per USER_FACING_SURFACE.md
   # §5. Sub-commands operate against the local cache + report
-  # directories resolved from the project's `.rspec-tracer` config
-  # (loaded lazily on first sub-command dispatch, not at CLI load time —
-  # `doctor` deliberately runs without requiring a configured project).
+  # directories resolved from the project's `.rspec-tracer` config.
+  # {.run} loads the tracer library (and with it the project + global
+  # `.rspec-tracer` configs) via {.load_tracer} right before
+  # sub-command dispatch, so `--help` / `--version` work even in a
+  # project whose config is broken, and a config file that raises at
+  # load time degrades to a one-line message + exit 1 instead of a
+  # raw backtrace.
   #
   # @api private
   module CLI
@@ -29,7 +34,8 @@ module RSpecTracer
       'cache:info' => 'CacheInfo',
       'cache:clear' => 'CacheClear',
       'report:open' => 'ReportOpen',
-      'explain' => 'Explain'
+      'explain' => 'Explain',
+      'blast-radius' => 'BlastRadius'
     }.freeze
 
     # CLI entry. Called by `bin/rspec-tracer` with `ARGV`. Wraps every
@@ -46,10 +52,102 @@ module RSpecTracer
       return print_top_level_help(stdout) if args.empty? || %w[-h --help help].include?(args.first)
       return print_version(stdout) if %w[-v --version].include?(args.first)
 
-      dispatch(args, stdout: stdout, stderr: stderr)
+      with_default_logger_out(stderr) do
+        if load_tracer(stderr)
+          with_logger_on(stderr) { dispatch(args, stdout: stdout, stderr: stderr) }
+        else
+          1
+        end
+      end
+    rescue Errno::EPIPE
+      # A downstream pipe consumer (`rspec-tracer ... | head`) closed
+      # early -- routine in shell pipelines, not a failure. Exit 0
+      # without printing: writing to stderr could raise EPIPE again
+      # when both streams share the closed pipe.
+      0
     rescue StandardError => e
       stderr.puts "rspec-tracer: #{e.class}: #{e.message}"
       1
+    end
+
+    # Boot the tracer library for sub-command dispatch. Loading
+    # `rspec_tracer` pulls in `docile` (used by
+    # `Configuration#configure`), the modules sub-commands rely on,
+    # AND the project's `.rspec-tracer` / `~/.rspec-tracer` configs
+    # (arbitrary user Ruby, `load`ed by `load_config`). It does NOT
+    # call `RSpecTracer.start` - the engine stays inert until a user
+    # invokes it explicitly.
+    #
+    # A raising config must not crash the binary with a backtrace:
+    # rescue ScriptError as well as StandardError because a syntax
+    # error in `.rspec-tracer` raises SyntaxError, which is not a
+    # StandardError and would sail past {.run}'s rescue.
+    #
+    # @param stderr [IO]
+    # @return [Boolean] true when the tracer library (and the user
+    #   configs it loads) booted cleanly
+    def self.load_tracer(stderr)
+      require 'rspec_tracer'
+      true
+    rescue ScriptError, StandardError => e
+      stderr.puts "rspec-tracer: could not load configuration (.rspec-tracer): #{e.class}: #{e.message}"
+      false
+    end
+
+    # Point {RSpecTracer::Logger.default_out} at the CLI's stderr for
+    # the duration of library boot + sub-command dispatch, restoring
+    # the previous value afterwards. This must wrap {.load_tracer}:
+    # booting the library `load`s the project + global `.rspec-tracer`
+    # configs, and those can write through the logger BEFORE
+    # {.with_logger_on} ever runs -- the 1.x-compat deprecation shims
+    # (`reports_s3_path`, `use_local_aws`) fire a one-time
+    # `logger.warn` at first use, and in a fresh CLI process
+    # "one-time" means every invocation. The logger's default
+    # destination is stdout -- the stream machine consumers parse --
+    # so that warning would land ahead of e.g. the `blast-radius
+    # --json` document and break `| jq`. With the default rebound,
+    # every logger constructed during the window binds to stderr,
+    # including loggers recreated mid-load when a config sets
+    # `log_level` (which resets the memoized instance) after a
+    # deprecated DSL call. Normal `rspec` runs (whose users expect
+    # stdout logs) never enter this path and stay untouched.
+    # @api private
+    def self.with_default_logger_out(stderr)
+      previous = RSpecTracer::Logger.default_out
+      RSpecTracer::Logger.default_out = stderr
+      yield
+    ensure
+      RSpecTracer::Logger.default_out = previous
+    end
+
+    # Bind the tracer's internal logger to the CLI's stderr for the
+    # duration of sub-command dispatch, restoring the previous logger
+    # afterwards. Backend diagnostics run through `RSpecTracer.logger`
+    # (e.g. {RSpecTracer::Storage::Backend.build}'s sqlite-unavailable
+    # fallback warning, JsonBackend's schema-mismatch info line).
+    # {.with_default_logger_out} already redirects loggers constructed
+    # during the CLI window; this layer additionally rebinds a logger
+    # that was memoized into `RSpecTracer.@logger` BEFORE {.run} was
+    # called (possible for in-process callers -- the spec suite, or a
+    # user embedding the CLI -- where the library booted earlier with
+    # the stdout default). Sub-commands like `blast-radius --json`
+    # promise exactly one JSON document on stdout, so a diagnostic
+    # line printed ahead of it breaks `| jq`; together the two layers
+    # keep ALL diagnostics on stderr alongside the CLI's own messages.
+    #
+    # `RSpecTracer.logger` memoizes into `@logger`
+    # (Configuration#logger); the ivar is seeded directly because
+    # Configuration deliberately exposes no logger setter -- adding
+    # one would leak it into the user-facing `configure` DSL surface.
+    # @api private
+    def self.with_logger_on(stderr)
+      previous = RSpecTracer.instance_variable_get(:@logger)
+      RSpecTracer.instance_variable_set(
+        :@logger, RSpecTracer::Logger.new(RSpecTracer.log_level, out: stderr)
+      )
+      yield
+    ensure
+      RSpecTracer.instance_variable_set(:@logger, previous)
     end
 
     # Internal helper for the tracer pipeline.
@@ -83,6 +181,7 @@ module RSpecTracer
           cache:clear     Remove cache, coverage, and report directories.
           report:open     Open the HTML report in the default browser.
           explain <id>    Show why an example is scheduled to run or skip.
+          blast-radius <f>  Show which examples a file change would re-run.
 
         Options:
           -h, --help      Print this help message.
@@ -96,6 +195,10 @@ module RSpecTracer
     # Internal helper for the tracer pipeline.
     # @api private
     def self.print_version(stdout)
+      # Only the version constant - not the full library, whose boot
+      # would `load` the project config and could raise before the
+      # version ever printed.
+      require 'rspec_tracer/version'
       stdout.puts "rspec-tracer #{RSpecTracer::VERSION}"
       0
     end

--- a/lib/rspec_tracer/cli/blast_radius.rb
+++ b/lib/rspec_tracer/cli/blast_radius.rb
@@ -1,0 +1,318 @@
+# frozen_string_literal: true
+
+require 'json'
+
+require 'rspec_tracer/cli/snapshot_helpers'
+require 'rspec_tracer/tracker/whole_suite_invalidators'
+
+module RSpecTracer
+  # Internal CLI -- see {RSpecTracer} for the user-facing surface.
+  # @api private
+  module CLI
+    # `rspec-tracer blast-radius <file> [<file> ...]` -- show which
+    # examples a change to each given file would re-run on the next
+    # rspec invocation. Reads the persisted reverse-dependency map
+    # (file -> examples) plus the whole-suite invalidator watch list
+    # and the boot set, so whole-suite triggers (Gemfile.lock, boot
+    # files) report "re-runs all N examples" instead of under-reporting
+    # via a bare reverse-dependency lookup. Reports the file-change
+    # trigger only; examples that always re-run for status reasons
+    # (failed / flaky / pending / interrupted) are not included.
+    # Backend-agnostic: dispatches through
+    # {RSpecTracer::Storage::Backend.build} (via
+    # {SnapshotHelpers.load_snapshot}) so `storage_backend :sqlite`
+    # resolves the latest run from the meta table instead of the
+    # JsonBackend-only `last_run.json` file.
+    module BlastRadius
+      # Internal constant.
+      # @api private
+      USAGE = 'rspec-tracer blast-radius [--list|--json] <file> [<file> ...]'
+
+      # Statuses whose blast radius is the entire suite (a change to
+      # the file invalidates every cached example, not just tracked
+      # dependents).
+      # @api private
+      WHOLE_SUITE_STATUSES = %w[whole_suite_invalidator boot_file].freeze
+
+      # @param args [Array<String>] sub-command args. `--list` / `--json`
+      #   flags plus one or more file paths (relative to the project
+      #   root or absolute).
+      # @param stdout [IO]
+      # @param stderr [IO]
+      # @return [Integer] exit status (0 = radius printed, including
+      #   untracked / zero-dependent files; 1 = no files given, unknown
+      #   option, cache missing, or schema mismatch).
+      def self.run(args, stdout: $stdout, stderr: $stderr)
+        return print_help(stdout) if SnapshotHelpers.help_requested?(args)
+
+        parsed = parse_args(args)
+        return unknown_option(parsed[:unknown], stderr) unless parsed[:unknown].nil?
+        return no_files(stderr) if parsed[:files].empty?
+
+        execute(parsed, stdout, stderr)
+      rescue Errno::EPIPE
+        # Downstream pipe (`... | head`, `... | jq`) closed early --
+        # routine in shell pipelines (the help text promotes them),
+        # not a failure. Exit 0 silently.
+        0
+      rescue StandardError => e
+        stderr.puts "blast-radius: #{e.class}: #{e.message}"
+        1
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.execute(parsed, stdout, stderr)
+        loaded = SnapshotHelpers.load_snapshot(RSpecTracer.cache_path, command: 'blast-radius', stderr: stderr)
+        return 1 if loaded.nil?
+
+        snapshot, = loaded
+        radii = parsed[:files].map { |file| radius_for(file, snapshot) }
+        if parsed[:json]
+          stdout.puts JSON.pretty_generate(json_payload(radii, snapshot))
+        else
+          print_report(stdout, radii, snapshot, list: parsed[:list])
+        end
+        0
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.parse_args(args)
+        parsed = { list: false, json: false, files: [], unknown: nil }
+        args.each do |arg|
+          case arg
+          when '--list' then parsed[:list] = true
+          when '--json' then parsed[:json] = true
+          when /\A-/ then parsed[:unknown] ||= arg
+          else parsed[:files] << arg
+          end
+        end
+        parsed
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.unknown_option(arg, stderr)
+        stderr.puts "blast-radius: unknown option #{arg.inspect}"
+        stderr.puts "  usage: #{USAGE}"
+        1
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.no_files(stderr)
+        stderr.puts 'blast-radius: no file paths given'
+        stderr.puts "  usage: #{USAGE}"
+        1
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.print_help(stdout)
+        stdout.puts <<~HELP
+          Usage: #{USAGE}
+
+          Show which examples a change to each given file would re-run on
+          the next rspec invocation. Reports the file-change trigger only;
+          examples that always re-run for status reasons (failed / flaky /
+          pending / interrupted) are not included. Paths may be relative to
+          the project root or absolute. Whole-suite invalidators
+          (Gemfile.lock, .ruby-version, .rspec-tracer) and boot files
+          re-run every example. Backend-aware: works under
+          `storage_backend :json` (default) and `storage_backend :sqlite`.
+          Requires a prior rspec run.
+
+          Multi-file input composes with git:
+
+            git diff --name-only main | xargs bundle exec rspec-tracer blast-radius
+
+          Options:
+            --list    Enumerate affected examples (location + description).
+            --json    Emit one machine-readable JSON document to stdout.
+        HELP
+        0
+      end
+
+      # Convert a user-supplied path into the cache's file_name
+      # convention (project-relative with a leading `/`, absolute when
+      # outside the project root). Computed at command runtime against
+      # `RSpecTracer.root` -- `SourceFile.file_name` is unsuitable here
+      # because its PROJECT_ROOT_REGEX freezes the root at gem-require
+      # time, before the CLI loads the project's `.rspec-tracer` config.
+      # @api private
+      def self.normalize_file_name(path)
+        root = RSpecTracer.root
+        abs = File.expand_path(path, root)
+        return abs unless abs.start_with?("#{root}/")
+
+        "/#{abs[(root.length + 1)..]}"
+      end
+
+      # Classify one input file and collect its affected examples.
+      # Precedence: whole-suite invalidator watch file, then boot file
+      # (boot-set changes OR into whole-suite invalidation), then
+      # tracked reverse dependents, then untracked / no-dependents.
+      # Note the key conventions: `boot_set` keys are project-relative
+      # (no leading slash) while `reverse_dependency` / `all_files`
+      # keys carry a leading slash.
+      # @api private
+      def self.radius_for(path, snapshot)
+        file_name = normalize_file_name(path)
+        relative = file_name.delete_prefix('/')
+
+        if Tracker::WholeSuiteInvalidators::WATCH_FILES.include?(relative)
+          whole_suite_radius(path, file_name, 'whole_suite_invalidator', snapshot)
+        elsif (snapshot.boot_set || {}).key?(relative)
+          whole_suite_radius(path, file_name, 'boot_file', snapshot)
+        else
+          dependent_radius(path, file_name, snapshot)
+        end
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.whole_suite_radius(path, file_name, status, snapshot)
+        ids = (snapshot.all_examples || {}).keys
+        { path: path, file_name: file_name, status: status,
+          examples: example_entries(ids, snapshot) }
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.dependent_radius(path, file_name, snapshot)
+        ids = (snapshot.reverse_dependency || {})[file_name]
+        if ids.nil? || ids.empty?
+          status = (snapshot.all_files || {}).key?(file_name) ? 'no_dependents' : 'untracked'
+          { path: path, file_name: file_name, status: status, examples: [] }
+        else
+          { path: path, file_name: file_name, status: 'tracked',
+            examples: example_entries(ids, snapshot) }
+        end
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.example_entries(ids, snapshot)
+        all = snapshot.all_examples || {}
+        ids.map { |id| example_entry(id.to_s, all[id]) }
+          .sort_by { |entry| [entry[:location], entry[:description]] }
+      end
+
+      # Enrich one example_id from the persisted all_examples meta.
+      # A dangling id (present in reverse_dependency but missing from
+      # all_examples -- stale or partially-written cache) degrades to
+      # `<unknown>` fields instead of raising.
+      # @api private
+      def self.example_entry(id, meta)
+        meta = {} unless meta.is_a?(::Hash)
+        file, line = SnapshotHelpers.example_location(meta)
+        {
+          example_id: id,
+          spec_file: file || '<unknown>',
+          location: file.nil? ? '<unknown>' : "#{file}:#{line}",
+          description: SnapshotHelpers.example_description(meta) || '<unknown>'
+        }
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.print_report(stdout, radii, snapshot, list:)
+        radii.each do |radius|
+          stdout.puts summary_line(radius)
+          next unless list
+
+          radius[:examples].each do |entry|
+            stdout.puts "  #{entry[:location]}  #{entry[:description]}"
+          end
+        end
+        print_total(stdout, radii, snapshot) if radii.size > 1
+      end
+
+      # Internal helper for the tracer pipeline.
+      # The untracked wording sticks to what the tracer can actually
+      # observe: absence of the file from the cache. It must NOT claim
+      # the file "never loaded" -- files consumed outside the hooked
+      # surface (spec_helper.rb itself, which executes before coverage
+      # tracking starts; reads via unhooked APIs, C extensions, or
+      # other threads) load fine yet never appear in the cache. See
+      # the soundness model in ARCHITECTURE.md.
+      # @api private
+      def self.summary_line(radius)
+        file_name = radius[:file_name]
+        count = radius[:examples].size
+        case radius[:status]
+        when 'whole_suite_invalidator'
+          "#{file_name}: whole-suite invalidator -- re-runs all #{count} examples"
+        when 'boot_file'
+          "#{file_name}: boot file -- re-runs all #{count} examples"
+        when 'untracked'
+          "#{file_name}: not tracked in cache (no recorded dependents -- the tracer never " \
+          'observed it as an input; see the soundness model in ARCHITECTURE.md)'
+        when 'no_dependents'
+          "#{file_name}: 0 examples (no tracked dependents)"
+        else
+          "#{file_name}: #{count} examples across #{spec_file_count(radius[:examples])} spec files"
+        end
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.print_total(stdout, radii, snapshot)
+        if radii.any? { |radius| WHOLE_SUITE_STATUSES.include?(radius[:status]) }
+          total = (snapshot.all_examples || {}).size
+          stdout.puts "total: all #{total} examples (whole-suite invalidator)"
+        else
+          union = union_entries(radii)
+          stdout.puts "total: #{union.size} unique examples across #{spec_file_count(union)} spec files"
+        end
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.union_entries(radii)
+        radii.flat_map { |radius| radius[:examples] }.uniq { |entry| entry[:example_id] }
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.spec_file_count(entries)
+        entries.map { |entry| entry[:spec_file] }.uniq.size
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.json_payload(radii, snapshot)
+        union = union_entries(radii)
+        {
+          'files' => radii.map { |radius| file_json(radius) },
+          'total' => {
+            'example_count' => union.size,
+            'spec_file_count' => spec_file_count(union),
+            'whole_suite' => radii.any? { |radius| WHOLE_SUITE_STATUSES.include?(radius[:status]) },
+            'all_examples_count' => (snapshot.all_examples || {}).size
+          }
+        }
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.file_json(radius)
+        {
+          'path' => radius[:path],
+          'file_name' => radius[:file_name],
+          'status' => radius[:status],
+          'example_count' => radius[:examples].size,
+          'spec_file_count' => spec_file_count(radius[:examples]),
+          'examples' => radius[:examples].map do |entry|
+            {
+              'example_id' => entry[:example_id],
+              'location' => entry[:location],
+              'description' => entry[:description]
+            }
+          end
+        }
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/cli/cache_clear.rb
+++ b/lib/rspec_tracer/cli/cache_clear.rb
@@ -18,7 +18,6 @@ module RSpecTracer
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 
-        require 'rspec_tracer/load_config'
         existing = existing_targets
         return nothing_to_remove(stdout) if existing.empty?
 
@@ -26,6 +25,10 @@ module RSpecTracer
         return aborted(stdout) unless skip_confirmation?(args) || confirm?(stdout)
 
         remove_each(stdout, existing)
+        0
+      rescue Errno::EPIPE
+        # Downstream pipe (`... | head`) closed early -- routine in
+        # shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "cache:clear: #{e.class}: #{e.message}"

--- a/lib/rspec_tracer/cli/cache_info.rb
+++ b/lib/rspec_tracer/cli/cache_info.rb
@@ -22,8 +22,6 @@ module RSpecTracer
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 
-        require 'rspec_tracer/load_config'
-
         cache_path = RSpecTracer.cache_path
         stdout.puts "cache_path: #{cache_path}"
         stdout.puts "size:       #{format_bytes(directory_size(cache_path))}"
@@ -37,6 +35,10 @@ module RSpecTracer
 
         stdout.puts "last_run:   #{run_id}"
         print_example_count(stdout, backend)
+        0
+      rescue Errno::EPIPE
+        # Downstream pipe (`... | head`) closed early -- routine in
+        # shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "cache:info: #{e.class}: #{e.message}"

--- a/lib/rspec_tracer/cli/doctor.rb
+++ b/lib/rspec_tracer/cli/doctor.rb
@@ -17,8 +17,6 @@ module RSpecTracer
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 
-        require 'rspec_tracer/load_config'
-
         checks = [
           ruby_version_check,
           tracer_version_check,
@@ -31,11 +29,16 @@ module RSpecTracer
           rails_check,
           cache_schema_version_check,
           remote_cache_check,
-          ar_schema_narrow_attribution_check
+          ar_schema_narrow_attribution_check,
+          ci_environment_check
         ]
         checks.each { |line| stdout.puts line }
         ok = checks.none? { |line| line.start_with?('FAIL') }
         ok ? 0 : 1
+      rescue Errno::EPIPE
+        # Downstream pipe (`... | head`) closed early -- routine in
+        # shell pipelines, not a failure. Exit 0 silently.
+        0
       rescue StandardError => e
         stderr.puts "doctor: #{e.class}: #{e.message}"
         1
@@ -250,6 +253,26 @@ module RSpecTracer
             'section "Narrow AR schema attribution".'
         else
           'OK   AR schema:   narrow attribution preconditions look good'
+        end
+      end
+
+      # Environment variables that signal a CI environment, one per
+      # major provider plus the near-universal `CI` convention.
+      CI_ENV_VARS = %w[CI GITHUB_ACTIONS GITLAB_CI CIRCLECI BUILDKITE TF_BUILD].freeze
+
+      # Surface the cache-persistence recipes exactly when the user is
+      # on CI, where a non-persisted cache silently degrades every run
+      # to a cold run. Detection requires a var that is set AND
+      # non-empty: `ENV['CI'] == ""` is truthy in Ruby (a shell with
+      # `CI=` exported would otherwise read as detected). INFO both
+      # ways - being in or out of CI is not a health state, so this
+      # check never affects the exit status.
+      def self.ci_environment_check
+        var = CI_ENV_VARS.find { |v| !ENV[v].to_s.empty? }
+        if var
+          "INFO ci:          detected via ENV[#{var}] -- cache persistence recipes: docs/CI_RECIPES.md"
+        else
+          'INFO ci:          not detected (local run)'
         end
       end
 

--- a/lib/rspec_tracer/cli/explain.rb
+++ b/lib/rspec_tracer/cli/explain.rb
@@ -1,62 +1,51 @@
 # frozen_string_literal: true
 
-require 'rspec_tracer/storage/backend'
-require 'rspec_tracer/storage/json_backend'
-require 'rspec_tracer/storage/schema'
-require 'rspec_tracer/storage/sqlite_backend' if RUBY_ENGINE == 'ruby'
+require 'rspec_tracer/cli/snapshot_helpers'
 
 module RSpecTracer
-  # Internal CLI — see {RSpecTracer} for the user-facing surface.
+  # Internal CLI -- see {RSpecTracer} for the user-facing surface.
   # @api private
   module CLI
-    # `rspec-tracer explain <example>` — show why a given example is
+    # `rspec-tracer explain <example>` -- show why a given example is
     # scheduled to run or skip on the next rspec invocation. Backend-
     # agnostic: dispatches through {RSpecTracer::Storage::Backend.build}
-    # so `storage_backend :sqlite` resolves the latest run from the
-    # meta table instead of the JsonBackend-only `last_run.json` file.
+    # (via {SnapshotHelpers.load_snapshot}) so `storage_backend :sqlite`
+    # resolves the latest run from the meta table instead of the
+    # JsonBackend-only `last_run.json` file.
     module Explain
       # @param args [Array<String>] sub-command args. First positional
-      #   arg is the example_id (or substring) to explain.
+      #   arg is the example_id (or substring) to explain. `--not-run`
+      #   flips the output to the skip-side view: why the example was
+      #   NOT run last time, and what would make it run next time.
       # @param stdout [IO]
       # @param stderr [IO]
       # @return [Integer] exit status (0 = explanation printed,
       #   1 = example not found / cache missing).
       def self.run(args, stdout: $stdout, stderr: $stderr)
-        return print_help(stdout) if args.empty? || args.include?('-h') || args.include?('--help')
+        args = args.dup
+        not_run = !args.delete('--not-run').nil?
+        return print_help(stdout) if SnapshotHelpers.help_requested?(args)
 
-        require 'rspec_tracer/load_config'
-        cache_path = RSpecTracer.cache_path
+        loaded = SnapshotHelpers.load_snapshot(RSpecTracer.cache_path, command: 'explain', stderr: stderr)
+        return 1 if loaded.nil?
 
-        snapshot = load_snapshot(cache_path, stderr)
-        return 1 if snapshot.nil?
-
+        snapshot, backend = loaded
         match = find_example(snapshot.all_examples, args.first)
         return no_match(args.first, snapshot.all_examples, stderr) if match.nil?
 
-        print_explanation(stdout, match, snapshot)
+        if not_run
+          print_not_run_explanation(stdout, match, snapshot, backend)
+        else
+          print_explanation(stdout, match, snapshot)
+        end
+        0
+      rescue Errno::EPIPE
+        # Downstream pipe (`... | head`) closed early -- routine in
+        # shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "explain: #{e.class}: #{e.message}"
         1
-      end
-
-      # Internal helper for the tracer pipeline.
-      # @api private
-      def self.load_snapshot(cache_path, stderr)
-        backend = Storage::Backend.build(cache_path: cache_path, configuration: RSpecTracer)
-        run_id = backend.last_run_id
-        if run_id.nil? || run_id.to_s.empty?
-          stderr.puts "explain: no cache yet at #{cache_path} — run rspec first"
-          return nil
-        end
-
-        snapshot = backend.load_graph(schema_version: Storage::Schema::CURRENT)
-        if snapshot.nil?
-          stderr.puts "explain: cache at #{cache_path} is incompatible with this rspec-tracer; next rspec run is cold"
-          return nil
-        end
-
-        snapshot
       end
 
       # Internal helper for the tracer pipeline.
@@ -71,13 +60,19 @@ module RSpecTracer
       # @api private
       def self.print_help(stdout)
         stdout.puts <<~HELP
-          Usage: rspec-tracer explain <example_id_or_substring>
+          Usage: rspec-tracer explain [--not-run] <example_id_or_substring>
 
           Show why an example is scheduled to run or skip. Matches against
           example_id exactly first, then falls back to a substring match
           on the example's full_description. Backend-aware: works under
           `storage_backend :json` (default) and `storage_backend :sqlite`.
           Requires a prior rspec run.
+
+          --not-run flips to the skip-side view: whether the example was
+          skipped on the last run (and why no run trigger fired), its last
+          recorded status, and what would make it run on the next rspec
+          invocation. The cache keeps only the most recent snapshot, so
+          "last status" reflects the last run, not a run history.
         HELP
         0
       end
@@ -89,7 +84,7 @@ module RSpecTracer
 
         all_examples.find do |id, meta|
           meta = {} unless meta.is_a?(::Hash)
-          desc = fetch_meta(meta, 'full_description') || fetch_meta(meta, 'description') || ''
+          desc = SnapshotHelpers.example_description(meta) || ''
           id.include?(query) || desc.include?(query)
         end&.last
       end
@@ -98,55 +93,177 @@ module RSpecTracer
       # @api private
       def self.print_explanation(stdout, meta, snapshot)
         meta = {} unless meta.is_a?(::Hash)
-        format_lines(meta).each { |line| stdout.puts line }
+        id = SnapshotHelpers.fetch_meta(meta, 'example_id', 'id')
+        format_lines(meta, skipped: skipped?(id, snapshot)).each { |line| stdout.puts line }
         print_dependency_summary(stdout, meta, snapshot)
       end
 
       # Internal helper for the tracer pipeline.
       # @api private
-      def self.format_lines(meta)
-        id = fetch_meta(meta, 'example_id', 'id') || '<unknown>'
-        file = fetch_meta(meta, 'rerun_file_name', 'file_name')
-        line = fetch_meta(meta, 'rerun_line_number', 'line_number')
-        status = dig_meta(meta, 'execution_result', 'status') || fetch_meta(meta, 'status') || 'unknown'
+      def self.format_lines(meta, skipped: false)
+        id = SnapshotHelpers.fetch_meta(meta, 'example_id', 'id') || '<unknown>'
+        file, line = SnapshotHelpers.example_location(meta)
+        status = last_status(meta)
         [
           "id:           #{id}",
-          "description:  #{fetch_meta(meta, 'full_description', 'description')}",
+          "description:  #{SnapshotHelpers.example_description(meta)}",
           "location:     #{file}:#{line}",
           "last status:  #{status}",
-          "run reason:   #{fetch_meta(meta, 'run_reason') || '<not recorded>'}"
+          "run reason:   #{run_reason_field(meta, skipped)}"
         ]
       end
 
-      # Look up a key from a Hash, tolerating both String and Symbol
-      # storage. Snapshot Hashes round-tripped through JSON yield
-      # String keys; the post-#182 msgpack serializer preserves
-      # Symbol keys end-to-end, so callers can't assume either shape.
-      def self.fetch_meta(meta, *keys)
-        keys.each do |k|
-          v = meta[k]
-          return v unless v.nil?
+      # The run-side `run reason:` value. For an example the filter
+      # SKIPPED on the last run, the persisted run_reason is the
+      # carry-forward reason seeded from an earlier snapshot -- it says
+      # why the example ran back then, not why it is in its current
+      # state. Printing it bare would misreport a skipped example as
+      # having a current run trigger, so flag it and point at the
+      # `--not-run` skip-side view instead.
+      # @api private
+      def self.run_reason_field(meta, skipped)
+        reason = SnapshotHelpers.fetch_meta(meta, 'run_reason') || '<not recorded>'
+        return reason unless skipped
 
-          sym_value = meta[k.to_sym]
-          return sym_value unless sym_value.nil?
+        "#{reason} (carried forward from an earlier run; " \
+          'this example was SKIPPED last run -- use --not-run for the skip-side view)'
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.last_status(meta)
+        SnapshotHelpers.dig_meta(meta, 'execution_result', 'status') ||
+          SnapshotHelpers.fetch_meta(meta, 'status') || 'unknown'
+      end
+
+      # The `--not-run` view. Deliberately does NOT print the
+      # `run reason:` field from all_examples meta: for a skipped
+      # example that field is the carry-forward PRIOR-run reason
+      # (seeded from the previous snapshot), so echoing it here would
+      # misreport why the example did not run. Everything below is
+      # derived from the per-run membership sets instead
+      # (skipped_examples / filtered_examples / the status id-sets).
+      def self.print_not_run_explanation(stdout, meta, snapshot, backend)
+        meta = {} unless meta.is_a?(::Hash)
+        id = SnapshotHelpers.fetch_meta(meta, 'example_id', 'id') || '<unknown>'
+        filter_persisted = SnapshotHelpers.filter_decisions_persisted?(backend)
+        print_not_run_header(stdout, meta, id)
+        stdout.puts last_run_line(id, snapshot, filter_persisted: filter_persisted)
+        not_run_detail_lines(id, snapshot).each { |detail| stdout.puts detail }
+        stdout.puts "last status:  #{last_status(meta)} (most recent snapshot; this cache keeps only the last run)"
+        stdout.puts "next run:     #{next_run_line(id, snapshot)}"
+        print_dependency_summary(stdout, meta, snapshot)
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.print_not_run_header(stdout, meta, id)
+        file, line = SnapshotHelpers.example_location(meta)
+        stdout.puts "id:           #{id}"
+        stdout.puts "description:  #{SnapshotHelpers.example_description(meta)}"
+        stdout.puts "location:     #{file}:#{line}"
+      end
+
+      # Detail lines printed under `last run:`: the itemized skip
+      # derivation for a skipped id, a run-side hint for an id that
+      # actually ran, nothing for the no-decision fallbacks.
+      # @return [Array<String>]
+      def self.not_run_detail_lines(id, snapshot)
+        return skip_reason_lines(id, snapshot) if skipped?(id, snapshot)
+
+        if ran_reason(id, snapshot)
+          return ["  it was not skipped; run 'rspec-tracer explain #{id}' for the run-side view"]
         end
+
+        []
+      end
+
+      # One `last run:` line for the `--not-run` view, derived from
+      # per-run membership: skipped_examples (the filter skipped it),
+      # filtered_examples (it ran, with the recorded reason), or
+      # neither. The neither case splits on `filter_persisted`: a
+      # backend that persists filter decisions (json) with an empty
+      # decision set means the last run recorded no decision for this
+      # id (a cold run persists empty sets by design, and an id absent
+      # from the last run has no entry either) -- only a
+      # non-persisting backend (sqlite) earns the storage-backend
+      # wording.
+      # @return [String]
+      def self.last_run_line(id, snapshot, filter_persisted:)
+        return 'last run:     skipped (cache hit)' if skipped?(id, snapshot)
+
+        reason = ran_reason(id, snapshot)
+        return "last run:     ran -- #{reason}" if reason
+        return 'last run:     <not recorded by this storage backend>' unless filter_persisted
+
+        'last run:     no filter decision recorded (cold run, or this example was not part of it)'
+      end
+
+      # Itemized derivation of WHY the filter skipped the example.
+      # Sound because a skip logically implies every trigger in the
+      # engine's precedence chain declined: no whole-suite invalidator
+      # fired, no boot file changed (the engine ORs the boot-set check
+      # into whole-suite invalidation), the example carried no
+      # always-re-run status, none of its tracked dependency files
+      # changed, and its tracked environment snapshot was unchanged.
+      # @return [Array<String>]
+      def self.skip_reason_lines(id, snapshot)
+        deps = Array((snapshot.dependency || {})[id])
+        [
+          'skip reason:  no run trigger fired last run:',
+          '  - whole-suite invalidators (Gemfile.lock, .ruby-version, .rspec-tracer, gem version): unchanged',
+          '  - boot set: no boot file changed',
+          '  - prior status: not failed / flaky / pending / interrupted',
+          "  - dependency files: #{deps.size} tracked, none changed",
+          '  - environment snapshot: unchanged for this example'
+        ]
+      end
+
+      # Prediction line for the NEXT run, from the persisted status
+      # sets (the inputs to the next run's always-re-run triggers).
+      # @return [String]
+      def self.next_run_line(id, snapshot)
+        reason = always_rerun_reason(id, snapshot)
+        return "will re-run regardless (#{reason} last run)" if reason
+
+        'runs only if a dependency, whole-suite invalidator, boot file, or tracked env var changes'
+      end
+
+      # First always-re-run status the id carries, in the filter's
+      # precedence order (interrupted > flaky > failed > pending), or
+      # nil when the example has no status-based re-run trigger.
+      # @return [String, nil]
+      def self.always_rerun_reason(id, snapshot)
+        return 'interrupted' if in_id_set?(snapshot.interrupted_examples, id)
+        return 'flaky' if in_id_set?(snapshot.flaky_examples, id)
+        return 'failed' if in_id_set?(snapshot.failed_examples, id)
+        return 'pending' if in_id_set?(snapshot.pending_examples, id)
+
         nil
       end
 
-      # Look up a nested key from a Hash, tolerating both String and
-      # Symbol storage at each level. See {.fetch_meta} for rationale.
-      def self.dig_meta(meta, *keys)
-        keys.reduce(meta) do |acc, k|
-          break nil if acc.nil? || !acc.is_a?(::Hash)
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.skipped?(id, snapshot)
+        in_id_set?(snapshot.skipped_examples, id)
+      end
 
-          acc[k] || acc[k.to_sym]
-        end
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.ran_reason(id, snapshot)
+        SnapshotHelpers.fetch_meta(snapshot.filtered_examples || {}, id)
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.in_id_set?(id_set, id)
+        (id_set || []).include?(id)
       end
 
       # Internal helper for the tracer pipeline.
       # @api private
       def self.print_dependency_summary(stdout, meta, snapshot)
-        id = fetch_meta(meta, 'example_id', 'id')
+        id = SnapshotHelpers.fetch_meta(meta, 'example_id', 'id')
         deps = snapshot.dependency || {}
         files = Array(deps[id])
         stdout.puts "dependencies: #{files.size} files tracked"

--- a/lib/rspec_tracer/cli/report_open.rb
+++ b/lib/rspec_tracer/cli/report_open.rb
@@ -17,8 +17,6 @@ module RSpecTracer
       def self.run(args, stdout: $stdout, stderr: $stderr)
         return print_help(stdout) if args.include?('-h') || args.include?('--help')
 
-        require 'rspec_tracer/load_config'
-
         report_path = RSpecTracer.report_path
         index_path = File.join(report_path, 'index.html')
 
@@ -35,6 +33,19 @@ module RSpecTracer
           return 0
         end
 
+        launch(opener, index_path, stdout, stderr)
+      rescue Errno::EPIPE
+        # Downstream pipe (`... | head`) closed early -- routine in
+        # shell pipelines, not a failure. Exit 0 silently.
+        0
+      rescue StandardError => e
+        stderr.puts "report:open: #{e.class}: #{e.message}"
+        1
+      end
+
+      # Internal helper for the tracer pipeline.
+      # @api private
+      def self.launch(opener, index_path, stdout, stderr)
         if system(opener, index_path, out: File::NULL, err: File::NULL)
           stdout.puts "report:open: opened #{index_path} via #{opener}"
           0
@@ -42,9 +53,6 @@ module RSpecTracer
           stderr.puts "report:open: failed to launch #{opener} #{index_path}"
           1
         end
-      rescue StandardError => e
-        stderr.puts "report:open: #{e.class}: #{e.message}"
-        1
       end
 
       # Internal helper for the tracer pipeline.

--- a/lib/rspec_tracer/cli/snapshot_helpers.rb
+++ b/lib/rspec_tracer/cli/snapshot_helpers.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'rspec_tracer/storage/backend'
+require 'rspec_tracer/storage/json_backend'
+require 'rspec_tracer/storage/schema'
+require 'rspec_tracer/storage/sqlite_backend' if RUBY_ENGINE == 'ruby'
+
+module RSpecTracer
+  # Internal CLI -- see {RSpecTracer} for the user-facing surface.
+  # @api private
+  module CLI
+    # Shared plumbing for the snapshot-reading sub-commands (Explain,
+    # BlastRadius): help-flag detection, backend-agnostic snapshot
+    # loading with uniform degradation messages, and String/Symbol-
+    # tolerant metadata lookups. Extracted so the two commands cannot
+    # drift apart on message wording or cache-shape tolerance.
+    # @api private
+    module SnapshotHelpers
+      # @param args [Array<String>] sub-command args (flags removed
+      #   by the caller where applicable)
+      # @return [Boolean] true when the sub-command should print its
+      #   help text instead of executing
+      def self.help_requested?(args)
+        args.empty? || args.include?('-h') || args.include?('--help')
+      end
+
+      # Resolve the persisted snapshot through the configured storage
+      # backend ({RSpecTracer::Storage::Backend.build}), so
+      # `storage_backend :sqlite` resolves the latest run from the
+      # meta table instead of the JsonBackend-only `last_run.json`.
+      #
+      # @param cache_path [String] root cache directory
+      # @param command [String] sub-command name used as the message
+      #   prefix (e.g. `explain`, `blast-radius`)
+      # @param stderr [IO]
+      # @return [Array(Object, Object), nil] `[snapshot, backend]` on
+      #   success; nil (after printing a one-line explanation) when no
+      #   run has been recorded yet or the cache schema is
+      #   incompatible
+      def self.load_snapshot(cache_path, command:, stderr:)
+        backend = Storage::Backend.build(cache_path: cache_path, configuration: RSpecTracer)
+        run_id = backend.last_run_id
+        if run_id.nil? || run_id.to_s.empty?
+          stderr.puts "#{command}: no cache yet at #{cache_path} -- run rspec first"
+          return nil
+        end
+
+        snapshot = backend.load_graph(schema_version: Storage::Schema::CURRENT)
+        if snapshot.nil?
+          stderr.puts "#{command}: cache at #{cache_path} is incompatible with this rspec-tracer; " \
+                      'next rspec run is cold'
+          return nil
+        end
+
+        [snapshot, backend]
+      end
+
+      # Whether the backend persists the per-run filter decisions
+      # (`filtered_examples` / `skipped_examples`). JsonBackend does;
+      # SqliteBackend deliberately does not (its `dispatch_read`
+      # returns `{}` for those fields). Callers use this to attribute
+      # an empty decision set honestly: on a persisting backend it
+      # means "no decision was recorded for this id" (cold run, or the
+      # id was not part of the last run), NOT a backend limitation.
+      #
+      # @param backend [Object] a {RSpecTracer::Storage::Backend.build}
+      #   product
+      # @return [Boolean]
+      def self.filter_decisions_persisted?(backend)
+        backend.is_a?(Storage::JsonBackend)
+      end
+
+      # Look up a key from a Hash, tolerating both String and Symbol
+      # storage. Snapshot Hashes round-tripped through JSON yield
+      # String keys; the post-#182 msgpack serializer preserves
+      # Symbol keys end-to-end, so callers can't assume either shape.
+      def self.fetch_meta(meta, *keys)
+        keys.each do |k|
+          v = meta[k]
+          return v unless v.nil?
+
+          sym_value = meta[k.to_sym]
+          return sym_value unless sym_value.nil?
+        end
+        nil
+      end
+
+      # Look up a nested key from a Hash, tolerating both String and
+      # Symbol storage at each level. See {.fetch_meta} for rationale.
+      def self.dig_meta(meta, *keys)
+        keys.reduce(meta) do |acc, k|
+          break nil if acc.nil? || !acc.is_a?(::Hash)
+
+          acc[k] || acc[k.to_sym]
+        end
+      end
+
+      # The example's rerun location from persisted all_examples meta,
+      # preferring the rerun_* fields the reporter records.
+      #
+      # @param meta [Hash] one all_examples entry
+      # @return [Array(Object, Object)] `[file, line]`; either element
+      #   may be nil when the meta is missing the field
+      def self.example_location(meta)
+        [
+          fetch_meta(meta, 'rerun_file_name', 'file_name'),
+          fetch_meta(meta, 'rerun_line_number', 'line_number')
+        ]
+      end
+
+      # @param meta [Hash] one all_examples entry
+      # @return [String, nil] the example's description, or nil when
+      #   the meta is missing both description fields
+      def self.example_description(meta)
+        fetch_meta(meta, 'full_description', 'description')
+      end
+    end
+  end
+end

--- a/lib/rspec_tracer/defaults.rb
+++ b/lib/rspec_tracer/defaults.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
 at_exit do
-  RSpecTracer.at_exit_behavior
+  # `respond_to?` guards against a crash while `lib/rspec_tracer.rb`
+  # is still loading (e.g. a corrupt `.rspec-tracer` raising at
+  # config-load time): this hook registers before the module body
+  # that defines `at_exit_behavior` runs, so without the guard the
+  # original error would be shadowed by a NoMethodError backtrace
+  # from the half-loaded module.
+  RSpecTracer.at_exit_behavior if RSpecTracer.respond_to?(:at_exit_behavior)
 end

--- a/lib/rspec_tracer/logger.rb
+++ b/lib/rspec_tracer/logger.rb
@@ -4,37 +4,56 @@ module RSpecTracer
   # Internal Logger — see {RSpecTracer} for the user-facing surface.
   # @api private
   #
-  # Internal logger; thin wrapper around `puts` gated on numeric log
-  # level. Exposed via `RSpecTracer.logger`.
+  # Internal logger; thin wrapper around `IO#puts` gated on numeric
+  # log level. Exposed via `RSpecTracer.logger`.
   class Logger
-    # Internal method on the tracer pipeline.
+    class << self
+      # Process-wide default destination for loggers constructed
+      # without an explicit `out:`. `nil` (the norm) means `$stdout`,
+      # which normal `rspec` runs rely on. The `rspec-tracer` binary
+      # sets this to its stderr BEFORE booting the tracer library, so
+      # loggers constructed while the project's `.rspec-tracer` config
+      # loads (e.g. by the 1.x deprecation shims, or recreated after a
+      # config `log_level` call resets the memoized instance) already
+      # bind to stderr and machine-readable stdout (`blast-radius
+      # --json`) stays free of diagnostics. See {RSpecTracer::CLI}.
+      #
+      # @return [IO, nil]
+      # @api private
+      attr_accessor :default_out
+    end
+
+    # @param log_level [Integer] numeric level (Configuration::LOG_LEVEL)
+    # @param out [IO, nil] destination stream. Falls back to
+    #   {Logger.default_out} when nil, then to `$stdout`.
     # @api private
-    def initialize(log_level)
+    def initialize(log_level, out: nil)
       @log_level = log_level
+      @out = out || self.class.default_out || $stdout
     end
 
     # Internal method on the tracer pipeline.
     # @api private
     def debug(message)
-      puts message if @log_level == 1
+      @out.puts message if @log_level == 1
     end
 
     # Internal method on the tracer pipeline.
     # @api private
     def info(message)
-      puts message if @log_level.between?(1, 2)
+      @out.puts message if @log_level.between?(1, 2)
     end
 
     # Internal method on the tracer pipeline.
     # @api private
     def warn(message)
-      puts message if @log_level.between?(1, 3)
+      @out.puts message if @log_level.between?(1, 3)
     end
 
     # Internal method on the tracer pipeline.
     # @api private
     def error(message)
-      puts message if @log_level.between?(1, 4)
+      @out.puts message if @log_level.between?(1, 4)
     end
   end
 end

--- a/spec/cli/blast_radius_spec.rb
+++ b/spec/cli/blast_radius_spec.rb
@@ -1,0 +1,469 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+require 'tmpdir'
+require 'set'
+
+require 'rspec_tracer/cli'
+require 'rspec_tracer/cli/blast_radius'
+require 'rspec_tracer/storage/json_backend'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/storage/schema'
+
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/InstanceVariable
+RSpec.describe RSpecTracer::CLI::BlastRadius do
+  let(:stdout) { StringIO.new }
+  let(:stderr) { StringIO.new }
+
+  describe '.run' do
+    it 'prints help when no args given' do
+      expect(described_class.run([], stdout: stdout, stderr: stderr)).to eq(0)
+      expect(stdout.string).to include('Usage: rspec-tracer blast-radius')
+    end
+
+    it 'prints help on -h / --help' do
+      %w[-h --help].each do |flag|
+        out = StringIO.new
+        expect(described_class.run([flag], stdout: out, stderr: stderr)).to eq(0)
+        expect(out.string).to include('Usage: rspec-tracer blast-radius')
+        expect(out.string).to include('git diff --name-only')
+        expect(out.string).to include('are not included')
+      end
+    end
+
+    it 'returns 1 when only flags and no file paths are given' do
+      expect(described_class.run(%w[--list], stdout: stdout, stderr: stderr)).to eq(1)
+      expect(stderr.string).to include('blast-radius: no file paths given')
+      expect(stderr.string).to include('usage: rspec-tracer blast-radius')
+    end
+
+    it 'returns 1 on an unknown option instead of treating it as a file path' do
+      expect(described_class.run(%w[--josn lib/foo.rb], stdout: stdout, stderr: stderr)).to eq(1)
+      expect(stderr.string).to include('blast-radius: unknown option "--josn"')
+      expect(stderr.string).to include('usage: rspec-tracer blast-radius')
+    end
+
+    it 'returns 1 with a clear error when no cache exists' do
+      Dir.mktmpdir do |dir|
+        allow(RSpecTracer).to receive_messages(cache_path: dir, root: dir, storage_backend: :json)
+        expect(described_class.run(%w[lib/foo.rb], stdout: stdout, stderr: stderr)).to eq(1)
+        expect(stderr.string).to include('no cache yet')
+      end
+    end
+
+    it 'returns 1 when the cache is schema-mismatched' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'last_run.json'),
+                   JSON.dump('schema_version' => 9999, 'run_id' => 'stale_run'))
+        allow(RSpecTracer).to receive_messages(cache_path: dir, root: dir, storage_backend: :json)
+        expect(described_class.run(%w[lib/foo.rb], stdout: stdout, stderr: stderr)).to eq(1)
+        expect(stderr.string).to include('incompatible')
+      end
+    end
+
+    it 'rescues StandardError and returns 1' do
+      allow(RSpecTracer).to receive(:cache_path).and_raise(StandardError, 'cache resolve boom')
+
+      expect(described_class.run(%w[lib/foo.rb], stdout: stdout, stderr: stderr)).to eq(1)
+      expect(stderr.string).to include('blast-radius:')
+      expect(stderr.string).to include('boom')
+    end
+
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run([], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
+    context 'with a populated cache (json backend)' do
+      let(:run_id) { 'run_blast' }
+      let(:all_examples) do
+        {
+          'spec/foo_spec.rb[1:1]' => {
+            'example_id' => 'spec/foo_spec.rb[1:1]',
+            'full_description' => 'Foo does bar',
+            'rerun_file_name' => './spec/foo_spec.rb',
+            'rerun_line_number' => 12
+          },
+          'spec/foo_spec.rb[1:2]' => {
+            'example_id' => 'spec/foo_spec.rb[1:2]',
+            'full_description' => 'Foo does baz',
+            'rerun_file_name' => './spec/foo_spec.rb',
+            'rerun_line_number' => 20
+          },
+          'spec/bar_spec.rb[1:1]' => {
+            'example_id' => 'spec/bar_spec.rb[1:1]',
+            'full_description' => 'Bar works',
+            'rerun_file_name' => './spec/bar_spec.rb',
+            'rerun_line_number' => 5
+          }
+        }
+      end
+      let(:reverse_dependency) do
+        {
+          '/lib/foo.rb' => Set.new(['spec/foo_spec.rb[1:2]', 'spec/foo_spec.rb[1:1]']),
+          '/lib/bar.rb' => Set.new(['spec/bar_spec.rb[1:1]', 'spec/foo_spec.rb[1:2]']),
+          '/lib/ghost.rb' => Set.new(['spec/gone_spec.rb[9:9]'])
+        }
+      end
+
+      before do
+        @tmp_dir = Dir.mktmpdir
+        @root_dir = Dir.mktmpdir
+        snapshot = RSpecTracer::Storage::Snapshot.empty(
+          schema_version: RSpecTracer::Storage::Schema::CURRENT, run_id: run_id
+        )
+        snapshot.all_examples = all_examples
+        snapshot.reverse_dependency = reverse_dependency
+        snapshot.all_files = {
+          '/lib/foo.rb' => { 'file_name' => '/lib/foo.rb' },
+          '/lib/bar.rb' => { 'file_name' => '/lib/bar.rb' },
+          '/lib/nodeps.rb' => { 'file_name' => '/lib/nodeps.rb' }
+        }
+        snapshot.boot_set = { 'spec/spec_helper.rb' => 'a' * 64 }
+        RSpecTracer::Storage::JsonBackend.new(cache_path: @tmp_dir).save_graph(
+          snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+        )
+        allow(RSpecTracer).to receive_messages(
+          cache_path: @tmp_dir, root: @root_dir, storage_backend: :json
+        )
+      end
+
+      after do
+        FileUtils.rm_rf(@tmp_dir) if @tmp_dir
+        FileUtils.rm_rf(@root_dir) if @root_dir
+      end
+
+      it 'prints a per-file summary line for a tracked file' do
+        expect(described_class.run(%w[lib/foo.rb], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('/lib/foo.rb: 2 examples across 1 spec files')
+        expect(stdout.string).not_to include('total:')
+      end
+
+      it 'prints per-file lines plus a dedup total for multi-file input' do
+        args = %w[lib/foo.rb lib/bar.rb]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('/lib/foo.rb: 2 examples across 1 spec files')
+        expect(stdout.string).to include('/lib/bar.rb: 2 examples across 2 spec files')
+        expect(stdout.string).to include('total: 3 unique examples across 2 spec files')
+      end
+
+      it 'enumerates affected examples sorted by location under --list' do
+        args = %w[--list lib/foo.rb]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        first = stdout.string.index('  ./spec/foo_spec.rb:12  Foo does bar')
+        second = stdout.string.index('  ./spec/foo_spec.rb:20  Foo does baz')
+        expect(first).not_to be_nil
+        expect(second).to be > first
+      end
+
+      it 'emits a machine-readable JSON document under --json' do
+        args = %w[--json lib/foo.rb lib/bar.rb]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        payload = JSON.parse(stdout.string)
+        foo = payload['files'].find { |f| f['file_name'] == '/lib/foo.rb' }
+        expect(foo).to include(
+          'path' => 'lib/foo.rb', 'status' => 'tracked',
+          'example_count' => 2, 'spec_file_count' => 1
+        )
+        expect(foo['examples'].first).to include(
+          'example_id' => 'spec/foo_spec.rb[1:1]',
+          'location' => './spec/foo_spec.rb:12',
+          'description' => 'Foo does bar'
+        )
+        expect(payload['total']).to eq(
+          'example_count' => 3, 'spec_file_count' => 2,
+          'whole_suite' => false, 'all_examples_count' => 3
+        )
+      end
+
+      it 'reports an untracked file as a benign no-op with exit 0' do
+        expect(described_class.run(%w[README.md], stdout: stdout, stderr: stderr)).to eq(0)
+        # The wording must stick to what the tracer observed (nothing)
+        # rather than claiming the file "never loaded": files consumed
+        # outside the hooked surface (spec_helper.rb, unhooked reads)
+        # load fine yet never land in the cache.
+        expect(stdout.string).to include(
+          '/README.md: not tracked in cache (no recorded dependents -- the tracer never ' \
+          'observed it as an input; see the soundness model in ARCHITECTURE.md)'
+        )
+      end
+
+      it 'reports a tracked file without dependents as 0 examples with exit 0' do
+        expect(described_class.run(%w[lib/nodeps.rb], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('/lib/nodeps.rb: 0 examples (no tracked dependents)')
+      end
+
+      it 'reports a whole-suite invalidator watch file as re-running everything' do
+        expect(described_class.run(%w[Gemfile.lock], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string)
+          .to include('/Gemfile.lock: whole-suite invalidator -- re-runs all 3 examples')
+      end
+
+      it 'reports a boot-set file as re-running everything' do
+        expect(described_class.run(%w[spec/spec_helper.rb], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('/spec/spec_helper.rb: boot file -- re-runs all 3 examples')
+      end
+
+      it 'collapses the total to the whole suite when any input is a whole-suite invalidator' do
+        args = %w[lib/foo.rb Gemfile.lock]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('total: all 3 examples (whole-suite invalidator)')
+      end
+
+      it 'marks the JSON total as whole_suite when an invalidator is among the inputs' do
+        args = %w[--json lib/foo.rb Gemfile.lock]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        payload = JSON.parse(stdout.string)
+        gemfile = payload['files'].find { |f| f['file_name'] == '/Gemfile.lock' }
+        expect(gemfile['status']).to eq('whole_suite_invalidator')
+        expect(payload['total']).to include('whole_suite' => true, 'example_count' => 3)
+      end
+
+      it 'resolves an absolute path inside the project root like a relative one' do
+        args = [File.join(@root_dir, 'lib/foo.rb')]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('/lib/foo.rb: 2 examples across 1 spec files')
+      end
+
+      it 'degrades a dangling example id to <unknown> fields instead of raising' do
+        args = %w[--list lib/ghost.rb]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('/lib/ghost.rb: 1 examples across 1 spec files')
+        expect(stdout.string).to include('  <unknown>  <unknown>')
+      end
+
+      context 'when storage_backend :sqlite degrades to :json mid-command' do
+        # Regression for the sqlite3-LoadError fallback path: with
+        # `storage_backend :sqlite` and the sqlite3 gem unavailable
+        # (every JRuby invocation; MRI without the gem installed),
+        # Storage::Backend.build rescues SqliteBackendError, warns
+        # through RSpecTracer.logger, and falls back to :json. The
+        # logger's default destination is stdout, so before the CLI
+        # dispatch layer rebound it to stderr the warning printed
+        # AHEAD of the --json document and broke `... --json | jq`.
+        before do
+          allow(RSpecTracer).to receive(:storage_backend).and_return(:sqlite)
+          fallback_error = Class.new(StandardError)
+          fake_sqlite = Class.new
+          fake_sqlite.const_set(:SqliteBackendError, fallback_error)
+          allow(fake_sqlite).to receive(:new).and_raise(
+            fallback_error, 'sqlite3 gem not available: cannot load such file -- sqlite3'
+          )
+          stub_const('RSpecTracer::Storage::SqliteBackend', fake_sqlite)
+        end
+
+        it 'emits exactly one parseable JSON document on stdout and the fallback warning on stderr' do
+          args = %w[blast-radius --json lib/foo.rb]
+          expect(RSpecTracer::CLI.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+          # JSON.parse over the WHOLE stdout capture is the contract
+          # check: it raises if any diagnostic line precedes or
+          # follows the single JSON document.
+          payload = JSON.parse(stdout.string)
+          expect(payload['files'].first).to include('status' => 'tracked', 'example_count' => 2)
+          expect(stderr.string).to include('sqlite backend unavailable')
+          expect(stderr.string).to include('falling back to :json')
+        end
+      end
+    end
+
+    context 'with a populated cache (sqlite backend)', :sqlite do
+      let(:run_id) { 'run_blast_sqlite' }
+
+      before do
+        skip 'sqlite backend unavailable on this Ruby' unless sqlite_available?
+        @tmp_dir = Dir.mktmpdir
+        @root_dir = Dir.mktmpdir
+        snapshot = RSpecTracer::Storage::Snapshot.empty(
+          schema_version: RSpecTracer::Storage::Schema::CURRENT, run_id: run_id
+        )
+        snapshot.all_examples = {
+          'spec/foo_spec.rb[1:1]' => {
+            'example_id' => 'spec/foo_spec.rb[1:1]',
+            'full_description' => 'Foo does bar',
+            'rerun_file_name' => './spec/foo_spec.rb',
+            'rerun_line_number' => 12
+          }
+        }
+        # SqliteBackend derives reverse_dependency from the dependency
+        # table at read time, so the fixture seeds the forward map.
+        snapshot.dependency = { 'spec/foo_spec.rb[1:1]' => Set.new(['/lib/foo.rb']) }
+        snapshot.reverse_dependency = { '/lib/foo.rb' => Set.new(['spec/foo_spec.rb[1:1]']) }
+        RSpecTracer::Storage::SqliteBackend.new(cache_path: @tmp_dir).save_graph(
+          snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+        )
+        allow(RSpecTracer).to receive_messages(
+          cache_path: @tmp_dir, root: @root_dir, storage_backend: :sqlite
+        )
+      end
+
+      after do
+        FileUtils.rm_rf(@tmp_dir) if @tmp_dir
+        FileUtils.rm_rf(@root_dir) if @root_dir
+      end
+
+      it 'resolves the reverse-dependency radius under storage_backend :sqlite' do
+        args = %w[--json lib/foo.rb]
+        expect(described_class.run(args, stdout: stdout, stderr: stderr)).to eq(0)
+        payload = JSON.parse(stdout.string)
+        expect(payload['files'].first).to include('status' => 'tracked', 'example_count' => 1)
+        expect(payload['files'].first['examples'].first['description']).to eq('Foo does bar')
+      end
+
+      def sqlite_available?
+        return false unless RUBY_ENGINE == 'ruby'
+
+        require 'sqlite3'
+        require 'rspec_tracer/storage/sqlite_backend'
+        true
+      rescue LoadError
+        false
+      end
+    end
+  end
+
+  describe '.parse_args' do
+    it 'separates flags from file paths' do
+      parsed = described_class.parse_args(%w[--list a.rb --json b.rb])
+      expect(parsed).to eq(list: true, json: true, files: %w[a.rb b.rb], unknown: nil)
+    end
+
+    it 'captures the first unknown dash-prefixed arg' do
+      parsed = described_class.parse_args(%w[--nope a.rb --also-nope])
+      expect(parsed[:unknown]).to eq('--nope')
+      expect(parsed[:files]).to eq(%w[a.rb])
+    end
+  end
+
+  describe '.normalize_file_name' do
+    before do
+      allow(RSpecTracer).to receive(:root).and_return('/projects/app')
+    end
+
+    it 'expands a relative path against the project root with a leading slash' do
+      expect(described_class.normalize_file_name('lib/foo.rb')).to eq('/lib/foo.rb')
+    end
+
+    it 'swaps the root prefix for a leading slash on an in-root absolute path' do
+      expect(described_class.normalize_file_name('/projects/app/lib/foo.rb')).to eq('/lib/foo.rb')
+    end
+
+    it 'keeps an absolute path outside the project root as-is' do
+      expect(described_class.normalize_file_name('/elsewhere/lib/foo.rb'))
+        .to eq('/elsewhere/lib/foo.rb')
+    end
+  end
+
+  describe '.radius_for' do
+    let(:snapshot) do
+      instance_double(
+        RSpecTracer::Storage::Snapshot,
+        all_examples: { 'ex1' => { 'full_description' => 'x' } },
+        reverse_dependency: { '/lib/foo.rb' => Set.new(%w[ex1]) },
+        all_files: { '/lib/foo.rb' => {}, '/lib/nodeps.rb' => {} },
+        boot_set: { 'spec/spec_helper.rb' => 'digest' }
+      )
+    end
+
+    before do
+      allow(RSpecTracer).to receive(:root).and_return('/projects/app')
+    end
+
+    it 'classifies a whole-suite invalidator watch file first' do
+      expect(described_class.radius_for('Gemfile.lock', snapshot))
+        .to include(status: 'whole_suite_invalidator')
+    end
+
+    it 'classifies a boot-set member (relative-key convention) as boot_file' do
+      expect(described_class.radius_for('spec/spec_helper.rb', snapshot))
+        .to include(status: 'boot_file')
+    end
+
+    it 'classifies a file with reverse dependents as tracked' do
+      radius = described_class.radius_for('lib/foo.rb', snapshot)
+      expect(radius[:status]).to eq('tracked')
+      expect(radius[:examples].map { |e| e[:example_id] }).to eq(%w[ex1])
+    end
+
+    it 'classifies a known file without dependents as no_dependents' do
+      expect(described_class.radius_for('lib/nodeps.rb', snapshot))
+        .to include(status: 'no_dependents', examples: [])
+    end
+
+    it 'classifies an unknown file as untracked' do
+      expect(described_class.radius_for('README.md', snapshot))
+        .to include(status: 'untracked', examples: [])
+    end
+  end
+
+  describe '.summary_line' do
+    it 'renders each status variant' do
+      examples = [{ example_id: 'e', spec_file: 's.rb', location: 's.rb:1', description: 'd' }]
+      lines = {
+        'tracked' => '/f.rb: 1 examples across 1 spec files',
+        'whole_suite_invalidator' => '/f.rb: whole-suite invalidator -- re-runs all 1 examples',
+        'boot_file' => '/f.rb: boot file -- re-runs all 1 examples',
+        'untracked' => '/f.rb: not tracked in cache (no recorded dependents -- the tracer never ' \
+                       'observed it as an input; see the soundness model in ARCHITECTURE.md)',
+        'no_dependents' => '/f.rb: 0 examples (no tracked dependents)'
+      }
+      no_example_statuses = %w[untracked no_dependents]
+      lines.each do |status, expected|
+        entries = no_example_statuses.include?(status) ? [] : examples
+        radius = { path: 'f.rb', file_name: '/f.rb', status: status, examples: entries }
+        expect(described_class.summary_line(radius)).to eq(expected)
+      end
+    end
+  end
+
+  describe '.example_entry' do
+    # Regression: post-#182 msgpack preserves Symbol keys end-to-end;
+    # JSON-deserialized caches yield String keys. CLI helpers must
+    # tolerate either shape.
+    it 'reads Symbol-keyed meta (msgpack shape)' do
+      meta = { rerun_file_name: './spec/a_spec.rb', rerun_line_number: 3, full_description: 'A' }
+      expect(described_class.example_entry('id1', meta)).to eq(
+        example_id: 'id1', spec_file: './spec/a_spec.rb',
+        location: './spec/a_spec.rb:3', description: 'A'
+      )
+    end
+
+    it 'falls back to file_name/line_number when rerun fields are absent' do
+      meta = { 'file_name' => './spec/b_spec.rb', 'line_number' => 7 }
+      entry = described_class.example_entry('id2', meta)
+      expect(entry[:location]).to eq('./spec/b_spec.rb:7')
+      expect(entry[:description]).to eq('<unknown>')
+    end
+
+    it 'degrades non-Hash meta to <unknown> fields' do
+      expect(described_class.example_entry('id3', nil)).to eq(
+        example_id: 'id3', spec_file: '<unknown>',
+        location: '<unknown>', description: '<unknown>'
+      )
+    end
+  end
+
+  describe '.json_payload' do
+    let(:snapshot) do
+      instance_double(RSpecTracer::Storage::Snapshot, all_examples: { 'e1' => {}, 'e2' => {} })
+    end
+
+    it 'builds sorted per-file entries plus a dedup total' do
+      entry = { example_id: 'e1', spec_file: 's.rb', location: 's.rb:1', description: 'd' }
+      radii = [
+        { path: 'a.rb', file_name: '/a.rb', status: 'tracked', examples: [entry] },
+        { path: 'b.rb', file_name: '/b.rb', status: 'tracked', examples: [entry] }
+      ]
+      payload = described_class.json_payload(radii, snapshot)
+      expect(payload['files'].size).to eq(2)
+      expect(payload['files'].first['examples'].first['example_id']).to eq('e1')
+      expect(payload['total']).to eq(
+        'example_count' => 1, 'spec_file_count' => 1,
+        'whole_suite' => false, 'all_examples_count' => 2
+      )
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/InstanceVariable

--- a/spec/cli/cache_clear_spec.rb
+++ b/spec/cli/cache_clear_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe RSpecTracer::CLI::CacheClear do
       end
     end
 
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run(%w[-h], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
     it 'reports nothing-to-remove when no directories exist' do
       Dir.mktmpdir do |dir|
         allow(RSpecTracer).to receive_messages(

--- a/spec/cli/cache_info_spec.rb
+++ b/spec/cli/cache_info_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe RSpecTracer::CLI::CacheInfo do
       end
     end
 
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run(%w[-h], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
     context 'with a populated cache (json backend)' do
       before do
         @tmp_dir = Dir.mktmpdir

--- a/spec/cli/cli_spec.rb
+++ b/spec/cli/cli_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe RSpecTracer::CLI do
       expect(stdout.string).to include('Usage: rspec-tracer <sub-command>')
       expect(stdout.string).to include('doctor')
       expect(stdout.string).to include('cache:info')
-      expect(stdout.string).to include('explain <id>')
+      expect(stdout.string).to include('explain <id>').and include('blast-radius <f>')
     end
 
     it 'prints top-level help on -h / --help / help' do
@@ -47,12 +47,125 @@ RSpec.describe RSpecTracer::CLI do
       expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(1)
       expect(stderr.string).to start_with('rspec-tracer:')
     end
+
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run(%w[--help], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'routes tracer logger diagnostics to stderr during dispatch and restores the logger after' do
+      # Backend degradation messages (sqlite-unavailable fallback,
+      # schema-mismatch info) go through RSpecTracer.logger, whose
+      # default destination is stdout. During CLI dispatch they must
+      # land on stderr instead, so machine-readable sub-command output
+      # (`blast-radius --json`) stays parseable.
+      logger_before = RSpecTracer.logger
+      allow(described_class).to receive(:dispatch) do
+        RSpecTracer.logger.warn('diagnostic emitted mid-dispatch')
+        0
+      end
+      expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(0)
+      expect(stderr.string).to include('diagnostic emitted mid-dispatch')
+      expect(stdout.string).to be_empty
+      expect(RSpecTracer.logger).to equal(logger_before)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'restores the previous logger even when dispatch raises' do
+      logger_before = RSpecTracer.logger
+      allow(described_class).to receive(:dispatch).and_raise(StandardError, 'dispatch boom')
+      expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(1)
+      expect(stderr.string).to include('dispatch boom')
+      expect(RSpecTracer.logger).to equal(logger_before)
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'routes logger writes fired during library boot (config load) to stderr' do
+      # The `.rspec-tracer` 1.x deprecation shims (`reports_s3_path`,
+      # `use_local_aws`) write through a logger constructed WHILE
+      # load_tracer boots the library -- before with_logger_on can
+      # rebind the memoized instance. Logger.default_out must already
+      # point at stderr inside that window, or the warning lands on
+      # stdout ahead of machine-readable output (`blast-radius
+      # --json`). End-to-end variant (real config, real subprocess):
+      # spec/edge_cases/cli_deprecated_config_purity_spec.rb.
+      allow(described_class).to receive(:load_tracer) do
+        RSpecTracer::Logger.new(2).warn('deprecation fired at config load')
+        true
+      end
+      allow(described_class).to receive(:dispatch).and_return(0)
+      expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(0)
+      expect(stderr.string).to include('deprecation fired at config load')
+      expect(stdout.string).to be_empty
+    end
+
+    it 'binds Logger.default_out to stderr for the dispatch window and restores it after' do
+      previous = RSpecTracer::Logger.default_out
+      seen = nil
+      allow(described_class).to receive(:dispatch) do
+        seen = RSpecTracer::Logger.default_out
+        0
+      end
+      expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(0)
+      expect(seen).to equal(stderr)
+      expect(RSpecTracer::Logger.default_out).to equal(previous)
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'restores Logger.default_out even when dispatch raises' do
+      previous = RSpecTracer::Logger.default_out
+      allow(described_class).to receive(:dispatch).and_raise(StandardError, 'dispatch boom')
+      expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(1)
+      expect(RSpecTracer::Logger.default_out).to equal(previous)
+    end
+
+    it 'returns 1 without dispatching when the tracer library fails to boot' do
+      allow(described_class).to receive(:load_tracer).and_return(false)
+      allow(described_class).to receive(:dispatch)
+      expect(described_class.run(%w[doctor], stdout: stdout, stderr: stderr)).to eq(1)
+      expect(described_class).not_to have_received(:dispatch)
+    end
+
+    it 'still prints help and version when the project config is broken' do
+      allow(described_class).to receive(:load_tracer).and_return(false)
+      expect(described_class.run(%w[--help], stdout: stdout, stderr: stderr)).to eq(0)
+      version_out = StringIO.new
+      expect(described_class.run(%w[--version], stdout: version_out, stderr: stderr)).to eq(0)
+      expect(version_out.string).to include("rspec-tracer #{RSpecTracer::VERSION}")
+    end
+  end
+
+  describe '.load_tracer' do
+    it 'returns true when the tracer library (and the user configs) load cleanly' do
+      expect(described_class.load_tracer(stderr)).to be(true)
+      expect(stderr.string).to be_empty
+    end
+
+    it 'degrades a raising config to a one-line message and false' do
+      allow(described_class).to receive(:require).with('rspec_tracer').and_raise(RuntimeError, 'boom at config load')
+      expect(described_class.load_tracer(stderr)).to be(false)
+      expect(stderr.string)
+        .to include('rspec-tracer: could not load configuration (.rspec-tracer): RuntimeError: boom at config load')
+    end
+
+    it 'catches ScriptError so a config SyntaxError cannot escape as a backtrace' do
+      # SyntaxError (raised by a corrupt `.rspec-tracer` at `load`
+      # time) is a ScriptError, NOT a StandardError -- a bare
+      # `rescue StandardError` would let it crash the binary.
+      allow(described_class).to receive(:require).with('rspec_tracer').and_raise(SyntaxError, 'unexpected end')
+      expect(described_class.load_tracer(stderr)).to be(false)
+      expect(stderr.string).to include('SyntaxError')
+      expect(stderr.string).to include('unexpected end')
+    end
   end
 
   describe 'SUB_COMMANDS' do
-    it 'lists exactly the 5 promised sub-commands per USER_FACING_SURFACE.md §10' do
+    it 'lists exactly the 6 promised sub-commands' do
       expect(described_class::SUB_COMMANDS.keys).to contain_exactly(
-        'doctor', 'cache:info', 'cache:clear', 'report:open', 'explain'
+        'doctor', 'cache:info', 'cache:clear', 'report:open', 'explain', 'blast-radius'
       )
     end
   end

--- a/spec/cli/doctor_spec.rb
+++ b/spec/cli/doctor_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe RSpecTracer::CLI::Doctor do
       end
     end
 
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run(%w[-h], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
     it 'prints checklist with OK lines for ruby + tracer + paths in a healthy project' do
       expect(described_class.run([], stdout: stdout, stderr: stderr)).to eq(0)
       lines = stdout.string.split("\n")
@@ -42,6 +49,13 @@ RSpec.describe RSpecTracer::CLI::Doctor do
       expect(described_class.run([], stdout: stdout, stderr: stderr)).to eq(1)
       expect(stderr.string).to include('doctor:')
       expect(stderr.string).to include('boom')
+    end
+
+    it 'always prints exactly one INFO ci: line without affecting the exit status' do
+      expect(described_class.run([], stdout: stdout, stderr: stderr)).to eq(0)
+      ci_lines = stdout.string.split("\n").select { |l| l.include?(' ci:') }
+      expect(ci_lines.size).to eq(1)
+      expect(ci_lines.first).to start_with('INFO ci:')
     end
   end
 
@@ -165,6 +179,38 @@ RSpec.describe RSpecTracer::CLI::Doctor do
       allow(RSpecTracer).to receive(:track_ar_schema_notifications?).and_return(true)
       hide_const('Rails') if defined?(Rails)
       expect(described_class.ar_schema_narrow_attribution_check).to start_with('INFO AR schema:')
+    end
+  end
+
+  describe '.ci_environment_check' do
+    around do |example|
+      saved = described_class::CI_ENV_VARS.to_h { |v| [v, ENV.fetch(v, nil)] }
+      described_class::CI_ENV_VARS.each { |v| ENV.delete(v) }
+      example.run
+    ensure
+      saved.each { |k, v| v.nil? ? ENV.delete(k) : ENV[k] = v }
+    end
+
+    it 'reports detected with the matched var name and the CI recipes pointer' do
+      ENV['GITHUB_ACTIONS'] = 'true'
+      line = described_class.ci_environment_check
+      expect(line).to start_with('INFO ci:')
+      expect(line).to include('ENV[GITHUB_ACTIONS]')
+      expect(line).to include('docs/CI_RECIPES.md')
+    end
+
+    it 'reports not detected when no CI env var is set' do
+      line = described_class.ci_environment_check
+      expect(line).to start_with('INFO ci:')
+      expect(line).to include('not detected (local run)')
+      expect(line).not_to include('docs/CI_RECIPES.md')
+    end
+
+    # ENV['CI'] == "" is truthy in Ruby; a shell with `CI=` exported
+    # must not read as a CI environment.
+    it 'does not count an empty-string CI var as detected' do
+      ENV['CI'] = ''
+      expect(described_class.ci_environment_check).to include('not detected (local run)')
     end
   end
 

--- a/spec/cli/explain_spec.rb
+++ b/spec/cli/explain_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe RSpecTracer::CLI::Explain do
       end
     end
 
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run([], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
     it 'returns 1 with a clear error when no cache exists' do
       Dir.mktmpdir do |dir|
         allow(RSpecTracer).to receive_messages(cache_path: dir, storage_backend: :json)
@@ -86,11 +93,196 @@ RSpec.describe RSpecTracer::CLI::Explain do
         expect(stdout.string).to include('passed')
         expect(stdout.string).to include('changed')
         expect(stdout.string).to include('./lib/foo.rb')
+        expect(stdout.string).not_to include('carried forward')
       end
 
       it 'falls back to substring match on full_description' do
         expect(described_class.run(%w[Foo], stdout: stdout, stderr: stderr)).to eq(0)
         expect(stdout.string).to include('Foo does bar')
+      end
+    end
+
+    it 'prints help when --not-run is given without a positional' do
+      expect(described_class.run(%w[--not-run], stdout: stdout, stderr: stderr)).to eq(0)
+      expect(stdout.string).to include('Usage: rspec-tracer explain')
+    end
+
+    it 'documents --not-run in the help text' do
+      expect(described_class.run([], stdout: stdout, stderr: stderr)).to eq(0)
+      expect(stdout.string).to include('--not-run')
+    end
+
+    context 'with --not-run against a populated cache (json backend)' do
+      def skipped_id
+        'a/spec.rb[1:1]'
+      end
+
+      def ran_id
+        'a/spec.rb[1:2]'
+      end
+
+      def failed_id
+        'a/spec.rb[1:3]'
+      end
+
+      def absent_id
+        'a/spec.rb[1:4]'
+      end
+
+      def meta_for(id, desc)
+        {
+          'example_id' => id,
+          'full_description' => desc,
+          'rerun_file_name' => './spec/foo_spec.rb',
+          'rerun_line_number' => 12,
+          'execution_result' => { 'status' => 'passed' },
+          'run_reason' => 'stale prior-run reason'
+        }
+      end
+
+      before do
+        @tmp_dir = Dir.mktmpdir
+        snapshot = RSpecTracer::Storage::Snapshot.empty(
+          schema_version: RSpecTracer::Storage::Schema::CURRENT, run_id: 'run_not_run'
+        )
+        snapshot.all_examples = {
+          skipped_id => meta_for(skipped_id, 'Foo skips cleanly'),
+          ran_id => meta_for(ran_id, 'Foo ran again'),
+          failed_id => meta_for(failed_id, 'Foo failed before'),
+          absent_id => meta_for(absent_id, 'Foo sat out the last run')
+        }
+        snapshot.skipped_examples = Set.new([skipped_id])
+        snapshot.filtered_examples = { ran_id => 'Files changed', failed_id => 'Failed previously' }
+        snapshot.failed_examples = Set.new([failed_id])
+        snapshot.dependency = {
+          skipped_id => Set.new(['./spec/foo_spec.rb', './lib/foo.rb'])
+        }
+        RSpecTracer::Storage::JsonBackend.new(cache_path: @tmp_dir).save_graph(
+          snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+        )
+        allow(RSpecTracer).to receive_messages(cache_path: @tmp_dir, storage_backend: :json)
+      end
+
+      after { FileUtils.rm_rf(@tmp_dir) if @tmp_dir }
+
+      it 'explains a skipped example with the itemized skip-reason derivation' do
+        expect(described_class.run(['--not-run', skipped_id], stdout: stdout, stderr: stderr)).to eq(0)
+        out = stdout.string
+        expect(out).to include('last run:     skipped (cache hit)')
+        expect(out).to include('skip reason:  no run trigger fired last run:')
+        expect(out).to include('whole-suite invalidators (Gemfile.lock, .ruby-version, .rspec-tracer, gem version)')
+        expect(out).to include('boot set: no boot file changed')
+        expect(out).to include('prior status: not failed / flaky / pending / interrupted')
+        expect(out).to include('dependency files: 2 tracked, none changed')
+        expect(out).to include('environment snapshot: unchanged for this example')
+        expect(out).to include('last status:  passed (most recent snapshot; this cache keeps only the last run)')
+        expect(out).to include(
+          'next run:     runs only if a dependency, whole-suite invalidator, boot file, or tracked env var changes'
+        )
+        expect(out).to include('dependencies: 2 files tracked')
+        expect(out).to include('./lib/foo.rb')
+      end
+
+      it 'attributes an absent filter decision to the run, not the storage backend, on json' do
+        # A cold run persists EMPTY filtered_examples/skipped_examples
+        # by design (the engine computes no filter decisions without a
+        # previous snapshot), and an id that was not part of the last
+        # run has no entry either -- neither is a backend limitation
+        # on the json backend, which persists the field.
+        expect(described_class.run(['--not-run', absent_id], stdout: stdout, stderr: stderr)).to eq(0)
+        out = stdout.string
+        expect(out).to include(
+          'last run:     no filter decision recorded (cold run, or this example was not part of it)'
+        )
+        expect(out).not_to include('not recorded by this storage backend')
+      end
+
+      it 'omits the stale carry-forward run reason from the --not-run view' do
+        expect(described_class.run(['--not-run', skipped_id], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).not_to include('stale prior-run reason')
+        expect(stdout.string).not_to include('run reason:')
+      end
+
+      it 'tells the truth when the example actually ran, with a run-side hint' do
+        expect(described_class.run(['--not-run', ran_id], stdout: stdout, stderr: stderr)).to eq(0)
+        out = stdout.string
+        expect(out).to include('last run:     ran -- Files changed')
+        expect(out).to include("it was not skipped; run 'rspec-tracer explain #{ran_id}' for the run-side view")
+      end
+
+      it 'predicts the unconditional re-run for a previously failed example' do
+        expect(described_class.run(['--not-run', failed_id], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('next run:     will re-run regardless (failed last run)')
+      end
+
+      it 'returns 1 on --not-run with no matching example' do
+        expect(described_class.run(%w[--not-run totally_bogus], stdout: stdout, stderr: stderr)).to eq(1)
+        expect(stderr.string).to include('no example matching')
+      end
+
+      it 'flags the carry-forward run reason in the plain view for a skipped example' do
+        # The persisted run_reason on a skipped example is seeded from
+        # an earlier snapshot; echoing it bare would misreport why the
+        # example did not run last time.
+        expect(described_class.run([skipped_id], stdout: stdout, stderr: stderr)).to eq(0)
+        out = stdout.string
+        expect(out).to include(
+          'run reason:   stale prior-run reason (carried forward from an earlier run; ' \
+          'this example was SKIPPED last run -- use --not-run for the skip-side view)'
+        )
+        expect(out).not_to include('last run:')
+      end
+
+      it 'prints the run reason bare in the plain view for an example that actually ran' do
+        expect(described_class.run([ran_id], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('run reason:   stale prior-run reason')
+        expect(stdout.string).not_to include('carried forward')
+        expect(stdout.string).not_to include('last run:')
+      end
+    end
+
+    context 'with --not-run against a sqlite cache that does not persist filtered_examples', :sqlite do
+      let(:run_id) { 'run_not_run_sqlite' }
+      let(:ran_id) { 'a/spec.rb[1:2]' }
+
+      before do
+        skip 'sqlite backend unavailable on this Ruby' unless sqlite_available?
+        @tmp_dir = Dir.mktmpdir
+        snapshot = RSpecTracer::Storage::Snapshot.empty(
+          schema_version: RSpecTracer::Storage::Schema::CURRENT, run_id: run_id
+        )
+        snapshot.all_examples = {
+          ran_id => {
+            'example_id' => ran_id,
+            'full_description' => 'Foo ran again',
+            'rerun_file_name' => './spec/foo_spec.rb',
+            'rerun_line_number' => 12,
+            'execution_result' => { 'status' => 'passed' }
+          }
+        }
+        snapshot.filtered_examples = { ran_id => 'Files changed' }
+        RSpecTracer::Storage::SqliteBackend.new(cache_path: @tmp_dir).save_graph(
+          snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+        )
+        allow(RSpecTracer).to receive_messages(cache_path: @tmp_dir, storage_backend: :sqlite)
+      end
+
+      after { FileUtils.rm_rf(@tmp_dir) if @tmp_dir }
+
+      it 'degrades to the not-recorded fallback without failing' do
+        expect(described_class.run(['--not-run', ran_id], stdout: stdout, stderr: stderr)).to eq(0)
+        expect(stdout.string).to include('last run:     <not recorded by this storage backend>')
+        expect(stdout.string).to include('next run:')
+      end
+
+      def sqlite_available?
+        return false unless RUBY_ENGINE == 'ruby'
+
+        require 'sqlite3'
+        require 'rspec_tracer/storage/sqlite_backend'
+        true
+      rescue LoadError
+        false
       end
     end
 
@@ -173,20 +365,93 @@ RSpec.describe RSpecTracer::CLI::Explain do
     end
   end
 
-  describe '.fetch_meta' do
-    # Regression: post-#182 msgpack preserves Symbol keys end-to-end;
-    # JSON-deserialized caches yield String keys. CLI helpers must
-    # tolerate either shape.
-    it 'reads through String keys' do
-      expect(described_class.fetch_meta({ 'full_description' => 'x' }, 'full_description')).to eq('x')
+  describe '--not-run helpers' do
+    let(:snapshot) do
+      RSpecTracer::Storage::Snapshot.empty(schema_version: 1, run_id: 'helper_run')
     end
 
-    it 'reads through Symbol keys when the value lives under one' do
-      expect(described_class.fetch_meta({ full_description: 'x' }, 'full_description')).to eq('x')
+    describe '.last_run_line' do
+      it 'reports skipped (cache hit) for a skipped id' do
+        snapshot.skipped_examples = Set.new(%w[ex_1])
+        expect(described_class.last_run_line('ex_1', snapshot, filter_persisted: true))
+          .to eq('last run:     skipped (cache hit)')
+      end
+
+      it 'reports ran with the recorded reason for a filtered id' do
+        snapshot.filtered_examples = { 'ex_1' => 'No cache' }
+        expect(described_class.last_run_line('ex_1', snapshot, filter_persisted: true))
+          .to eq('last run:     ran -- No cache')
+      end
+
+      it 'attributes an empty decision set to the run when the backend persists decisions' do
+        expect(described_class.last_run_line('ex_1', snapshot, filter_persisted: true))
+          .to eq('last run:     no filter decision recorded (cold run, or this example was not part of it)')
+      end
+
+      it 'blames the storage backend only when it does not persist filter decisions' do
+        expect(described_class.last_run_line('ex_1', snapshot, filter_persisted: false))
+          .to eq('last run:     <not recorded by this storage backend>')
+      end
+
+      it 'tolerates nil skipped_examples and filtered_examples fields' do
+        snapshot.skipped_examples = nil
+        snapshot.filtered_examples = nil
+        expect(described_class.last_run_line('ex_1', snapshot, filter_persisted: false)).to include('<not recorded')
+      end
     end
 
-    it 'returns the first non-nil match across alternatives' do
-      expect(described_class.fetch_meta({ description: 'y' }, 'full_description', 'description')).to eq('y')
+    describe '.skip_reason_lines' do
+      it 'itemizes every declined trigger with the tracked dependency count' do
+        snapshot.dependency = { 'ex_1' => Set.new(%w[./lib/a.rb ./lib/b.rb ./lib/c.rb]) }
+        lines = described_class.skip_reason_lines('ex_1', snapshot)
+        expect(lines.first).to eq('skip reason:  no run trigger fired last run:')
+        expect(lines).to include('  - dependency files: 3 tracked, none changed')
+        expect(lines.any? { |l| l.include?('whole-suite invalidators') }).to be(true)
+        # The engine ORs the boot-set check into whole-suite
+        # invalidation, so a skip also implies no boot file changed.
+        expect(lines).to include('  - boot set: no boot file changed')
+        expect(lines.any? { |l| l.include?('prior status') }).to be(true)
+        expect(lines.any? { |l| l.include?('environment snapshot') }).to be(true)
+      end
+
+      it 'reports zero tracked dependency files when the id has no entry' do
+        snapshot.dependency = nil
+        lines = described_class.skip_reason_lines('ex_1', snapshot)
+        expect(lines).to include('  - dependency files: 0 tracked, none changed')
+      end
+    end
+
+    describe '.always_rerun_reason' do
+      it 'returns each status label for membership in its id set' do
+        %w[interrupted flaky failed pending].each do |status|
+          fresh = RSpecTracer::Storage::Snapshot.empty(schema_version: 1, run_id: 'r')
+          fresh["#{status}_examples"] = Set.new(%w[ex_1])
+          expect(described_class.always_rerun_reason('ex_1', fresh)).to eq(status)
+        end
+      end
+
+      it 'resolves ties in filter precedence order (interrupted first)' do
+        snapshot.interrupted_examples = Set.new(%w[ex_1])
+        snapshot.failed_examples = Set.new(%w[ex_1])
+        expect(described_class.always_rerun_reason('ex_1', snapshot)).to eq('interrupted')
+      end
+
+      it 'returns nil when the id carries no always-re-run status' do
+        expect(described_class.always_rerun_reason('ex_1', snapshot)).to be_nil
+      end
+    end
+
+    describe '.next_run_line' do
+      it 'predicts an unconditional re-run for a status-carrying id' do
+        snapshot.flaky_examples = Set.new(%w[ex_1])
+        expect(described_class.next_run_line('ex_1', snapshot))
+          .to eq('will re-run regardless (flaky last run)')
+      end
+
+      it 'predicts a conditional run otherwise, enumerating the boot-file trigger too' do
+        expect(described_class.next_run_line('ex_1', snapshot))
+          .to eq('runs only if a dependency, whole-suite invalidator, boot file, or tracked env var changes')
+      end
     end
   end
 end

--- a/spec/cli/report_open_spec.rb
+++ b/spec/cli/report_open_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe RSpecTracer::CLI::ReportOpen do
       end
     end
 
+    it 'exits 0 silently when a downstream pipe closes early (broken pipe from `| head`)' do
+      broken = StringIO.new
+      allow(broken).to receive(:puts).and_raise(Errno::EPIPE)
+      expect(described_class.run(%w[-h], stdout: broken, stderr: stderr)).to eq(0)
+      expect(stderr.string).to be_empty
+    end
+
     it 'returns 1 with a clear error when index.html is missing' do
       Dir.mktmpdir do |dir|
         allow(RSpecTracer).to receive(:report_path).and_return(dir)

--- a/spec/cli/snapshot_helpers_spec.rb
+++ b/spec/cli/snapshot_helpers_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+require 'tmpdir'
+require 'set'
+
+require 'rspec_tracer/cli/snapshot_helpers'
+require 'rspec_tracer/storage/json_backend'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/storage/schema'
+
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+RSpec.describe RSpecTracer::CLI::SnapshotHelpers do
+  let(:stderr) { StringIO.new }
+
+  describe '.help_requested?' do
+    it 'is true for empty args' do
+      expect(described_class.help_requested?([])).to be(true)
+    end
+
+    it 'is true when -h or --help appears anywhere' do
+      expect(described_class.help_requested?(%w[foo -h])).to be(true)
+      expect(described_class.help_requested?(%w[--help foo])).to be(true)
+    end
+
+    it 'is false for ordinary positional args' do
+      expect(described_class.help_requested?(%w[lib/foo.rb])).to be(false)
+    end
+  end
+
+  describe '.load_snapshot' do
+    it 'prints a prefixed no-cache message and returns nil when no run is recorded' do
+      Dir.mktmpdir do |dir|
+        allow(RSpecTracer).to receive(:storage_backend).and_return(:json)
+        expect(described_class.load_snapshot(dir, command: 'blast-radius', stderr: stderr)).to be_nil
+        expect(stderr.string).to include("blast-radius: no cache yet at #{dir} -- run rspec first")
+      end
+    end
+
+    it 'prints a prefixed incompatibility message and returns nil on schema mismatch' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'last_run.json'),
+                   JSON.dump('schema_version' => 9999, 'run_id' => 'stale_run'))
+        allow(RSpecTracer).to receive(:storage_backend).and_return(:json)
+        expect(described_class.load_snapshot(dir, command: 'explain', stderr: stderr)).to be_nil
+        expect(stderr.string)
+          .to include("explain: cache at #{dir} is incompatible with this rspec-tracer; next rspec run is cold")
+      end
+    end
+
+    it 'returns the snapshot and the backend it was loaded through on success' do
+      Dir.mktmpdir do |dir|
+        snapshot = RSpecTracer::Storage::Snapshot.empty(
+          schema_version: RSpecTracer::Storage::Schema::CURRENT, run_id: 'run_helpers'
+        )
+        snapshot.all_examples = { 'a/spec.rb[1:1]' => { 'example_id' => 'a/spec.rb[1:1]' } }
+        RSpecTracer::Storage::JsonBackend.new(cache_path: dir).save_graph(
+          snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+        )
+        allow(RSpecTracer).to receive(:storage_backend).and_return(:json)
+
+        loaded = described_class.load_snapshot(dir, command: 'explain', stderr: stderr)
+        expect(loaded).not_to be_nil
+        loaded_snapshot, backend = loaded
+        expect(loaded_snapshot.all_examples.keys).to eq(['a/spec.rb[1:1]'])
+        expect(backend).to be_a(RSpecTracer::Storage::JsonBackend)
+        expect(stderr.string).to be_empty
+      end
+    end
+  end
+
+  describe '.filter_decisions_persisted?' do
+    it 'is true for the json backend, which persists filtered_examples' do
+      Dir.mktmpdir do |dir|
+        backend = RSpecTracer::Storage::JsonBackend.new(cache_path: dir)
+        expect(described_class.filter_decisions_persisted?(backend)).to be(true)
+      end
+    end
+
+    it 'is false for any backend that does not persist filter decisions (e.g. sqlite)' do
+      expect(described_class.filter_decisions_persisted?(Object.new)).to be(false)
+    end
+  end
+
+  describe '.fetch_meta' do
+    # Regression: post-#182 msgpack preserves Symbol keys end-to-end;
+    # JSON-deserialized caches yield String keys. CLI helpers must
+    # tolerate either shape.
+    it 'reads through String keys' do
+      expect(described_class.fetch_meta({ 'full_description' => 'x' }, 'full_description')).to eq('x')
+    end
+
+    it 'reads through Symbol keys when the value lives under one' do
+      expect(described_class.fetch_meta({ full_description: 'x' }, 'full_description')).to eq('x')
+    end
+
+    it 'returns the first non-nil match across alternatives' do
+      expect(described_class.fetch_meta({ description: 'y' }, 'full_description', 'description')).to eq('y')
+    end
+
+    it 'returns nil when no alternative matches' do
+      expect(described_class.fetch_meta({}, 'full_description')).to be_nil
+    end
+  end
+
+  describe '.dig_meta' do
+    it 'digs through nested String keys' do
+      meta = { 'execution_result' => { 'status' => 'passed' } }
+      expect(described_class.dig_meta(meta, 'execution_result', 'status')).to eq('passed')
+    end
+
+    it 'digs through mixed String/Symbol levels' do
+      meta = { 'execution_result' => { status: 'failed' } }
+      expect(described_class.dig_meta(meta, 'execution_result', 'status')).to eq('failed')
+    end
+
+    it 'returns nil when an intermediate level is missing or not a Hash' do
+      expect(described_class.dig_meta({}, 'execution_result', 'status')).to be_nil
+      expect(described_class.dig_meta({ 'execution_result' => 'oops' }, 'execution_result', 'status')).to be_nil
+    end
+  end
+
+  describe '.example_location' do
+    it 'prefers the rerun_* fields' do
+      meta = {
+        'rerun_file_name' => './spec/a_spec.rb', 'rerun_line_number' => 3,
+        'file_name' => './spec/other.rb', 'line_number' => 99
+      }
+      expect(described_class.example_location(meta)).to eq(['./spec/a_spec.rb', 3])
+    end
+
+    it 'falls back to file_name/line_number' do
+      meta = { 'file_name' => './spec/b_spec.rb', 'line_number' => 7 }
+      expect(described_class.example_location(meta)).to eq(['./spec/b_spec.rb', 7])
+    end
+
+    it 'returns nils when the meta has no location fields' do
+      expect(described_class.example_location({})).to eq([nil, nil])
+    end
+  end
+
+  describe '.example_description' do
+    it 'prefers full_description and falls back to description' do
+      expect(described_class.example_description({ 'full_description' => 'A' })).to eq('A')
+      expect(described_class.example_description({ 'description' => 'B' })).to eq('B')
+      expect(described_class.example_description({})).to be_nil
+    end
+  end
+end
+# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/edge_cases/cli_corrupt_config_spec.rb
+++ b/spec/edge_cases/cli_corrupt_config_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# End-to-end graceful degradation of the `rspec-tracer` binary when
+# the project's `.rspec-tracer` config itself is broken. The config is
+# arbitrary user Ruby `load`ed while `lib/rspec_tracer.rb` boots, so a
+# raise there happens OUTSIDE every sub-command's rescue. The binary
+# must degrade to a one-line message + exit 1 with:
+#   - no backtrace from the original error (CLI.load_tracer rescues
+#     ScriptError as well as StandardError, because a config
+#     SyntaxError is not a StandardError), and
+#   - no secondary NoMethodError backtrace from the at_exit hook in
+#     lib/rspec_tracer/defaults.rb, which registers before the module
+#     body that defines `at_exit_behavior` runs (guarded via
+#     `respond_to?`).
+#
+# Subprocess-driven because the failure mode lives at library load +
+# process exit -- it cannot be reproduced in-process once the spec
+# suite has loaded rspec_tracer.
+
+require 'open3'
+require 'tmpdir'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'rspec-tracer binary with a corrupt project config' do
+  def run_cli(config_body, *argv)
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, '.rspec-tracer'), config_body)
+      Open3.capture3(
+        { 'BUNDLE_GEMFILE' => File.expand_path('../../Gemfile', __dir__) },
+        'bundle', 'exec', 'ruby', File.expand_path('../../bin/rspec-tracer', __dir__), *argv,
+        chdir: dir
+      )
+    end
+  end
+
+  it 'degrades a raising config to a one-line message and exit 1 for every sub-command path' do
+    _out, err, status = run_cli("raise 'boom at config load'\n", 'cache:info')
+    expect(status.exitstatus).to eq(1)
+    expect(err).to include(
+      'rspec-tracer: could not load configuration (.rspec-tracer): RuntimeError: boom at config load'
+    )
+    # No backtrace frames from the original raise, and no secondary
+    # at_exit crash from the half-loaded module.
+    expect(err).not_to include('load_local_config')
+    expect(err).not_to include('at_exit_behavior')
+    expect(err).not_to include('defaults.rb')
+  end
+
+  it 'degrades a config SyntaxError (not a StandardError) the same way' do
+    _out, err, status = run_cli("def broken(\n", 'doctor')
+    expect(status.exitstatus).to eq(1)
+    expect(err).to include('rspec-tracer: could not load configuration (.rspec-tracer): SyntaxError:')
+    expect(err).not_to include('load_local_config')
+    expect(err).not_to include('at_exit_behavior')
+  end
+
+  it 'still answers --version without booting the config' do
+    out, err, status = run_cli("raise 'boom at config load'\n", '--version')
+    expect(status.exitstatus).to eq(0)
+    expect(out).to match(/\Arspec-tracer \d/)
+    expect(err).to eq('')
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/edge_cases/cli_deprecated_config_purity_spec.rb
+++ b/spec/edge_cases/cli_deprecated_config_purity_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+# End-to-end stdout purity of the `rspec-tracer` binary when the
+# project's `.rspec-tracer` uses a deprecated 1.x DSL option. The
+# deprecation shims (`reports_s3_path`, `use_local_aws`) fire a
+# one-time `logger.warn` while the config loads -- BEFORE sub-command
+# dispatch, and in a fresh CLI process "one-time" means every
+# invocation. The logger's default destination is stdout, so before
+# the CLI rebound `Logger.default_out` around library boot the
+# warning printed AHEAD of the `blast-radius --json` document and
+# broke `... --json | jq` deterministically for exactly the users the
+# compat shims exist to support.
+#
+# Subprocess-driven because the failure mode lives at library load --
+# it cannot be reproduced in-process once the spec suite has loaded
+# rspec_tracer (a second `require 'rspec_tracer'` is a no-op, so the
+# config-load window never reopens).
+
+require 'json'
+require 'open3'
+require 'set'
+require 'tmpdir'
+
+require 'rspec_tracer/storage/json_backend'
+require 'rspec_tracer/storage/snapshot'
+require 'rspec_tracer/storage/schema'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'rspec-tracer binary with a deprecated-DSL project config' do
+  def seed_cache(dir)
+    snapshot = RSpecTracer::Storage::Snapshot.empty(
+      schema_version: RSpecTracer::Storage::Schema::CURRENT, run_id: 'run_purity'
+    )
+    snapshot.all_examples = {
+      'spec/calc_spec.rb[1:1]' => {
+        'example_id' => 'spec/calc_spec.rb[1:1]',
+        'full_description' => 'Calc adds',
+        'rerun_file_name' => './spec/calc_spec.rb',
+        'rerun_line_number' => 7
+      }
+    }
+    snapshot.reverse_dependency = { '/lib/calc.rb' => Set.new(['spec/calc_spec.rb[1:1]']) }
+    RSpecTracer::Storage::JsonBackend.new(cache_path: File.join(dir, 'rspec_tracer_cache')).save_graph(
+      snapshot, schema_version: RSpecTracer::Storage::Schema::CURRENT
+    )
+  end
+
+  def run_cli(config_body, *argv)
+    Dir.mktmpdir do |dir|
+      File.write(File.join(dir, '.rspec-tracer'), config_body)
+      seed_cache(dir)
+      Open3.capture3(
+        {
+          'BUNDLE_GEMFILE' => File.expand_path('../../Gemfile', __dir__),
+          # Deleted (nil) so the subprocess cache_path stays exactly
+          # <dir>/rspec_tracer_cache -- either var appends a scope
+          # segment and would miss the seeded cache.
+          'TEST_SUITE_ID' => nil,
+          'TEST_ENV_NUMBER' => nil
+        },
+        'bundle', 'exec', 'ruby', File.expand_path('../../bin/rspec-tracer', __dir__), *argv,
+        chdir: dir
+      )
+    end
+  end
+
+  it 'keeps `blast-radius --json` stdout strictly parseable with the deprecation warning on stderr' do
+    config = <<~CONFIG
+      RSpecTracer.configure do
+        reports_s3_path 's3://bucket/prefix'
+      end
+    CONFIG
+    out, err, status = run_cli(config, 'blast-radius', '--json', 'lib/calc.rb')
+    expect(status.exitstatus).to eq(0)
+    # Strict parse over the WHOLE stdout capture is the contract
+    # check: it raises if the deprecation line (or anything else)
+    # precedes or follows the single JSON document.
+    payload = JSON.parse(out)
+    expect(payload['files'].first).to include('status' => 'tracked', 'example_count' => 1)
+    expect(err).to include('rspec-tracer deprecation')
+    expect(err).to include('reports_s3_path')
+  end
+
+  it 'keeps the stderr binding when the config resets log_level between deprecated DSL calls' do
+    # `Configuration#log_level` nils the memoized logger instance; the
+    # next deprecation warning constructs a fresh logger mid-load,
+    # which must still pick up the CLI's stderr default.
+    config = <<~CONFIG
+      RSpecTracer.configure do
+        reports_s3_path 's3://bucket/prefix'
+        log_level :debug
+        use_local_aws true
+      end
+    CONFIG
+    out, err, status = run_cli(config, 'blast-radius', '--json', 'lib/calc.rb')
+    expect(status.exitstatus).to eq(0)
+    expect { JSON.parse(out) }.not_to raise_error
+    expect(err).to include('reports_s3_path')
+    expect(err).to include('use_local_aws')
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/lib/rspec_tracer/logger_spec.rb
+++ b/spec/lib/rspec_tracer/logger_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+
+RSpec.describe RSpecTracer::Logger do
+  let(:out) { StringIO.new }
+
+  # Drive every level method once so each spec pins the full gate
+  # table for its log level.
+  def emit_all(logger)
+    logger.debug('d')
+    logger.info('i')
+    logger.warn('w')
+    logger.error('e')
+  end
+
+  describe 'level gating' do
+    it 'emits all four levels at debug (1)' do
+      emit_all(described_class.new(1, out: out))
+      expect(out.string).to eq("d\ni\nw\ne\n")
+    end
+
+    it 'suppresses debug at info (2)' do
+      emit_all(described_class.new(2, out: out))
+      expect(out.string).to eq("i\nw\ne\n")
+    end
+
+    it 'emits only warn and error at warn (3)' do
+      emit_all(described_class.new(3, out: out))
+      expect(out.string).to eq("w\ne\n")
+    end
+
+    it 'emits only error at error (4)' do
+      emit_all(described_class.new(4, out: out))
+      expect(out.string).to eq("e\n")
+    end
+
+    it 'suppresses everything at off (0)' do
+      emit_all(described_class.new(0, out: out))
+      expect(out.string).to be_empty
+    end
+  end
+
+  describe 'destination resolution' do
+    around do |example|
+      # Every path below exercises the fallback chain; pin the
+      # class-level default to a known state and restore after.
+      previous = described_class.default_out
+      example.run
+    ensure
+      described_class.default_out = previous
+    end
+
+    it 'binds to $stdout when out: is omitted and no default_out is set' do
+      described_class.default_out = nil
+      expect { emit_all(described_class.new(1)) }.to output("d\ni\nw\ne\n").to_stdout
+    end
+
+    it 'binds to the class-level default_out when set and out: is omitted' do
+      default = StringIO.new
+      described_class.default_out = default
+      emit_all(described_class.new(1))
+      expect(default.string).to eq("d\ni\nw\ne\n")
+    end
+
+    it 'prefers an explicit out: over the class-level default_out' do
+      described_class.default_out = StringIO.new
+      emit_all(described_class.new(1, out: out))
+      expect(out.string).to eq("d\ni\nw\ne\n")
+    end
+
+    it 'writes nothing through the class-level default_out when out: is explicit' do
+      default = StringIO.new
+      described_class.default_out = default
+      emit_all(described_class.new(1, out: out))
+      expect(default.string).to be_empty
+    end
+
+    it 'captures the destination at construction, not per write' do
+      described_class.default_out = out
+      logger = described_class.new(1)
+      described_class.default_out = StringIO.new
+      logger.error('after rebind')
+      expect(out.string).to eq("after rebind\n")
+    end
+  end
+end

--- a/taskfiles/test-mutation.yml
+++ b/taskfiles/test-mutation.yml
@@ -1319,10 +1319,50 @@ tasks:
           "RSpecTracer::Reporters::Registry*" 86 || fail=1
         exit "$fail"
 
+  test:mutation:cli:
+    desc: >-
+      Mutation pass on the cli/ snapshot-reading surface (BlastRadius +
+      the SnapshotHelpers module both read-side sub-commands share).
+      Single combined run (~20s local); gate 87% sits ~4 pp under the
+      local M2 Max baseline (91.44%, 1578 mutations) to absorb
+      local-vs-CI run variance -- re-cut from CI numbers if the first
+      CI run lands materially lower (154ec27 + 10c0d67 precedent).
+      Explain / Doctor / CacheInfo / CacheClear / ReportOpen are not
+      gated (line-coverage only); BlastRadius is gated because it
+      computes the re-run prediction users act on, and SnapshotHelpers
+      rides along as its (and Explain's) shared loading/lookup core.
+    env:
+      RSPEC_TRACER_DISABLE: '1'
+    cmds:
+      - |
+        if ! bundle show mutant >/dev/null 2>&1; then
+          echo "skip: mutant not installed on this Ruby (needs MRI >= 3.2)"
+          exit 0
+        fi
+
+        echo "=== mutation:cli [CLI::BlastRadius + CLI::SnapshotHelpers] ==="
+        out=$(bundle exec mutant run --use rspec --usage opensource \
+          --jobs 8 \
+          --include lib --require rspec_tracer/cli/blast_radius \
+          "RSpecTracer::CLI::BlastRadius*" \
+          "RSpecTracer::CLI::SnapshotHelpers*" 2>&1 || true)
+        echo "$out"
+        cov=$(echo "$out" | awk '/^Coverage:/ { gsub(/%/, "", $2); print $2 }' | tail -1)
+        if [ -z "$cov" ]; then
+          echo "ERROR [CLI::BlastRadius + CLI::SnapshotHelpers]: could not parse mutant coverage"
+          exit 1
+        fi
+        if awk "BEGIN { exit ($cov >= 87) ? 0 : 1 }"; then
+          echo "mutation:cli [CLI::BlastRadius + CLI::SnapshotHelpers] PASS (coverage $cov% >= 87%)"
+          exit 0
+        fi
+        echo "mutation:cli [CLI::BlastRadius + CLI::SnapshotHelpers] FAIL (coverage $cov% < 87%)"
+        exit 1
+
   test:mutation:full:
     desc: >-
       Full mutation pass - test:mutation:smoke + the per-module
-      subtasks (tracker / storage / rspec / top-level) + the
+      subtasks (tracker / storage / rspec / top-level / cli) + the
       :remote-cache subtask + the :rails / :reporters subtasks.
       Runs per-PR + per-main via lint-and-specs.yml's parallel mutation
       jobs (migrated from the deleted nightly.yml).
@@ -1332,6 +1372,7 @@ tasks:
       - task: test:mutation:storage
       - task: test:mutation:rspec
       - task: test:mutation:top-level
+      - task: test:mutation:cli
       - task: test:mutation:remote-cache
       - task: test:mutation:rails
       - task: test:mutation:reporters


### PR DESCRIPTION
## Summary

**`blast-radius <file> [<file> ...]`** reports which cached examples a change
to each given file would re-run, with `--list` to enumerate them and `--json`
emitting exactly one JSON document on stdout (all diagnostics, including
deprecation shims and backend fallback warnings fired during config load, go
to stderr). Whole-suite invalidators and boot-set files report
`re-runs all N examples` instead of under-reporting via a bare
reverse-dependency lookup. The count reflects the file-change trigger only --
status-based re-runs (failed / flaky / pending / interrupted) are excluded --
and `not tracked in cache` means the tracer never observed the file as an
input (heuristic-tier and blind-spot inputs in ARCHITECTURE.md's soundness
model land here), not that the file never loaded.

**`explain --not-run <example>`** is the skip-side view of `explain`: whether
the example was skipped on the last run, the derivation of why no run trigger
fired, its last recorded status, what would make it run on the next
invocation, and the tracked dependency files. The cache keeps only the most
recent snapshot, so "last status" reflects the last run rather than a run
history, and the derivation covers recorded inputs only -- a change to an
input the tracer never observed cannot appear as a reason.

**`doctor`** now prints an INFO line naming the CI environment variable it
detected and pointing at the cache-persistence recipes in
`docs/CI_RECIPES.md`; it never affects the exit status. This delivers the
CI-discoverability criterion deferred from #228.

Closes #230
Closes #231

## Verification

Three adversarial review rounds, findings fixed and re-verified:

- Acceptance-criteria walk exercised live on both `json` and `sqlite`
  backends across cold, warm, and red cache states.
- Corruption battery (truncated / mangled / wrong-schema caches, raising and
  syntactically-broken `.rspec-tracer` configs) with zero raise paths --
  every failure degrades to a one-line message and a deterministic exit
  status.
- Per-line coverage inspection of the new code in `coverage/.resultset.json`
  (not eyeballed from the summary percentage).
- Mutation gate on the new subjects (`CLI::BlastRadius` +
  `CLI::SnapshotHelpers`): 91.48% coverage against the 87% gate.
- Full pre-PR parity set (lint:ruby, lint:actions, lint:yaml, check:bundle,
  security:bundle-audit, security:trivy, test:unit, test:property,
  test:mutation:smoke, test:dogfood, benchmark:smoke).
- stdout-purity regression: `--json` stdout stays a single parseable JSON
  document even when config-load-time diagnostics fire.

## Out of scope

A pre-existing sqlite-backend defect where a red run's example statuses are
not persisted was reproduced on unmodified main during verification and is
tracked separately from this PR.
