### PR TITLE
release: prepare v2.0.0.rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,38 @@
-## [Unreleased]
+## [2.0.0.rc.1] - 2026-07-13
+
+The first release candidate of the 2.0 line. Fixes the
+duplicate-example drop discarding spec files whose examples live in
+nested `describe` groups
+([#262](https://github.com/avmnu-sng/rspec-tracer/issues/262), fixed
+in [#265](https://github.com/avmnu-sng/rspec-tracer/pull/265)); adds
+a `blast-radius` CLI sub-command
+([#230](https://github.com/avmnu-sng/rspec-tracer/issues/230)) and an
+`explain --not-run` flag
+([#231](https://github.com/avmnu-sng/rspec-tracer/issues/231)), both
+shipped in [#273](https://github.com/avmnu-sng/rspec-tracer/pull/273);
+and repositions the README and docs around the soundness model, CI
+cost framing, and maintenance policy
+([#266](https://github.com/avmnu-sng/rspec-tracer/pull/266), closing
+[#223](https://github.com/avmnu-sng/rspec-tracer/issues/223)–[#229](https://github.com/avmnu-sng/rspec-tracer/issues/229)).
+CI and maintenance hardening alongside: exact dev-tool gem pins
+([#267](https://github.com/avmnu-sng/rspec-tracer/pull/267)), a lint
+gate against internal planning vocabulary shipping in public files
+([#272](https://github.com/avmnu-sng/rspec-tracer/pull/272)), a weekly
+non-gating Ruby-HEAD canary
+([#269](https://github.com/avmnu-sng/rspec-tracer/pull/269)), a
+`release:preflight` task
+([#270](https://github.com/avmnu-sng/rspec-tracer/pull/270)), removal
+of the unused 1.x sample-project tree
+([#268](https://github.com/avmnu-sng/rspec-tracer/pull/268)), and
+security dependency updates across the sample Rails app and CI
+actions ([#257](https://github.com/avmnu-sng/rspec-tracer/pull/257),
+[#259](https://github.com/avmnu-sng/rspec-tracer/pull/259)–[#261](https://github.com/avmnu-sng/rspec-tracer/pull/261),
+[#263](https://github.com/avmnu-sng/rspec-tracer/pull/263),
+[#264](https://github.com/avmnu-sng/rspec-tracer/pull/264)).
+
+The cache `schema_version` is unchanged at `5`: a pre.2 cache carries
+forward warm -- no cold run on this upgrade. See
+[`UPGRADING.md`](UPGRADING.md).
 
 ### Added
 
@@ -69,7 +103,8 @@
   `NoMethodError` backtrace from the library's `at_exit` hook firing
   against the half-loaded module. The binary now prints a one-line
   `could not load configuration` message and exits 1, and `--help` /
-  `--version` answer without booting the config at all.
+  `--version` answer without booting the config at all
+  ([#273](https://github.com/avmnu-sng/rspec-tracer/pull/273)).
 
 - **Duplicate-example drop no longer discards nested spec files**
   ([#262](https://github.com/avmnu-sng/rspec-tracer/issues/262)).

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -35,7 +35,7 @@ Goal: skip already-passing examples on subsequent runs.
 ```ruby
 # Gemfile
 # 2.0 is in pre-release; switch to '~> 2.0' once 2.0.0 final ships.
-gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
+gem 'rspec-tracer', '= 2.0.0.rc.1', group: :test, require: false
 ```
 
 ```sh
@@ -83,7 +83,7 @@ with views, locales, fixtures, schema, and per-example AR queries.
 ```ruby
 # Gemfile (test group)
 # 2.0 is in pre-release; switch to '~> 2.0' once 2.0.0 final ships.
-gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
+gem 'rspec-tracer', '= 2.0.0.rc.1', group: :test, require: false
 ```
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ is supported until at least six months past its upstream EOL -- see
 
 ```ruby
 # Gemfile -- 2.0 is in pre-release; pin explicitly until 2.0.0 final
-gem 'rspec-tracer', '= 2.0.0.pre.2', group: :test, require: false
+gem 'rspec-tracer', '= 2.0.0.rc.1', group: :test, require: false
 ```
 
 Add the tracer's working directories to your `.gitignore` before the

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -16,8 +16,8 @@ issues / PRs.
 The 2.0 line is a ground-up architecture rewrite around the
 input-taxonomy mental model: every test is a pure function of its
 inputs; tracking is input identification; cache invalidation is
-input-digest mismatch. Currently on `2.0.0.pre.2`; observation
-window open before the next pre-release / rc cut.
+input-digest mismatch. Currently on `2.0.0.rc.1`; observation
+window open before the `2.0.0` final cut.
 
 The full per-release feature list is in [`CHANGELOG.md`](CHANGELOG.md).
 The headline themes already shipped:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -70,6 +70,15 @@ unnamed examples, or inserting/removing one ahead of it, gives the
 shifted examples a new identity (one cold run). Give an example an
 explicit description for a fully reorder-stable identity.
 
+**The 2.0.0.pre.2 -> 2.0.0.rc.1 upgrade costs no cold run.** The cache
+`schema_version` is unchanged (still `5`), so a pre.2 cache carries
+forward warm. What rc.1 adds on top is CLI surface, not cache shape:
+`bundle exec rspec-tracer blast-radius <file> [<file> ...]` reports how
+many examples a change to each file would re-run (`--list` enumerates
+them, `--json` for tooling), and `bundle exec rspec-tracer explain
+--not-run <example_id>` shows why an example was skipped on the last
+run and what would make it run on the next.
+
 ## SimpleCov branch coverage now works
 
 The 1.x README warned: *"If you use RSpec Tracer with SimpleCov, then

--- a/lib/rspec_tracer/version.rb
+++ b/lib/rspec_tracer/version.rb
@@ -4,5 +4,5 @@ module RSpecTracer
   # The currently installed gem version, in `MAJOR.MINOR.PATCH[.pre.N]`
   # form. Bumped per release; CI's release workflow asserts the tag
   # matches this constant before pushing to RubyGems.
-  VERSION = '2.0.0.pre.2'
+  VERSION = '2.0.0.rc.1'
 end

--- a/taskfiles/release.yml
+++ b/taskfiles/release.yml
@@ -31,7 +31,11 @@ tasks:
         echo "== [2/5] Forward version promises ========================"
         # Docs sometimes promise a feature for a future version; each
         # promise must still be true (or be rewritten) at tag time.
-        if git grep -InE 'lands in v[0-9]'; then
+        # Case-insensitive and tolerant of up to two punctuation
+        # characters before the version (e.g. a backtick-quoted
+        # "Lands in vN.N.N"); the example spells the version with N
+        # placeholders so this line never matches its own pattern.
+        if git grep -IinE 'lands in .{0,2}v[0-9]'; then
           echo "VERIFY-MANUALLY: re-verify each promised version above."
         else
           echo "PASS: no forward version promises found."


### PR DESCRIPTION
## Summary

Cuts the CHANGELOG block and bumps the version for **v2.0.0.rc.1** — the first release candidate. The [v2.0.0.rc.1 milestone](https://github.com/avmnu-sng/rspec-tracer/milestone/1) is 10/10 closed: the nested-group duplicate-drop fix (#262), the CLI additions (`blast-radius`, `explain --not-run`; #230/#231), the docs repositioning with the soundness model and maintenance policy (#223-#229), CI/maintenance hardening (exact dev-tool pins, committed-text lint gate, Ruby-HEAD canary, release preflight task), and the security dependency updates.

## Verification

`task release:preflight` passes with every manual item resolved (version pins swept — remaining hardcoded versions are honest measurement provenance; forward promises verified against the rc.2 milestone; gem-unpack nomenclature audit clean; VERSION matches the CHANGELOG heading). Full parity set green: rubocop, yamllint, actionlint, leak gate, bundle check, unit, property, mutation smoke, dogfood, edge cases, benchmark smoke, YARD, gem build.

## After merge

Tag the merge commit with an annotated `v2.0.0.rc.1` — the tag push fires the publish workflow (RubyGems + GitHub release). RubyGems treats the `.rc.` segment as a pre-release, so plain `gem install rspec-tracer` continues to resolve 1.x until 2.0.0 final.