### PR TITLE
ci: fix release stub install version and refresh stale workflow comment

### DIFF
--- a/.github/workflows/example-tracer-cache.yml
+++ b/.github/workflows/example-tracer-cache.yml
@@ -17,9 +17,10 @@ name: example-tracer-cache
 #      reads last_run.json + <run_id>/ subdirs from that restored
 #      tree, and decides per-example whether dependencies have
 #      shifted (run) or are unchanged (skip).
-#   3. The post-step save (built into actions/cache@v5) writes the
-#      freshly-updated rspec_tracer_cache/ tree back under the same
-#      key for the next run to restore.
+#   3. When the job succeeds, the post-job save built into the same
+#      actions/cache "Restore" step (no separate save step is needed)
+#      writes the freshly-updated rspec_tracer_cache/ tree back under
+#      the same key for the next run to restore.
 #
 # Trigger shape: workflow_dispatch + a path-filtered push so the
 # demo only auto-fires when the workflow file itself changes (the

--- a/.github/workflows/lint-and-specs.yml
+++ b/.github/workflows/lint-and-specs.yml
@@ -51,7 +51,7 @@ jobs:
         run: task lint:yaml
       - name: Lint — Node (HTML reporter frontend)
         run: task lint:node
-      - name: Lint -- Internal-nomenclature leak check
+      - name: "Lint: Internal-nomenclature leak check"
         run: task docs:leak-check
       - name: Check — Bundle
         run: task check:bundle
@@ -459,7 +459,7 @@ jobs:
     # subjects. Combines original shards 2 + 3 (write-side and
     # init/util) since first CI showed 3-shard split was over-sharded.
     # Includes #initialize and private connection/schema/utility
-    # helpers -- mutant credits kills to the describe block whose
+    # helpers: mutant credits kills to the describe block whose
     # label names the subject, and these helpers have no dedicated
     # describes (they are exercised only through public callers), so
     # their kill rate has a structural ceiling. That is why the
@@ -562,7 +562,7 @@ jobs:
         uses: actions/checkout@v7
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Test -- Mutation (cli)
+      - name: "Test: Mutation (cli)"
         timeout-minutes: 5
         run: task test:mutation:cli
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,16 @@ jobs:
           echo "::error::RUBYGEMS_API_KEY secret is not set. Add it under Settings \u2192 Secrets and variables \u2192 Actions."
           exit 1
 
+      - name: Compute bare gem version from the tag
+        id: version
+        # The tag carries a leading "v" (e.g. v2.0.0.rc.1) but
+        # `gem install -v` needs the bare version (2.0.0.rc.1);
+        # interpolating github.ref_name directly into the release
+        # body rendered the invalid `gem install rspec-tracer -v
+        # v2.0.0.rc.1`. This workflow only fires on tag pushes, so
+        # the fix is empirically testable at the next tag cut.
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v3
         with:
@@ -106,7 +116,7 @@ jobs:
             Install:
 
             ```
-            gem install rspec-tracer -v ${{ github.ref_name }}
+            gem install rspec-tracer -v ${{ steps.version.outputs.value }}
             ```
           draft: false
           prerelease: ${{ steps.prerelease.outputs.value }}

--- a/.github/workflows/ruby-head-canary.yml
+++ b/.github/workflows/ruby-head-canary.yml
@@ -9,19 +9,19 @@ name: ruby-head-canary
 # job never fails the run; each job's final step writes its outcome
 # to $GITHUB_STEP_SUMMARY so failures are visible on the run page.
 #
-# Wednesdays 05:30 UTC -- an off-peak slot distinct from the other
+# Wednesdays 05:30 UTC: an off-peak slot distinct from the other
 # scheduled workflows (combinations Sun 02:00, soak daily 03:00,
 # soak-bump Mon 04:00, CodeQL Mon 09:23).
 #
 # workflow_dispatch enables ad-hoc runs from the Actions UI between
 # scheduled runs. Note: `gh workflow run ruby-head-canary.yml` only
-# resolves after this file lands on the default branch -- GitHub
+# resolves after this file lands on the default branch, because GitHub
 # registers dispatchable workflows from the default branch only.
 #
 # Both interpreters install as prebuilt nightly binaries via
 # ruby/setup-ruby (ruby/ruby-dev-builder and
-# ruby/truffleruby-dev-builder), so setup costs seconds -- no source
-# build. Neither job pins Bundler or RSPEC_VERSION: a head canary
+# ruby/truffleruby-dev-builder), so setup costs seconds with no
+# source build. Neither job pins Bundler or RSPEC_VERSION: a head canary
 # should track the latest toolchain the same way it tracks the
 # latest interpreter.
 #
@@ -64,10 +64,10 @@ jobs:
           version: 3.45.4
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bundle -- list resolved versions
+      - name: "Bundle: list resolved versions"
         run: bundle list
 
-      - name: Test -- Unit
+      - name: "Test: Unit"
         id: unit
         run: task test:unit
 
@@ -93,7 +93,7 @@ jobs:
   truffleruby-head:
     # Runs the same task surface as full-matrix.yml's pinned
     # `truffleruby:` cell (features + edge cases) rather than
-    # `task test:unit` -- the full unit suite is only exercised on
+    # `task test:unit`; the full unit suite is only exercised on
     # MRI cells, so unit failures here would be engine noise, not
     # head signal. Benchmark smoke is intentionally omitted: a
     # weekly informational cell has no ratchet to feed.
@@ -118,14 +118,14 @@ jobs:
           version: 3.45.4
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Bundle -- list resolved versions
+      - name: "Bundle: list resolved versions"
         run: bundle list
 
-      - name: Test -- Features (TruffleRuby)
+      - name: "Test: Features (TruffleRuby)"
         id: features
         run: task test:features:truffleruby
 
-      - name: Test -- Edge cases (concurrent_write + sqlite cases auto-skip)
+      - name: "Test: Edge cases (concurrent_write + sqlite cases auto-skip)"
         id: edge-cases
         if: always() && steps.setup-ruby.outcome == 'success'
         run: task test:edge-cases

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -9,7 +9,7 @@ name: soak
 # parallel under fail-fast: false so one cell's failure doesn't cancel
 # the others. Per-cell timeout-minutes: 240 (4 h cap = 50% margin
 # under GHA's 6 h hard limit so the actions/cache post-hook save
-# still fires even on a slow cold-cache first run -- a job cancelled
+# still fires even on a slow cold-cache first run; a job cancelled
 # at the hard limit skips post-hooks and loses the cache save).
 #
 # 03:00 UTC schedule keeps the run off-peak relative to per-PR CI

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -316,7 +316,7 @@ tracer never observed cannot trigger a re-run. The tiers below
 classify every input type by which side it falls on. Independent of
 tier, examples that previously failed, were flagged flaky, were
 pending, or were interrupted are always re-run, as is any example
-with no cache entry -- skip decisions apply only to examples with a
+with no cache entry: skip decisions apply only to examples with a
 clean, fully-recorded history.
 
 ### The four tiers
@@ -337,7 +337,7 @@ clean, fully-recorded history.
 | Declared file globs (`track_files`, `tracks: { files: ... }`) | Boot-time walk + digest per run | Sound, given the declaration | The guarantee is conditional and applies to files the cache has seen: any change or deletion under a declared glob re-runs the attributed examples. Files added after the last observed run follow the "New source files" row below. |
 | Declared ENV vars (`track_env`, `tracks: { env: ... }`) | Per-run value digest, compared against the cached snapshot | Sound, two documented exceptions | (1) An unset variable and an empty string digest identically, so unset -> `""` is not a change. (2) Wildcard patterns (`RAILS_*`) re-expand against the live environment each run; a variable that disappears entirely also drops off the watch list. Prefer literal names for variables that come and go. |
 | Boot-set files (everything loaded before the first example: `spec_helper` requires, gem-loaded engine `lib/`, eager-loaded `app/`) | Digest snapshot of the boot set; any change invalidates the whole suite | Conservative | Deliberately coarse: safe under `config.eager_load = true` and constant autoload timing, at the cost of whole-suite re-runs on boot-file edits. Opt-out: `transitive_load_tracking false` (re-opens the constants-lookup blind spot). |
-| New source files | Boot-set snapshot compare + per-run re-walk of declared globs and `lib/**/*.rb` | Conservative when boot-loaded; blind spot when runtime-only | A new file that loads during boot (eager-loaded `app/`, `spec_helper` requires) changes the boot-set snapshot and re-runs the whole suite. A new spec file's examples always run (no cache entry). But a file that is only consumed at runtime (a new locale file, a constant resolved by reflection) cannot appear in any previously-cached dependency set, so by itself it does not re-run previously-passing examples -- it enters the graph on the first run that observes it. |
+| New source files | Boot-set snapshot compare + per-run re-walk of declared globs and `lib/**/*.rb` | Conservative when boot-loaded; blind spot when runtime-only | A new file that loads during boot (eager-loaded `app/`, `spec_helper` requires) changes the boot-set snapshot and re-runs the whole suite. A new spec file's examples always run (no cache entry). But a file that is only consumed at runtime (a new locale file, a constant resolved by reflection) cannot appear in any previously-cached dependency set, so by itself it does not re-run previously-passing examples; it enters the graph on the first run that observes it. |
 | File I/O (`File.read`, `YAML.load_file`, `JSON.load_file`, `IO.read`, `Kernel#load`, ...) | `Module#prepend` hooks on class-level entry points | Heuristic | Records exactly what passes through the hooked methods, for allow-listed extensions (`.yml .yaml .json .erb .haml .slim .builder .jbuilder .ru .rake`; `.rb` for `Kernel#load`). Reads via unhooked APIs, C extensions, other extensions, or threads other than the example's are not recorded. |
 | Rails template renders | `render_{template,partial,collection}.action_view` subscribers | Heuristic | Attribution is thread-local: renders on another thread (e.g. an app server thread under browser tests) are not attributed. Malformed event payloads are skipped by design. |
 | I18n translations | Prepend on `I18n::Backend::Base#load_translations` | Heuristic | Covers backends that super-call `Base` (Simple, Chain, Cascade). A backend that never calls up is invisible; YAML-file backends are also caught by the I/O hook. |
@@ -346,15 +346,15 @@ clean, fully-recorded history.
 
 ### What we don't detect
 
-These are the known blind spots -- inputs with no observation
+These are the known blind spots, inputs with no observation
 mechanism. If one of them can change an example's outcome, the tracer
 will not re-run that example on its own:
 
 - **Runtime metaprogramming.** Behavior manufactured from non-file
   state at runtime (`define_method` / `const_set` driven by data the
   tracer never saw as a file read).
-- **Monkey-patches in files that never execute in this process** --
-  most commonly gem code outside the project root, or paths excluded
+- **Monkey-patches in files that never execute in this process.**
+  Most commonly gem code outside the project root, or paths excluded
   by a user filter. A patched gem upgrade is still caught, but only
   at `Gemfile.lock` granularity (whole-suite invalidator).
 - **ENV-var branches without declarations.** The tracer watches only
@@ -369,11 +369,11 @@ will not re-run that example on its own:
   the clock: the tracer digests files, not the world. Schema files
   are the closest observable proxy (see the opt-in row above).
 
-The escape hatch for all of these is declaration -- turning an
-unobservable input into a declared (sound-tier) one:
+The escape hatch for all of these is declaration: turning an
+unobservable input into a declared (sound-tier) one.
 
 ```ruby
-# .rspec-tracer -- suite-wide
+# .rspec-tracer (suite-wide)
 RSpecTracer.configure do
   track_files 'config/feature_flags/**/*.yml'
   track_env 'FEATURE_X'
@@ -397,7 +397,7 @@ end
   when your suite consumes it outside that surface (another thread,
   an exotic backend, an unhooked read path), add a declaration.
 - A **blind spot** must be declared or accepted. When in doubt about
-  whether something is observed, declare it -- a redundant
+  whether something is observed, declare it: a redundant
   declaration costs one digest per run; a missed input costs a stale
   green.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ shipped in [#273](https://github.com/avmnu-sng/rspec-tracer/pull/273);
 and repositions the README and docs around the soundness model, CI
 cost framing, and maintenance policy
 ([#266](https://github.com/avmnu-sng/rspec-tracer/pull/266), closing
-[#223](https://github.com/avmnu-sng/rspec-tracer/issues/223)–[#229](https://github.com/avmnu-sng/rspec-tracer/issues/229)).
+[#223](https://github.com/avmnu-sng/rspec-tracer/issues/223)-[#229](https://github.com/avmnu-sng/rspec-tracer/issues/229)).
 CI and maintenance hardening alongside: exact dev-tool gem pins
 ([#267](https://github.com/avmnu-sng/rspec-tracer/pull/267)), a lint
 gate against internal planning vocabulary shipping in public files
@@ -26,12 +26,12 @@ of the unused 1.x sample-project tree
 ([#268](https://github.com/avmnu-sng/rspec-tracer/pull/268)), and
 security dependency updates across the sample Rails app and CI
 actions ([#257](https://github.com/avmnu-sng/rspec-tracer/pull/257),
-[#259](https://github.com/avmnu-sng/rspec-tracer/pull/259)–[#261](https://github.com/avmnu-sng/rspec-tracer/pull/261),
+[#259](https://github.com/avmnu-sng/rspec-tracer/pull/259)-[#261](https://github.com/avmnu-sng/rspec-tracer/pull/261),
 [#263](https://github.com/avmnu-sng/rspec-tracer/pull/263),
 [#264](https://github.com/avmnu-sng/rspec-tracer/pull/264)).
 
 The cache `schema_version` is unchanged at `5`: a pre.2 cache carries
-forward warm -- no cold run on this upgrade. See
+forward warm, with no cold run on this upgrade. See
 [`UPGRADING.md`](UPGRADING.md).
 
 ### Added
@@ -40,7 +40,7 @@ forward warm -- no cold run on this upgrade. See
   classifying what the tracer guarantees (content digests, explicit
   declarations, env snapshots), where it is deliberately
   conservative, where it relies on heuristics, and what it cannot
-  observe at all -- with the `tracks:` DSL as the escape hatch
+  observe at all, with the `tracks:` DSL as the escape hatch
   ([#226](https://github.com/avmnu-sng/rspec-tracer/issues/226)).
 - **Cost framing for CI.** New README section with measured cold/warm
   timings and a formula for estimating CI-minute and dollar savings

--- a/COOKBOOK.md
+++ b/COOKBOOK.md
@@ -173,7 +173,7 @@ to the tracer.
 ## 3. Detect flaky tests
 
 Goal: find examples that pass and fail without their inputs
-changing -- no extra gems, no retry loops, and no test skipped in
+changing: no extra gems, no retry loops, and no test skipped in
 the process.
 
 rspec-tracer records each example's outcome alongside the inputs it
@@ -184,15 +184,15 @@ is never skipped, so every subsequent run re-investigates it.
 The default setup is all you need:
 
 ```ruby
-# spec/spec_helper.rb -- top of file, before any application code.
-# With SimpleCov, start SimpleCov first -- load order is part of
+# spec/spec_helper.rb, top of file, before any application code.
+# With SimpleCov, start SimpleCov first: load order is part of
 # the contract.
 require 'rspec_tracer'
 RSpecTracer.start
 ```
 
-Not ready to let the tracer skip anything? Run in record-only mode
--- every example still runs, and flaky detection works unchanged:
+Not ready to let the tracer skip anything? Run in record-only mode;
+every example still runs, and flaky detection works unchanged:
 
 ```ruby
 # .rspec-tracer
@@ -216,8 +216,8 @@ Where the output lives:
 **One honest caveat**: flaky detection needs repeated runs on
 unchanged inputs. A single run proves nothing, and if you edit code
 between runs, a fail-then-pass flip looks like a fix, not a flake.
-The strongest signal comes from re-running the same commit -- CI
-retries, or local re-runs without edits.
+The strongest signal comes from re-running the same commit (CI
+retries, or local re-runs without edits).
 
 Pairing with `RSpec::Retry` so flakes don't block CI while you fix
 them? See recipe
@@ -236,8 +236,8 @@ examples depend on it, and through which spec files. No config
 beyond the default:
 
 ```ruby
-# spec/spec_helper.rb -- top of file, before any application code.
-# With SimpleCov, start SimpleCov first -- load order is part of
+# spec/spec_helper.rb, top of file, before any application code.
+# With SimpleCov, start SimpleCov first: load order is part of
 # the contract.
 require 'rspec_tracer'
 RSpecTracer.start
@@ -257,8 +257,8 @@ Run the suite once (a cold run populates the map), then open
 Want the map without enabling skipping? Use the record-only mode
 from recipe [#3](#3-detect-flaky-tests).
 
-**One honest caveat**: the map shows test-to-file dependencies --
-which tests depend on which files -- not code-to-code coupling. Two
+**One honest caveat**: the map shows test-to-file dependencies
+(which tests depend on which files), not code-to-code coupling. Two
 application files that always change together show up only
 indirectly, through the examples that consume both.
 
@@ -300,7 +300,7 @@ identical — only the storage substrate differs.
 
 Whichever backend you pick, the cache is plain files in
 infrastructure you own (your S3 bucket, your Redis, your
-filesystem) -- nothing ships to a vendor backend.
+filesystem); nothing ships to a vendor backend.
 
 ### S3 (preserves 1.x layout)
 
@@ -610,12 +610,12 @@ order, schema version, remote-cache reachability, AR-schema config).
 bundle exec rspec-tracer explain --not-run 'AdminController#create'
 ```
 
-Prints whether the example was skipped on the last run -- and if
+Prints whether the example was skipped on the last run and, if
 so, the derivation of why no run trigger fired (no whole-suite
 invalidator, no boot-file change, no failed / flaky / pending /
 interrupted status, no changed dependency file, unchanged env
-snapshot) -- plus its last recorded status, the condition under
-which it runs next time, and its tracked dependency files. The
+snapshot). It also prints the last recorded status, the condition
+under which it runs next time, and its tracked dependency files. The
 cache keeps only the most recent snapshot, so "last status"
 reflects the last run, not a run history.
 
@@ -786,7 +786,7 @@ bundle exec rspec-tracer blast-radius --list app/models/user.rb
 bundle exec rspec-tracer blast-radius --json app/models/user.rb
 ```
 
-Multiple files compose, with a deduplicated `total:` line -- so you
+Multiple files compose, with a deduplicated `total:` line, so you
 can pipe a branch diff through it and see what a PR invalidates
 before review:
 
@@ -797,7 +797,7 @@ git diff --name-only main | xargs bundle exec rspec-tracer blast-radius
 Files the cache never saw (docs, CI config) report
 `not tracked in cache` and still exit 0, so the git pipeline never
 breaks on non-Ruby paths. `not tracked` means the tracer never
-observed the file as an input -- NOT that the file never loaded.
+observed the file as an input, NOT that the file never loaded.
 Files consumed outside the hooked surface land here too:
 `spec/spec_helper.rb` itself (it executes before coverage tracking
 starts), reads via unhooked APIs or C extensions, and the other

--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://avmnu-sng.github.io/rspec-tracer/)
 
 **Test-dependency intelligence for RSpec: detect flaky tests, map code
-coupling, and -- when you are ready -- re-run only what changed.**
+coupling, and, when you are ready, re-run only what changed.**
 
 rspec-tracer records the inputs it can observe for each RSpec
-example -- Ruby files, file I/O, Rails templates and queries,
-declared globs and ENV branches -- and turns that record into a
+example (Ruby files, file I/O, Rails templates and queries,
+declared globs and ENV branches) and turns that record into a
 flaky-test detector, a per-example dependency map, and optional CI
 acceleration. The flaky report and the dependency map never skip a
 test: value before trust.
 
 **Measured, not promised.** In the maintainer's May 2026 field test
-(rspec-tracer 2.0.0.pre.1, Apple M2 Max), Mastodon's `spec/lib` --
-1,234 examples, Rails 8.1.3, Ruby 3.4.8 -- ran in 116.4 s cold and
+(rspec-tracer 2.0.0.pre.1, Apple M2 Max), Mastodon's `spec/lib`
+(1,234 examples, Rails 8.1.3, Ruby 3.4.8) ran in 116.4 s cold and
 17.0 s warm: **6.85x**, with the tracer's own recording overhead
 included in both runs. "Cold" here is the tracer's own first run,
 not plain RSpec: recording costs roughly 1.6x plain RSpec on this
@@ -25,34 +25,34 @@ repository's Rails benchmark fixture (approximate), and no
 tracer-free Mastodon baseline was measured, so your gain over a
 suite without the tracer will be smaller than cold minus warm.
 Suite shape matters: across the same field tests, warm-run skip
-rates ranged from 31% (a suite carrying 177 pre-existing failures --
+rates ranged from 31% (a suite carrying 177 pre-existing failures:
 failed examples are never skipped) to 100%. Measure your own suite
 before you rely on these numbers.
 
 **Conservative by design, honest about its limits.** The tracer
 never skips failed, flaky, or pending examples, nor any example
 whose recorded inputs changed; when a recorded input is ambiguous,
-it re-runs. Real blind spots exist -- runtime metaprogramming and
+it re-runs. Real blind spots exist (runtime metaprogramming and
 monkey-patches are invisible to it; the `tracks:` DSL is the escape
-hatch -- and the [soundness model](ARCHITECTURE.md#soundness-model)
+hatch), and the [soundness model](ARCHITECTURE.md#soundness-model)
 catalogues the known blind spots. Shadow mode (run everything,
 report what would have been skipped) lands in v2.0.0.rc.2, so you
 can verify the tracer on your own data before trusting it with a
 single skip.
 
 **Your data never leaves your infrastructure.** Everything runs inside
-your test process and your CI cache -- no SaaS backend, no telemetry,
+your test process and your CI cache: no SaaS backend, no telemetry,
 no per-seat pricing.
 
 ## Quick start
 
 Requires Ruby 3.1+ and rspec-core 3.12+ (Rails 7.0+ when using Rails;
 Rails 8.0 needs Ruby 3.2+; JRuby 9.4 supported). Every CI-gated Ruby
-is supported until at least six months past its upstream EOL -- see
+is supported until at least six months past its upstream EOL; see
 [Maintenance](#maintenance).
 
 ```ruby
-# Gemfile -- 2.0 is in pre-release; pin explicitly until 2.0.0 final
+# Gemfile: 2.0 is in pre-release; pin explicitly until 2.0.0 final
 gem 'rspec-tracer', '= 2.0.0.rc.1', group: :test, require: false
 ```
 
@@ -68,7 +68,7 @@ rspec_tracer_report/
 
 ```ruby
 # Top of spec_helper.rb / rails_helper.rb, before any application
-# code. With SimpleCov, start SimpleCov first -- load order is part
+# code. With SimpleCov, start SimpleCov first: load order is part
 # of the contract.
 require 'rspec_tracer'
 RSpecTracer.start
@@ -79,7 +79,7 @@ inputs are unchanged and prints a per-reason breakdown of what
 re-ran; open `rspec_tracer_report/index.html` to audit every
 per-example decision. Not ready to let it skip anything? Set
 `RSPEC_TRACER_RUN_ALL_EXAMPLES=true` (or `run_all_examples true`
-inside the `RSpecTracer.configure` block in `.rspec-tracer`) --
+inside the `RSpecTracer.configure` block in `.rspec-tracer`);
 every example still runs while the flaky report and the dependency
 maps accumulate data.
 
@@ -110,10 +110,10 @@ Heroku CI, plus a link to the canonical GitHub Actions workflow.
 
 All timings are wall-clock and measured, not projected: maintainer
 field tests, May 2026, Apple M2 Max, rspec-tracer 2.0.0.pre.1. In
-every row, "cold" is the tracer's own first, recording run -- it
+every row, "cold" is the tracer's own first, recording run: it
 costs more than plain RSpec (roughly 1.6x on this repository's Rails
 benchmark fixture; approximate), and no tracer-free baseline was
-measured for these projects -- so your savings versus a suite
+measured for these projects, so your savings versus a suite
 without the tracer will be smaller than cold minus warm.
 
 | Project measured | Examples | Cold run | Warm run | Warm skip rate | Saved per warm run |
@@ -126,14 +126,14 @@ The Mastodon warm run is the zero-change best case; in the same
 field test, editing one file re-ran 68 of 1,234 examples in 19.0 s.
 Laptop rows understate CI savings: CI runners are slower than the
 development machine, so the seconds saved per run are typically
-larger there -- the skip ratios are what transfer.
+larger there; the skip ratios are what transfer.
 
 **Worked examples** (every input is an assumption you should replace
 with your own). For any suite:
 
 `(cold seconds - warm seconds) x runs/day / 60 x $/CI-minute x 30 = $/month per full-suite job`
 
-At $0.006/CI-minute (illustrative -- GitHub-hosted Linux list price
+At $0.006/CI-minute (illustrative: GitHub-hosted Linux list price
 at the time of writing; check your provider's current rate) and 50
 CI runs/day on one job:
 
@@ -148,17 +148,17 @@ workers share the saving rather than multiply it.
 
 Conservative assumptions: 50 runs/day and the dollar rate are stated
 assumptions, not measurements; your skip rate may be far lower (see
-the 31% row -- suites with many failing examples skip less, by
+the 31% row: suites with many failing examples skip less, by
 design); remote-cache download time on fresh CI workers is not
 subtracted (measured end-to-end remote-cache gain on clearance was
 still ~4.6x).
 
 ## How it works
 
-Each example's observed inputs -- executed Ruby source (via
-`Coverage`), file I/O (via `Module#prepend` hooks), Rails framework
-events, declared globs and env vars, and whole-suite invalidators
-like `Gemfile.lock` -- are digested and stored per example. The next
+Each example's observed inputs are digested and stored per example:
+executed Ruby source (via `Coverage`), file I/O (via
+`Module#prepend` hooks), Rails framework events, declared globs and
+env vars, and whole-suite invalidators like `Gemfile.lock`. The next
 run recomputes the digests and skips examples whose recorded inputs
 are unchanged. The full input taxonomy lives in
 [ARCHITECTURE.md](ARCHITECTURE.md#input-taxonomy); what each input
@@ -344,8 +344,8 @@ The cache step:
 ```
 
 The 4-component cache key (`runner.os` + Ruby version + your
-project's Gemfile lock -- which also pins the rspec-tracer gem's
-version -- + a fixed name suffix) invalidates when something would
+project's Gemfile lock, which also pins the rspec-tracer gem's
+version, + a fixed name suffix) invalidates when something would
 make the previous run's decisions incorrect: native gem binaries
 differ across runner OSes, Ruby ABI
 changes invalidate native extensions, a tracer upgrade can change the
@@ -461,7 +461,7 @@ proves they coexist.
 **Datadog Test Optimization / Buildkite Test Analytics / CircleCI
 Test Insights?** Those are hosted services: your test metadata ships
 to a vendor backend, with the pricing and procurement that implies.
-rspec-tracer runs entirely inside your test process -- the cache and
+rspec-tracer runs entirely inside your test process: the cache and
 reports are plain files in your repo, S3 bucket, or Redis. No SaaS
 backend, no telemetry, no per-seat pricing; keeping it that way is a
 standing commitment in [ROADMAP.md](ROADMAP.md)'s "Won't do" list.
@@ -487,18 +487,18 @@ After the run, `rspec_tracer_report/index.html` opens five HTML
 reports. The first two deliver value even if you never let the
 tracer skip a single example:
 
-- **Flaky Examples** -- examples that failed on one run and passed on
+- **Flaky Examples**: examples that failed on one run and passed on
   a later one, the canonical intermittence signal: a flake list your
   suite builds passively from the runs you were already doing. Once
   flagged, the tracer refuses to skip them on subsequent runs.
-- **Files Dependency** -- "if I change this file, which tests run?"
+- **Files Dependency**: "if I change this file, which tests run?"
   The file-to-test map that makes refactors, reviews, and deletions
-  safer -- the report unique to rspec-tracer.
-- **Examples Dependency** -- the per-example inverse: "what does this
+  safer, and the report unique to rspec-tracer.
+- **Examples Dependency**: the per-example inverse, "what does this
   test depend on?"
-- **All Examples** -- basic test info (id, status, duration, the
+- **All Examples**: basic test info (id, status, duration, the
   inputs the example consumed).
-- **Duplicate Examples** -- pairs RSpec couldn't uniquely identify
+- **Duplicate Examples**: pairs RSpec couldn't uniquely identify
   (file:line collisions; only appears when duplicates are present).
 
 Plus a machine-readable `rspec_tracer_report/report.json` for CI
@@ -516,8 +516,8 @@ that page is authoritative for the dates below.
 
 | Version | CI-gated | Status |
 |---------|----------|--------|
-| Ruby 3.1 | Yes | Supported. Upstream EOL was 2025-03-26, so the committed six-month window has lapsed -- and 3.1 is still supported today because the policy is a minimum, not a schedule. It remains the floor for the 2.0 release line. |
-| Ruby 3.2 | Yes | Supported. Upstream EOL was 2026-04-01; supported until at least 2026-10-01, and potentially longer -- the policy is a minimum. |
+| Ruby 3.1 | Yes | Supported. Upstream EOL was 2025-03-26, so the committed six-month window has lapsed, and 3.1 is still supported today because the policy is a minimum, not a schedule. It remains the floor for the 2.0 release line. |
+| Ruby 3.2 | Yes | Supported. Upstream EOL was 2026-04-01; supported until at least 2026-10-01, and potentially longer; the policy is a minimum. |
 | Ruby 3.3 | Yes | Supported. Upstream EOL is expected 2027-03-31; supported until at least six months past the published EOL date. |
 | Ruby 3.4 | Yes | Supported, until at least six months past its upstream EOL date (not yet announced). |
 | Ruby 4.0 | Yes | Supported, until at least six months past its upstream EOL date (not yet announced). |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -67,7 +67,7 @@ the pinned Ruby active (`.ruby-version` via rbenv).
 If publishing fails midway (for example RubyGems accepted the gem but
 the GitHub release step failed), do not retag; the tag and the gem
 version are already immutable. Do not reach for "Re-run failed jobs"
-either -- it cannot recover this state, for two reasons:
+either: it cannot recover this state, for two reasons.
 
 - A re-run executes the whole `publish` job from the top, including
   `gem push`. RubyGems rejects a repush of an already-published

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -76,8 +76,8 @@ Items:
   `tracks:`, env snapshot), **conservative** (boot-set whole-suite
   invalidator, Rails `lib/` engine-load fallback), **heuristic** (Rails
   subscriber attribution under common configs), **blind spot** (runtime
-  metaprogramming, monkey-patches, hidden reflection -- called out
-  prominently). Shipped -- see
+  metaprogramming, monkey-patches, hidden reflection, called out
+  prominently). Shipped; see
   [ARCHITECTURE.md](ARCHITECTURE.md#soundness-model).
 - **`safety_mode :paranoid | :balanced | :aggressive` preset DSL.**
   Named presets that toggle existing knobs (`transitive_load_tracking`,
@@ -89,11 +89,11 @@ Items:
   `explain`. Outputs *"if you modify this file, it triggers N examples
   across M files."* Lets developers spot architectural drift before
   the PR review; turns the dependency graph from invisible infra into
-  inspectable insight. Shipped -- see
+  inspectable insight. Shipped; see
   [COOKBOOK.md](COOKBOOK.md#16-measure-a-files-blast-radius).
 - **`bin/rspec-tracer explain --not-run <example_id>`.** The "why
   did this NOT run?" inverse of the existing `explain`. Closes the
-  most-requested observability gap from pre-release. Shipped -- see
+  most-requested observability gap from pre-release. Shipped; see
   [COOKBOOK.md](COOKBOOK.md#12-debug-why-did-this-test-re-run).
 - **Confidence scoring on per-run summary.** Terminal output extends
   to show what proportion of selection decisions came from explicit

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -127,8 +127,8 @@ using the new names; the warns are advisory.
 ## Behavior changes worth knowing
 
 For the full classification of which invalidation decisions are
-guaranteed, conservative, or heuristic -- and what the tracer cannot
-observe at all -- see the
+guaranteed, conservative, or heuristic, and what the tracer cannot
+observe at all, see the
 [soundness model](ARCHITECTURE.md#soundness-model).
 
 ### Duplicate example identities

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -12,7 +12,7 @@ ratchet to catch performance regressions before they land.
 | `cache_load` | Just `Cache#populate_from_disk` + process exit | same |
 | `cold_rails` | Cold RSpec against the Rails fixture (model specs only) | `spec/fixtures/rails_app` |
 
-`file_read_hook` landed later than the other scenarios -- 1.x had no
+`file_read_hook` landed later than the other scenarios: 1.x had no
 I/O prepend hooks to measure.
 
 ## Running

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -71,7 +71,7 @@
 <body>
   <header>
     <h1>rspec-tracer</h1>
-    <p class="lede">Test-dependency intelligence for RSpec: detect flaky tests, map code coupling, and -- when you are ready -- re-run only what changed.</p>
+    <p class="lede">Test-dependency intelligence for RSpec: detect flaky tests, map code coupling, and, when you are ready, re-run only what changed.</p>
     <p class="badges">
       <!-- Single-line per anchor: any internal whitespace would become
            a text-node child of the <a> and render as an underline in

--- a/lib/rspec_tracer/cli.rb
+++ b/lib/rspec_tracer/cli.rb
@@ -2,7 +2,7 @@
 
 require 'optparse'
 
-# Only the Logger class -- NOT the full library, whose boot would
+# Only the Logger class, NOT the full library, whose boot would
 # `load` the project config. {CLI.with_default_logger_out} needs the
 # class defined before that boot so the config-load window cannot
 # construct a stdout-bound logger.
@@ -61,7 +61,7 @@ module RSpecTracer
       end
     rescue Errno::EPIPE
       # A downstream pipe consumer (`rspec-tracer ... | head`) closed
-      # early -- routine in shell pipelines, not a failure. Exit 0
+      # early, which is routine in shell pipelines, not a failure. Exit 0
       # without printing: writing to stderr could raise EPIPE again
       # when both streams share the closed pipe.
       0
@@ -99,11 +99,11 @@ module RSpecTracer
     # the previous value afterwards. This must wrap {.load_tracer}:
     # booting the library `load`s the project + global `.rspec-tracer`
     # configs, and those can write through the logger BEFORE
-    # {.with_logger_on} ever runs -- the 1.x-compat deprecation shims
+    # {.with_logger_on} ever runs: the 1.x-compat deprecation shims
     # (`reports_s3_path`, `use_local_aws`) fire a one-time
     # `logger.warn` at first use, and in a fresh CLI process
     # "one-time" means every invocation. The logger's default
-    # destination is stdout -- the stream machine consumers parse --
+    # destination is stdout (the stream machine consumers parse),
     # so that warning would land ahead of e.g. the `blast-radius
     # --json` document and break `| jq`. With the default rebound,
     # every logger constructed during the window binds to stderr,
@@ -128,8 +128,8 @@ module RSpecTracer
     # {.with_default_logger_out} already redirects loggers constructed
     # during the CLI window; this layer additionally rebinds a logger
     # that was memoized into `RSpecTracer.@logger` BEFORE {.run} was
-    # called (possible for in-process callers -- the spec suite, or a
-    # user embedding the CLI -- where the library booted earlier with
+    # called (possible for in-process callers, the spec suite or a
+    # user embedding the CLI, where the library booted earlier with
     # the stdout default). Sub-commands like `blast-radius --json`
     # promise exactly one JSON document on stdout, so a diagnostic
     # line printed ahead of it breaks `| jq`; together the two layers
@@ -137,7 +137,7 @@ module RSpecTracer
     #
     # `RSpecTracer.logger` memoizes into `@logger`
     # (Configuration#logger); the ivar is seeded directly because
-    # Configuration deliberately exposes no logger setter -- adding
+    # Configuration deliberately exposes no logger setter; adding
     # one would leak it into the user-facing `configure` DSL surface.
     # @api private
     def self.with_logger_on(stderr)

--- a/lib/rspec_tracer/cli/blast_radius.rb
+++ b/lib/rspec_tracer/cli/blast_radius.rb
@@ -6,10 +6,10 @@ require 'rspec_tracer/cli/snapshot_helpers'
 require 'rspec_tracer/tracker/whole_suite_invalidators'
 
 module RSpecTracer
-  # Internal CLI -- see {RSpecTracer} for the user-facing surface.
+  # Internal CLI; see {RSpecTracer} for the user-facing surface.
   # @api private
   module CLI
-    # `rspec-tracer blast-radius <file> [<file> ...]` -- show which
+    # `rspec-tracer blast-radius <file> [<file> ...]`: show which
     # examples a change to each given file would re-run on the next
     # rspec invocation. Reads the persisted reverse-dependency map
     # (file -> examples) plus the whole-suite invalidator watch list
@@ -51,9 +51,9 @@ module RSpecTracer
 
         execute(parsed, stdout, stderr)
       rescue Errno::EPIPE
-        # Downstream pipe (`... | head`, `... | jq`) closed early --
-        # routine in shell pipelines (the help text promotes them),
-        # not a failure. Exit 0 silently.
+        # Downstream pipe (`... | head`, `... | jq`) closed early,
+        # which is routine in shell pipelines (the help text promotes
+        # them), not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "blast-radius: #{e.class}: #{e.message}"
@@ -137,7 +137,7 @@ module RSpecTracer
       # Convert a user-supplied path into the cache's file_name
       # convention (project-relative with a leading `/`, absolute when
       # outside the project root). Computed at command runtime against
-      # `RSpecTracer.root` -- `SourceFile.file_name` is unsuitable here
+      # `RSpecTracer.root`; `SourceFile.file_name` is unsuitable here
       # because its PROJECT_ROOT_REGEX freezes the root at gem-require
       # time, before the CLI loads the project's `.rspec-tracer` config.
       # @api private
@@ -201,7 +201,7 @@ module RSpecTracer
 
       # Enrich one example_id from the persisted all_examples meta.
       # A dangling id (present in reverse_dependency but missing from
-      # all_examples -- stale or partially-written cache) degrades to
+      # all_examples, a stale or partially-written cache) degrades to
       # `<unknown>` fields instead of raising.
       # @api private
       def self.example_entry(id, meta)
@@ -232,7 +232,7 @@ module RSpecTracer
       # Internal helper for the tracer pipeline.
       # The untracked wording sticks to what the tracer can actually
       # observe: absence of the file from the cache. It must NOT claim
-      # the file "never loaded" -- files consumed outside the hooked
+      # the file "never loaded": files consumed outside the hooked
       # surface (spec_helper.rb itself, which executes before coverage
       # tracking starts; reads via unhooked APIs, C extensions, or
       # other threads) load fine yet never appear in the cache. See
@@ -243,11 +243,11 @@ module RSpecTracer
         count = radius[:examples].size
         case radius[:status]
         when 'whole_suite_invalidator'
-          "#{file_name}: whole-suite invalidator -- re-runs all #{count} examples"
+          "#{file_name}: whole-suite invalidator; re-runs all #{count} examples"
         when 'boot_file'
-          "#{file_name}: boot file -- re-runs all #{count} examples"
+          "#{file_name}: boot file; re-runs all #{count} examples"
         when 'untracked'
-          "#{file_name}: not tracked in cache (no recorded dependents -- the tracer never " \
+          "#{file_name}: not tracked in cache (no recorded dependents: the tracer never " \
           'observed it as an input; see the soundness model in ARCHITECTURE.md)'
         when 'no_dependents'
           "#{file_name}: 0 examples (no tracked dependents)"

--- a/lib/rspec_tracer/cli/cache_clear.rb
+++ b/lib/rspec_tracer/cli/cache_clear.rb
@@ -27,8 +27,8 @@ module RSpecTracer
         remove_each(stdout, existing)
         0
       rescue Errno::EPIPE
-        # Downstream pipe (`... | head`) closed early -- routine in
-        # shell pipelines, not a failure. Exit 0 silently.
+        # Downstream pipe (`... | head`) closed early, which is routine
+        # in shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "cache:clear: #{e.class}: #{e.message}"

--- a/lib/rspec_tracer/cli/cache_info.rb
+++ b/lib/rspec_tracer/cli/cache_info.rb
@@ -37,8 +37,8 @@ module RSpecTracer
         print_example_count(stdout, backend)
         0
       rescue Errno::EPIPE
-        # Downstream pipe (`... | head`) closed early -- routine in
-        # shell pipelines, not a failure. Exit 0 silently.
+        # Downstream pipe (`... | head`) closed early, which is routine
+        # in shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "cache:info: #{e.class}: #{e.message}"

--- a/lib/rspec_tracer/cli/doctor.rb
+++ b/lib/rspec_tracer/cli/doctor.rb
@@ -36,8 +36,8 @@ module RSpecTracer
         ok = checks.none? { |line| line.start_with?('FAIL') }
         ok ? 0 : 1
       rescue Errno::EPIPE
-        # Downstream pipe (`... | head`) closed early -- routine in
-        # shell pipelines, not a failure. Exit 0 silently.
+        # Downstream pipe (`... | head`) closed early, which is routine
+        # in shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "doctor: #{e.class}: #{e.message}"
@@ -270,7 +270,7 @@ module RSpecTracer
       def self.ci_environment_check
         var = CI_ENV_VARS.find { |v| !ENV[v].to_s.empty? }
         if var
-          "INFO ci:          detected via ENV[#{var}] -- cache persistence recipes: docs/CI_RECIPES.md"
+          "INFO ci:          detected via ENV[#{var}]; cache persistence recipes: docs/CI_RECIPES.md"
         else
           'INFO ci:          not detected (local run)'
         end

--- a/lib/rspec_tracer/cli/explain.rb
+++ b/lib/rspec_tracer/cli/explain.rb
@@ -3,10 +3,10 @@
 require 'rspec_tracer/cli/snapshot_helpers'
 
 module RSpecTracer
-  # Internal CLI -- see {RSpecTracer} for the user-facing surface.
+  # Internal CLI; see {RSpecTracer} for the user-facing surface.
   # @api private
   module CLI
-    # `rspec-tracer explain <example>` -- show why a given example is
+    # `rspec-tracer explain <example>`: show why a given example is
     # scheduled to run or skip on the next rspec invocation. Backend-
     # agnostic: dispatches through {RSpecTracer::Storage::Backend.build}
     # (via {SnapshotHelpers.load_snapshot}) so `storage_backend :sqlite`
@@ -40,8 +40,8 @@ module RSpecTracer
         end
         0
       rescue Errno::EPIPE
-        # Downstream pipe (`... | head`) closed early -- routine in
-        # shell pipelines, not a failure. Exit 0 silently.
+        # Downstream pipe (`... | head`) closed early, which is routine
+        # in shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "explain: #{e.class}: #{e.message}"
@@ -115,7 +115,7 @@ module RSpecTracer
 
       # The run-side `run reason:` value. For an example the filter
       # SKIPPED on the last run, the persisted run_reason is the
-      # carry-forward reason seeded from an earlier snapshot -- it says
+      # carry-forward reason seeded from an earlier snapshot: it says
       # why the example ran back then, not why it is in its current
       # state. Printing it bare would misreport a skipped example as
       # having a current run trigger, so flag it and point at the
@@ -126,7 +126,7 @@ module RSpecTracer
         return reason unless skipped
 
         "#{reason} (carried forward from an earlier run; " \
-          'this example was SKIPPED last run -- use --not-run for the skip-side view)'
+          'this example was SKIPPED last run; use --not-run for the skip-side view)'
       end
 
       # Internal helper for the tracer pipeline.
@@ -185,7 +185,7 @@ module RSpecTracer
       # backend that persists filter decisions (json) with an empty
       # decision set means the last run recorded no decision for this
       # id (a cold run persists empty sets by design, and an id absent
-      # from the last run has no entry either) -- only a
+      # from the last run has no entry either); only a
       # non-persisting backend (sqlite) earns the storage-backend
       # wording.
       # @return [String]
@@ -193,7 +193,7 @@ module RSpecTracer
         return 'last run:     skipped (cache hit)' if skipped?(id, snapshot)
 
         reason = ran_reason(id, snapshot)
-        return "last run:     ran -- #{reason}" if reason
+        return "last run:     ran (#{reason})" if reason
         return 'last run:     <not recorded by this storage backend>' unless filter_persisted
 
         'last run:     no filter decision recorded (cold run, or this example was not part of it)'

--- a/lib/rspec_tracer/cli/report_open.rb
+++ b/lib/rspec_tracer/cli/report_open.rb
@@ -35,8 +35,8 @@ module RSpecTracer
 
         launch(opener, index_path, stdout, stderr)
       rescue Errno::EPIPE
-        # Downstream pipe (`... | head`) closed early -- routine in
-        # shell pipelines, not a failure. Exit 0 silently.
+        # Downstream pipe (`... | head`) closed early, which is routine
+        # in shell pipelines, not a failure. Exit 0 silently.
         0
       rescue StandardError => e
         stderr.puts "report:open: #{e.class}: #{e.message}"

--- a/lib/rspec_tracer/cli/snapshot_helpers.rb
+++ b/lib/rspec_tracer/cli/snapshot_helpers.rb
@@ -6,7 +6,7 @@ require 'rspec_tracer/storage/schema'
 require 'rspec_tracer/storage/sqlite_backend' if RUBY_ENGINE == 'ruby'
 
 module RSpecTracer
-  # Internal CLI -- see {RSpecTracer} for the user-facing surface.
+  # Internal CLI; see {RSpecTracer} for the user-facing surface.
   # @api private
   module CLI
     # Shared plumbing for the snapshot-reading sub-commands (Explain,
@@ -41,7 +41,7 @@ module RSpecTracer
         backend = Storage::Backend.build(cache_path: cache_path, configuration: RSpecTracer)
         run_id = backend.last_run_id
         if run_id.nil? || run_id.to_s.empty?
-          stderr.puts "#{command}: no cache yet at #{cache_path} -- run rspec first"
+          stderr.puts "#{command}: no cache yet at #{cache_path}; run rspec first"
           return nil
         end
 

--- a/lib/rspec_tracer/configuration.rb
+++ b/lib/rspec_tracer/configuration.rb
@@ -1023,8 +1023,8 @@ module RSpecTracer
     # module default. 0 disables the respective check.
     #
     # Duplicated body rather than factored to a private helper
-    # because configure's alias loop wraps every instance method --
-    # private helpers included -- as a public `_name` DSL surface.
+    # because configure's alias loop wraps every instance method,
+    # private helpers included, as a public `_name` DSL surface.
     # rubocop:disable Metrics/PerceivedComplexity
     def cache_size_warn_per_file_mb(size_mb = nil)
       return @cache_size_warn_per_file_mb if defined?(@cache_size_warn_per_file_mb) && size_mb.nil?

--- a/lib/rspec_tracer/engine.rb
+++ b/lib/rspec_tracer/engine.rb
@@ -481,7 +481,7 @@ module RSpecTracer
     #   subscribers + the inline AR-schema warn at suite time.
     #
     # Without the late-bind path, `track_ar_schema_notifications` was
-    # silently inert under the canonical README setup -- the documented
+    # silently inert under the canonical README setup: the documented
     # `use_transactional_fixtures` warn never fired and the
     # `sql.active_record` subscriber never attached.
     def install_rails_observers
@@ -568,7 +568,7 @@ module RSpecTracer
     #   - DatabaseCleaner :truncation / :deletion / :transaction in
     #     around hooks: same outcome.
     #
-    # Eager path: defer the check to before(:suite) -- at engine.setup
+    # Eager path: defer the check to before(:suite), because at engine.setup
     # the user has not run their RSpec.configure block yet, so
     # `use_transactional_fixtures` is unset. The late-bind path
     # short-circuits this method and inline-fires

--- a/lib/rspec_tracer/line_stub.rb
+++ b/lib/rspec_tracer/line_stub.rb
@@ -14,7 +14,7 @@ module RSpecTracer
   # CI work that isn't justified for stub-line generation).
   #
   # Methods use `def self.x` (not module_function) so future mutation
-  # gating maps to the singleton form -- module_function attaches
+  # gating maps to the singleton form; module_function attaches
   # methods to an anonymous singleton that mutant cannot observe.
   module LineStub
     # Internal helper for the tracer pipeline.

--- a/lib/rspec_tracer/remote_cache/s3_backend.rb
+++ b/lib/rspec_tracer/remote_cache/s3_backend.rb
@@ -286,7 +286,7 @@ module RSpecTracer
         value.empty? ? nil : value
       end
 
-      # -- Tier + key composition -------------------------
+      # ---- Tier + key composition -------------------------
 
       def pr_tier?
         @branch != @default_branch
@@ -346,7 +346,7 @@ module RSpecTracer
         segments.compact.reject { |s| s.to_s.empty? }.join('/')
       end
 
-      # -- Local-side paths -------------------------------
+      # ---- Local-side paths -------------------------------
 
       def local_last_run_path
         File.join(@cache_path, LAST_RUN_FILENAME)
@@ -374,7 +374,7 @@ module RSpecTracer
         nil
       end
 
-      # -- Tree-SHA secondary index -----------------------
+      # ---- Tree-SHA secondary index -----------------------
 
       # Build the list of (tier_prefix, ref) pairs to try, in
       # priority order:
@@ -430,7 +430,7 @@ module RSpecTracer
         FileUtils.rm_f(pointer_path) if defined?(pointer_path) && pointer_path
       end
 
-      # -- Download flow ----------------------------------
+      # ---- Download flow ----------------------------------
 
       # Download the archive for (tier, ref), extract into cache_path,
       # validate the resulting last_run.json. Returns true on validated
@@ -480,14 +480,14 @@ module RSpecTracer
         File.join(@cache_path, ".cache_#{purpose}_#{Process.pid}_#{SecureRandom.hex(4)}.tar.gz")
       end
 
-      # -- Upload flow ------------------------------------
+      # ---- Upload flow ------------------------------------
 
       def upload_file(local_path, s3_key)
         ok, _stdout, stderr = aws_cp_silent(local_path, s3_url(s3_key))
         raise S3BackendError, "Failed to upload #{local_path}: #{stderr.chomp}" unless ok
       end
 
-      # -- Retention --------------------------------------
+      # ---- Retention --------------------------------------
 
       # List refs under the backend's own tier with their last_run.json
       # LastModified. Returns Array<[ref, epoch_timestamp]>, newest first.
@@ -654,7 +654,7 @@ module RSpecTracer
         0
       end
 
-      # -- AWS CLI shell-out ------------------------------
+      # ---- AWS CLI shell-out ------------------------------
 
       def aws_cp_silent(src, dst)
         run_aws('s3', 'cp', src, dst)
@@ -695,7 +695,7 @@ module RSpecTracer
         [status.success?, stdout, stderr]
       end
 
-      # -- Logging ----------------------------------------
+      # ---- Logging ----------------------------------------
 
       def log_debug(message)
         @logger&.debug("rspec-tracer remote_cache: #{message}")

--- a/lib/rspec_tracer/rspec/parallel_tests.rb
+++ b/lib/rspec_tracer/rspec/parallel_tests.rb
@@ -322,7 +322,7 @@ module RSpecTracer
 
       # Elects the worker that performs the per-run merge. Delegates to
       # `::ParallelTests.first_process?`, which returns true iff
-      # `TEST_ENV_NUMBER.to_i <= 1` -- i.e. for exactly one worker
+      # `TEST_ENV_NUMBER.to_i <= 1`, i.e. for exactly one worker
       # (TEST_ENV_NUMBER == '' or '1'), regardless of how many workers
       # were actually spawned vs. how many CPUs the runner reports.
       #
@@ -334,13 +334,13 @@ module RSpecTracer
       #      worker 1 could finish its examples before worker 2 even
       #      loaded spec_helper, observe itself as the max, and enter
       #      `wait_for_other_processes_to_finish` concurrently with
-      #      worker 2's own self-election -- both workers spun on each
+      #      worker 2's own self-election; both workers spun on each
       #      other's pid.
       #
       #   2. `::ParallelTests.last_process?` compares TEST_ENV_NUMBER
       #      against PARALLEL_TEST_GROUPS. parallel_rspec's CLI sets
       #      PARALLEL_TEST_GROUPS to the CPU-based *intended* process
-      #      count, NOT the actual worker count -- so when fewer specs
+      #      count, NOT the actual worker count, so when fewer specs
       #      than CPUs are present, no TEST_ENV_NUMBER ever matches
       #      PARALLEL_TEST_GROUPS and the merge is silently skipped.
       #

--- a/lib/rspec_tracer/tracker/coverage_adapter.rb
+++ b/lib/rspec_tracer/tracker/coverage_adapter.rb
@@ -11,7 +11,7 @@ module RSpecTracer
   # @api private
   module Tracker
     # Wraps Ruby's built-in ::Coverage module. The first observer in
-    # the 2.0 tracker pipeline -- ingests the per-file line-coverage
+    # the 2.0 tracker pipeline: it ingests the per-file line-coverage
     # bitmap that MRI/JRuby maintain natively, normalizes the two
     # possible shapes (array vs SimpleCov-style hash) and emits
     # Tracker::Input values for the files touched between two peeks.
@@ -23,8 +23,8 @@ module RSpecTracer
     # Changing the algorithm is a storage schema_version bump.
     class CoverageAdapter
       # ::Coverage.peek_result returns one of two shapes:
-      #   :array -- { path => [hit_counts | nil, ...] }           (default)
-      #   :hash  -- { path => { lines: [...], branches: {...} } } (SimpleCov
+      #   :array -> { path => [hit_counts | nil, ...] }           (default)
+      #   :hash  -> { path => { lines: [...], branches: {...} } } (SimpleCov
       #                                                           with branch
       #                                                           coverage)
       # :auto detects on the first peek by sniffing a value's type.
@@ -49,13 +49,13 @@ module RSpecTracer
       # Snapshot of the current coverage state: { absolute_path =>
       # Array<Integer|nil> } for files under project root that survive
       # the user filter. Hash-mode input is reduced to its :lines
-      # component -- 2.0 ignores branch coverage (same as 1.x; noted in
+      # component; 2.0 ignores branch coverage (same as 1.x; noted in
       # the upgrade docs).
       def peek
         peek_normalized { |path| filtered?(path) }
       end
 
-      # Same shape as #peek but only filters by `@root_prefix` -- skips
+      # Same shape as #peek but only filters by `@root_prefix`, skipping
       # the user `filters` filter. The coverage.json emitter
       # (`Reporters::CoverageJsonReporter`) calls this at finalize to
       # capture cumulative coverage matching legacy semantics: 1.x's
@@ -97,7 +97,7 @@ module RSpecTracer
 
       # Pure function: returns Set<Input> for files whose line arrays
       # changed between `before` and `after`. Handles nil line entries
-      # (unexecutable lines) correctly -- nil<->nil is not a delta, any
+      # (unexecutable lines) correctly: nil<->nil is not a delta, any
       # other transition is.
       def compute_diff(before, after)
         changed = Set.new

--- a/rspec-tracer.gemspec
+++ b/rspec-tracer.gemspec
@@ -13,11 +13,11 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/avmnu-sng/rspec-tracer'
   spec.summary = <<-SUMMARY.strip.gsub(/\s+/, ' ')
     Test-dependency intelligence for RSpec: detect flaky tests, map code
-    coupling, and -- when you are ready -- re-run only what changed.
+    coupling, and, when you are ready, re-run only what changed.
   SUMMARY
   spec.description = <<-DESCRIPTION.strip.gsub(/\s+/, ' ')
-    RSpec Tracer records the inputs each RSpec example consumes -- using
-    Ruby's built-in coverage library plus explicit declarations -- and turns
+    RSpec Tracer records the inputs each RSpec example consumes, using
+    Ruby's built-in coverage library plus explicit declarations, and turns
     that record into a flaky-test detector, a per-example dependency map, and
     optional CI acceleration that skips the examples whose recorded inputs
     are unchanged. It never skips failed, flaky, or pending examples.

--- a/scripts/leak_check.rb
+++ b/scripts/leak_check.rb
@@ -47,7 +47,7 @@ LEAK_PATTERN = [
   # Word boundaries are spelled as character classes, NOT \b: BSD
   # regex (git grep -E on macOS) has no \b, so a \b-based pattern
   # silently matches nothing locally while GNU regex on Linux CI
-  # matches -- exactly the local/CI divergence this gate exists to
+  # matches: exactly the local/CI divergence this gate exists to
   # prevent. `#` is excluded from the left boundary so CSS hex
   # colors (e.g. #B00100 in fixture error pages) cannot match.
   '(^|[^[:alnum:]_#])[BQFC][0-9]+([^[:alnum:]_]|$)'

--- a/spec/README.md
+++ b/spec/README.md
@@ -134,7 +134,7 @@ local on the first CI run. Precedents: `154ec27`, `10c0d67`.
 
 **Genuine gap, not a ceiling?** Add a behavior test under the natural
 describe that asserts the real contract being broken by the mutation.
-Never weaken an existing assertion to make CI green -- diagnose the
+Never weaken an existing assertion to make CI green; diagnose the
 real cause instead. Never add mutation-bait tests that
 exist only to kill mutations - the test should document a real
 contract the lib promises. If the contract is fuzzy (e.g. log-message

--- a/spec/cli/blast_radius_spec.rb
+++ b/spec/cli/blast_radius_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe RSpecTracer::CLI::BlastRadius do
         # outside the hooked surface (spec_helper.rb, unhooked reads)
         # load fine yet never land in the cache.
         expect(stdout.string).to include(
-          '/README.md: not tracked in cache (no recorded dependents -- the tracer never ' \
+          '/README.md: not tracked in cache (no recorded dependents: the tracer never ' \
           'observed it as an input; see the soundness model in ARCHITECTURE.md)'
         )
       end
@@ -199,12 +199,12 @@ RSpec.describe RSpecTracer::CLI::BlastRadius do
       it 'reports a whole-suite invalidator watch file as re-running everything' do
         expect(described_class.run(%w[Gemfile.lock], stdout: stdout, stderr: stderr)).to eq(0)
         expect(stdout.string)
-          .to include('/Gemfile.lock: whole-suite invalidator -- re-runs all 3 examples')
+          .to include('/Gemfile.lock: whole-suite invalidator; re-runs all 3 examples')
       end
 
       it 'reports a boot-set file as re-running everything' do
         expect(described_class.run(%w[spec/spec_helper.rb], stdout: stdout, stderr: stderr)).to eq(0)
-        expect(stdout.string).to include('/spec/spec_helper.rb: boot file -- re-runs all 3 examples')
+        expect(stdout.string).to include('/spec/spec_helper.rb: boot file; re-runs all 3 examples')
       end
 
       it 'collapses the total to the whole suite when any input is a whole-suite invalidator' do
@@ -403,9 +403,9 @@ RSpec.describe RSpecTracer::CLI::BlastRadius do
       examples = [{ example_id: 'e', spec_file: 's.rb', location: 's.rb:1', description: 'd' }]
       lines = {
         'tracked' => '/f.rb: 1 examples across 1 spec files',
-        'whole_suite_invalidator' => '/f.rb: whole-suite invalidator -- re-runs all 1 examples',
-        'boot_file' => '/f.rb: boot file -- re-runs all 1 examples',
-        'untracked' => '/f.rb: not tracked in cache (no recorded dependents -- the tracer never ' \
+        'whole_suite_invalidator' => '/f.rb: whole-suite invalidator; re-runs all 1 examples',
+        'boot_file' => '/f.rb: boot file; re-runs all 1 examples',
+        'untracked' => '/f.rb: not tracked in cache (no recorded dependents: the tracer never ' \
                        'observed it as an input; see the soundness model in ARCHITECTURE.md)',
         'no_dependents' => '/f.rb: 0 examples (no tracked dependents)'
       }

--- a/spec/cli/cli_spec.rb
+++ b/spec/cli/cli_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe RSpecTracer::CLI do
     it 'routes logger writes fired during library boot (config load) to stderr' do
       # The `.rspec-tracer` 1.x deprecation shims (`reports_s3_path`,
       # `use_local_aws`) write through a logger constructed WHILE
-      # load_tracer boots the library -- before with_logger_on can
+      # load_tracer boots the library, before with_logger_on can
       # rebind the memoized instance. Logger.default_out must already
       # point at stderr inside that window, or the warning lands on
       # stdout ahead of machine-readable output (`blast-radius
@@ -153,7 +153,7 @@ RSpec.describe RSpecTracer::CLI do
 
     it 'catches ScriptError so a config SyntaxError cannot escape as a backtrace' do
       # SyntaxError (raised by a corrupt `.rspec-tracer` at `load`
-      # time) is a ScriptError, NOT a StandardError -- a bare
+      # time) is a ScriptError, NOT a StandardError; a bare
       # `rescue StandardError` would let it crash the binary.
       allow(described_class).to receive(:require).with('rspec_tracer').and_raise(SyntaxError, 'unexpected end')
       expect(described_class.load_tracer(stderr)).to be(false)

--- a/spec/cli/explain_spec.rb
+++ b/spec/cli/explain_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe RSpecTracer::CLI::Explain do
         # A cold run persists EMPTY filtered_examples/skipped_examples
         # by design (the engine computes no filter decisions without a
         # previous snapshot), and an id that was not part of the last
-        # run has no entry either -- neither is a backend limitation
+        # run has no entry either; neither is a backend limitation
         # on the json backend, which persists the field.
         expect(described_class.run(['--not-run', absent_id], stdout: stdout, stderr: stderr)).to eq(0)
         out = stdout.string
@@ -206,7 +206,7 @@ RSpec.describe RSpecTracer::CLI::Explain do
       it 'tells the truth when the example actually ran, with a run-side hint' do
         expect(described_class.run(['--not-run', ran_id], stdout: stdout, stderr: stderr)).to eq(0)
         out = stdout.string
-        expect(out).to include('last run:     ran -- Files changed')
+        expect(out).to include('last run:     ran (Files changed)')
         expect(out).to include("it was not skipped; run 'rspec-tracer explain #{ran_id}' for the run-side view")
       end
 
@@ -228,7 +228,7 @@ RSpec.describe RSpecTracer::CLI::Explain do
         out = stdout.string
         expect(out).to include(
           'run reason:   stale prior-run reason (carried forward from an earlier run; ' \
-          'this example was SKIPPED last run -- use --not-run for the skip-side view)'
+          'this example was SKIPPED last run; use --not-run for the skip-side view)'
         )
         expect(out).not_to include('last run:')
       end
@@ -380,7 +380,7 @@ RSpec.describe RSpecTracer::CLI::Explain do
       it 'reports ran with the recorded reason for a filtered id' do
         snapshot.filtered_examples = { 'ex_1' => 'No cache' }
         expect(described_class.last_run_line('ex_1', snapshot, filter_persisted: true))
-          .to eq('last run:     ran -- No cache')
+          .to eq('last run:     ran (No cache)')
       end
 
       it 'attributes an empty decision set to the run when the backend persists decisions' do

--- a/spec/cli/snapshot_helpers_spec.rb
+++ b/spec/cli/snapshot_helpers_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RSpecTracer::CLI::SnapshotHelpers do
       Dir.mktmpdir do |dir|
         allow(RSpecTracer).to receive(:storage_backend).and_return(:json)
         expect(described_class.load_snapshot(dir, command: 'blast-radius', stderr: stderr)).to be_nil
-        expect(stderr.string).to include("blast-radius: no cache yet at #{dir} -- run rspec first")
+        expect(stderr.string).to include("blast-radius: no cache yet at #{dir}; run rspec first")
       end
     end
 

--- a/spec/edge_cases/cli_corrupt_config_spec.rb
+++ b/spec/edge_cases/cli_corrupt_config_spec.rb
@@ -14,7 +14,7 @@
 #     `respond_to?`).
 #
 # Subprocess-driven because the failure mode lives at library load +
-# process exit -- it cannot be reproduced in-process once the spec
+# process exit; it cannot be reproduced in-process once the spec
 # suite has loaded rspec_tracer.
 
 require 'open3'

--- a/spec/edge_cases/cli_deprecated_config_purity_spec.rb
+++ b/spec/edge_cases/cli_deprecated_config_purity_spec.rb
@@ -3,7 +3,7 @@
 # End-to-end stdout purity of the `rspec-tracer` binary when the
 # project's `.rspec-tracer` uses a deprecated 1.x DSL option. The
 # deprecation shims (`reports_s3_path`, `use_local_aws`) fire a
-# one-time `logger.warn` while the config loads -- BEFORE sub-command
+# one-time `logger.warn` while the config loads, BEFORE sub-command
 # dispatch, and in a fresh CLI process "one-time" means every
 # invocation. The logger's default destination is stdout, so before
 # the CLI rebound `Logger.default_out` around library boot the
@@ -11,7 +11,7 @@
 # broke `... --json | jq` deterministically for exactly the users the
 # compat shims exist to support.
 #
-# Subprocess-driven because the failure mode lives at library load --
+# Subprocess-driven because the failure mode lives at library load;
 # it cannot be reproduced in-process once the spec suite has loaded
 # rspec_tracer (a second `require 'rspec_tracer'` is a no-op, so the
 # config-load window never reopens).
@@ -53,7 +53,7 @@ RSpec.describe 'rspec-tracer binary with a deprecated-DSL project config' do
         {
           'BUNDLE_GEMFILE' => File.expand_path('../../Gemfile', __dir__),
           # Deleted (nil) so the subprocess cache_path stays exactly
-          # <dir>/rspec_tracer_cache -- either var appends a scope
+          # <dir>/rspec_tracer_cache; either var appends a scope
           # segment and would miss the seeded cache.
           'TEST_SUITE_ID' => nil,
           'TEST_ENV_NUMBER' => nil

--- a/spec/engine_spec.rb
+++ b/spec/engine_spec.rb
@@ -994,8 +994,8 @@ RSpec.describe RSpecTracer::Engine do
   end
 
   # Late-bind path (#192): when the user follows the canonical
-  # README setup order -- RSpecTracer.start before
-  # `require_relative '../config/environment'` -- Rails is not yet
+  # README setup order (RSpecTracer.start before
+  # `require_relative '../config/environment'`), Rails is not yet
   # loaded at engine.setup time. arm_rails_late_bind_install
   # registers a before(:suite) hook that re-checks
   # defined?(::Rails::VERSION) once Rails has had a chance to load,
@@ -1075,7 +1075,7 @@ RSpec.describe RSpecTracer::Engine do
     it 'is a no-op when Rails still has not loaded by suite-start time' do
       build_tracker(stub_configuration(rails?: false)).tap(&:setup)
       hook = captured_suite_blocks.first
-      # Intentionally do NOT stub Rails::VERSION -- the hook fires
+      # Intentionally do NOT stub Rails::VERSION: the hook fires
       # before Rails was ever required (rare but possible in pure-Ruby
       # suites that opt into track_ar_schema_notifications by mistake).
       hide_const('Rails::VERSION') if defined?(Rails::VERSION)

--- a/spec/integration/env_var_storage_override_spec.rb
+++ b/spec/integration/env_var_storage_override_spec.rb
@@ -19,7 +19,7 @@ require 'tmpdir'
 #              pointer lives inside the DB).
 #
 # Both contexts assert on the on-disk cache layout (filesystem
-# state), not just exit code -- exit-status-only checks mask
+# state), not just exit code; exit-status-only checks mask
 # cache-persistence bugs.
 #
 # rubocop:disable RSpec/DescribeClass, RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/integration/fail_on_duplicates_spec.rb
+++ b/spec/integration/fail_on_duplicates_spec.rb
@@ -31,7 +31,7 @@ require 'tmpdir'
 #
 # Assertion shape: the load-bearing checks are the exit code, the
 # banner's surviving-example count, and (on the exit-0 path) the
-# written cache -- exit status alone masks cache-persistence bugs.
+# written cache; exit status alone masks cache-persistence bugs.
 #
 # Fixture: a parameterized `.each` loop wrapping a single `it` block
 # produces N examples that share example_group + description +

--- a/spec/integration/flaky_detection_spec.rb
+++ b/spec/integration/flaky_detection_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # End-to-end regression for #194: flaky-test detection silently
-# regressed in 2.0.0.pre.1 -- registry exposes :flaky status, the
+# regressed in 2.0.0.pre.1: registry exposes :flaky status, the
 # filter recognizes :flaky_example, and the JSON / HTML reporters
 # emit flaky_examples, but no production code path transitions an
 # example into the :flaky bucket. README pitches rspec-tracer as a

--- a/spec/integration/leak_check_spec.rb
+++ b/spec/integration/leak_check_spec.rb
@@ -7,8 +7,8 @@ require 'tmpdir'
 
 # Verifies the contract of `task docs:leak-check`
 # (scripts/leak_check.rb): exit zero on a clean tree, non-zero on a
-# leaked internal-nomenclature token, and -- the CHANGELOG-specific
-# section rule -- non-zero on a leak in the active [Unreleased]
+# leaked internal-nomenclature token, and, per the CHANGELOG-specific
+# section rule, non-zero on a leak in the active [Unreleased]
 # block while shipped-history sections below the first
 # released-version heading stay exempt.
 #

--- a/spec/integration/per_example_dsl_spec.rb
+++ b/spec/integration/per_example_dsl_spec.rb
@@ -92,8 +92,9 @@ module PerExampleDslSpecHelpers
 
   # Filter the all_examples map down to the env-branch describe's
   # examples by full_description prefix match.
-  # rubocop:disable Style/ArrayIntersect -- `full` is a String; include? is a
-  #   substring check here, not array membership, so intersect? doesn't apply.
+  # `full` is a String; include? is a substring check here, not array
+  # membership, so intersect? doesn't apply.
+  # rubocop:disable Style/ArrayIntersect
   def env_branch_ids(all_examples)
     all_examples.select do |_, meta|
       full = meta['full_description'] || meta[:full_description]

--- a/spec/integration/schema_version_upgrade_spec.rb
+++ b/spec/integration/schema_version_upgrade_spec.rb
@@ -31,7 +31,7 @@ require 'rspec_tracer/storage/schema'
 #     writes a fresh schema_version-tagged manifest)
 #
 # Assert on the contract behavior (logger output + nil return +
-# post-fallback save), not just on absence-of-raise -- raise-free
+# post-fallback save), not just on absence-of-raise; raise-free
 # runs alone mask cache-persistence bugs.
 # rubocop:disable RSpec/DescribeClass, RSpec/InstanceVariable, RSpec/ContextWording
 # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength

--- a/spec/integration/track_env_config_spec.rb
+++ b/spec/integration/track_env_config_spec.rb
@@ -11,7 +11,7 @@
 #
 # Assertion philosophy matches the other integration specs: assert
 # on the set of examples that re-ran (filter decisions), not exit
-# status -- exit-status-only checks mask cache-persistence bugs.
+# status; exit-status-only checks mask cache-persistence bugs.
 
 require 'bundler'
 require 'fileutils'

--- a/spec/properties/metadata_inheritance_spec.rb
+++ b/spec/properties/metadata_inheritance_spec.rb
@@ -20,7 +20,7 @@ PROPERTY_FILES_POOL = %w[
   app/**/*.rb config/**/*.yml lib/tasks/*.rake db/schema.rb
   app/policies/**/*.rb app/helpers/*.rb
 ].freeze
-# Wildcard entries are opaque strings to Metadata.tracks_for --
+# Wildcard entries are opaque strings to Metadata.tracks_for:
 # the cascade walker just unions them; expansion happens downstream in
 # Engine#register_tracks via Tracker::EnvMatcher.expand. Mixing
 # literals + wildcards in the property pool asserts the walker stays

--- a/spec/soak/realworld_soak_spec.rb
+++ b/spec/soak/realworld_soak_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe "realworld soak (#{PROJECT}#{SHARD_LABEL})" do
   # rubocop:enable RSpec/DescribeClass, RSpec/BeforeAfterAll, RSpec/ExampleLength
   # rubocop:enable RSpec/NoExpectationExample
 
-  # -- helpers ---------------------------------------------------
+  # ---- helpers -------------------------------------------------
 
   def skip_if_jruby
     skip 'soak runs MRI-only (JRuby x Rails subprocess floor too high)' if RUBY_ENGINE != 'ruby'
@@ -432,9 +432,10 @@ RSpec.describe "realworld soak (#{PROJECT}#{SHARD_LABEL})" do
     end
   end
 
-  # rubocop:disable RSpec/Output -- iter-progress markers are the spec's
-  #   primary observability artifact; without them the GHA UI shows zero
-  #   activity for 30+ min which looks like a hang.
+  # Iter-progress markers are the spec's primary observability
+  # artifact; without them the GHA UI shows zero activity for 30+ min
+  # which looks like a hang.
+  # rubocop:disable RSpec/Output
   def announce_iter_start(iter)
     $stdout.write("\n=== #{PROJECT}#{SHARD_LABEL} iter #{iter}/#{ITERATIONS} starting ===\n")
     $stdout.flush
@@ -562,7 +563,7 @@ RSpec.describe "realworld soak (#{PROJECT}#{SHARD_LABEL})" do
       }.join("\n")
   end
 
-  # -- summary --------------------------------------------------
+  # ---- summary ------------------------------------------------
   #
   # write_soak_summary renders tmp/soak/summary.md +
   # tmp/soak/summary.json at the end of every soak run (success or

--- a/taskfiles/release.yml
+++ b/taskfiles/release.yml
@@ -105,9 +105,9 @@ tasks:
         echo
 
         if [ "$fail" -ne 0 ]; then
-          echo "release:preflight: FAILED -- fix the FAIL items above."
+          echo "release:preflight: FAILED. Fix the FAIL items above."
         else
-          echo "release:preflight: OK -- work through the VERIFY-MANUALLY"
+          echo "release:preflight: OK. Work through the VERIFY-MANUALLY"
           echo "items above before tagging."
         fi
         exit "$fail"

--- a/taskfiles/soak.yml
+++ b/taskfiles/soak.yml
@@ -42,7 +42,7 @@ tasks:
       - task: soak:fixture:refinery
       - task: soak:fixture:spree
 
-  # -- Solidus ---------------------------------------------------
+  # ---- Solidus -------------------------------------------------
 
   soak:fixture:solidus:
     desc: >-
@@ -107,7 +107,7 @@ tasks:
     cmds:
       - bundle exec rspec --no-color spec/soak/realworld_soak_spec.rb
 
-  # -- Refinery --------------------------------------------------
+  # ---- Refinery ------------------------------------------------
 
   soak:fixture:refinery:
     desc: >-
@@ -174,7 +174,7 @@ tasks:
     cmds:
       - bundle exec rspec --no-color spec/soak/realworld_soak_spec.rb
 
-  # -- Spree -----------------------------------------------------
+  # ---- Spree ---------------------------------------------------
 
   soak:fixture:spree:
     desc: >-

--- a/taskfiles/test-mutation.yml
+++ b/taskfiles/test-mutation.yml
@@ -174,7 +174,7 @@ tasks:
         # prepended-method entry created equivalent-mutations against
         # the inner `_record` bucket-nil check (mutating either guard
         # alone leaves the other intact, plus the outer rescue
-        # StandardError swallows downstream nil-bucket errors) --
+        # StandardError swallows downstream nil-bucket errors):
         # observably-equivalent mutations plus prepend's no-unprepend
         # idempotency ceiling. Accept the structural carve-out instead
         # of tightening tests against an unobservable difference.
@@ -217,7 +217,7 @@ tasks:
 
   test:mutation:storage:misc:
     desc: >-
-      Storage shard -- small non-JsonBackend / non-SqliteBackend
+      Storage shard: small non-JsonBackend / non-SqliteBackend
       subjects (LazySnapshot, Serializer::Json, Serializer::Msgpack).
       Combined CI wall clock under 2 min. Same gates as the parent
       test:mutation:storage entry.
@@ -269,7 +269,7 @@ tasks:
 
   test:mutation:storage:json-backend:
     desc: >-
-      Storage aggregate -- Storage::JsonBackend split into 9
+      Storage aggregate: Storage::JsonBackend split into 9
       sibling shards (`json-backend-shard-{1..9}`) that run as
       separate parallel CI jobs. JsonBackend has 50 mutant subjects
       (43 instance methods + FieldReader nested class + Merger nested
@@ -301,7 +301,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-1:
     desc: >-
-      JsonBackend shard 1 of 3 -- alphabetical first third: clear!
+      JsonBackend shard 1 of 3, alphabetical first third: clear!
       through field_filename (10 subjects: reads, deserializers,
       formatters). Lighter-weight read/parse helpers; default
       `--mutation-timeout 5` with `--jobs 8`.
@@ -342,7 +342,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-2:
     desc: >-
-      JsonBackend shard 2 of 8 -- middle-section first half
+      JsonBackend shard 2 of 8, middle-section first half
       (9 subjects): format_mib, info, initialize, last_run_id,
       last_run_path, load_graph, lock_path, maybe_prune_after_save,
       maybe_warn_size_budget. Originally an 18-subject shard at
@@ -384,7 +384,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-7:
     desc: >-
-      JsonBackend shard 7 of 8 -- middle-section second half
+      JsonBackend shard 7 of 8, middle-section second half
       (9 subjects): merge_from_peers, msgpack_unavailable_fallback,
       partition_dirs_to_prune, per_file_glob, positive_threshold?,
       read_field, resolve_serializer + FieldReader nested class
@@ -425,7 +425,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-3:
     desc: >-
-      JsonBackend shard 3 of 5 -- heavy write core (7 subjects):
+      JsonBackend shard 3 of 5, heavy write core (7 subjects):
       save_graph, transactional_save, write_json_atomic,
       write_last_run_atomic, write_payload_atomic, write_run_field,
       write_run_files. The file-I/O-dense atomic-write helpers that
@@ -475,7 +475,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-4:
     desc: >-
-      JsonBackend shard 4 of 5 -- reads + serializers + prune
+      JsonBackend shard 4 of 5, reads + serializers + prune
       (7 subjects): prune_run_dirs!, read_json, read_last_run_manifest,
       read_run_file, serialize_dependency, serialize_id_set,
       total_cache_size_bytes. Mixed I/O density.
@@ -519,7 +519,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-5:
     desc: >-
-      JsonBackend shard 5 of 8 -- warn helpers (2 subjects):
+      JsonBackend shard 5 of 8, warn helpers (2 subjects):
       warn_oversized_cache_total, warn_oversized_run_files.
       Originally a 4-subject shard at 4:46 CI (over the 4-min cap);
       split into 5 + 8 isolating Merger.absorb/call (which have
@@ -560,7 +560,7 @@ tasks:
 
   test:mutation:storage:json-backend-shard-8:
     desc: >-
-      JsonBackend shard 8 of 9 -- Merger.absorb (1 subject).
+      JsonBackend shard 8 of 9: Merger.absorb (1 subject).
       Originally a 2-subject shard with Merger.call; split into 1+1
       because the 2-subject shard hit 4:36 CI (over the 4-min cap).
       Merger.absorb does the actual hash absorption — many mutations
@@ -672,7 +672,7 @@ tasks:
 
   test:mutation:storage:sqlite-read:
     desc: >-
-      SqliteBackend shard -- read-side (15 subjects): last_run_id,
+      SqliteBackend shard, read-side (15 subjects): last_run_id,
       load_graph, read_field, read_all_examples, read_all_files,
       read_dependency, read_digest_map, read_duplicate_examples,
       read_env_dependency, read_examples_coverage, read_id_set,
@@ -726,7 +726,7 @@ tasks:
 
   test:mutation:storage:sqlite-write:
     desc: >-
-      SqliteBackend shard -- write-side + connection / schema /
+      SqliteBackend shard, write-side + connection / schema /
       utility (30 subjects). Combines the original shards 2 + 3 since
       first CI showed the 3-shard split was over-sharded
       (each 1-2 min). Includes:
@@ -792,7 +792,7 @@ tasks:
         # Gate is 65% (vs read-side 73%) because this shard
         # concentrates the structural-ceiling subjects:
         # `#initialize` (exercised through sibling-method describes,
-        # which mutant credits to the sibling, not #initialize --
+        # which mutant credits to the sibling, not #initialize;
         # same pattern as Tracker::NewFileDetector#initialize) plus the
         # private connection / schema / utility helpers (exercised
         # via public describes that mutant credits to the public
@@ -879,7 +879,7 @@ tasks:
 
   test:mutation:top-level-a:
     desc: >-
-      Top-level shard A -- alphabetical first half (8 methods):
+      Top-level shard A, alphabetical first half (8 methods):
       at_exit_behavior, build_run_metadata, coverage_reporter,
       emit_reporters, engine, initial_setup, parallel_tests?, rails?.
       Default `--mutation-timeout 5` with `--jobs 8`. Wall clock
@@ -921,7 +921,7 @@ tasks:
 
   test:mutation:top-level-b:
     desc: >-
-      Top-level shard B -- exit/finalize methods (5 methods):
+      Top-level shard B, exit/finalize methods (5 methods):
       run_coverage_exit_task, run_elapsed_seconds, run_exit_tasks,
       run_finalize, run_simplecov_exit_task. Originally 9 methods
       (paired with -c which has setup/start) — split because the
@@ -961,7 +961,7 @@ tasks:
 
   test:mutation:top-level-c:
     desc: >-
-      Top-level shard C -- setup/start methods (4 methods):
+      Top-level shard C, setup/start methods (4 methods):
       setup_coverage, setup_rails, simplecov?, start. Split out from
       top-level-b after the 9-method shard hit the 4-min cap on CI.
     env:
@@ -1038,7 +1038,7 @@ tasks:
 
         fail=0
         # Per-subject gates sized at ~3-5 pp under CI ubuntu-latest
-        # baselines for variance -- always size gates from CI numbers,
+        # baselines for variance: always size gates from CI numbers,
         # never local. Initial cut sized from local M2 Max baselines
         # was too tight: GitAncestry alone swung from 94.59% local to
         # 72.68% CI on the first run because mutant's per-mutation
@@ -1177,7 +1177,7 @@ tasks:
         # end-to-end via the prose-form integration describes
         # (`render subscriber integration via fake AS::Notifications` /
         # `sql.active_record subscriber integration`). Restructuring
-        # describes for coverage rejected -- test organization exists to
+        # describes for coverage rejected: test organization exists to
         # document behavior, not to satisfy the mutation tool.
         run_mutant_gate "Rails::Notifications" \
           "rspec_tracer/rails/notifications" \
@@ -1224,7 +1224,7 @@ tasks:
       via the public `#generate` / `.build` / `.emit_all` describes
       receive no direct credit (mutant credits kills to the describe
       label's method only). Carve-outs sized accordingly; restructuring
-      describes for coverage rejected -- test organization documents
+      describes for coverage rejected: test organization documents
       behavior, it is not reshaped to satisfy the mutation tool.
     env:
       RSPEC_TRACER_DISABLE: '1'
@@ -1325,7 +1325,7 @@ tasks:
       the SnapshotHelpers module both read-side sub-commands share).
       Single combined run (~20s local); gate 87% sits ~4 pp under the
       local M2 Max baseline (91.44%, 1578 mutations) to absorb
-      local-vs-CI run variance -- re-cut from CI numbers if the first
+      local-vs-CI run variance; re-cut from CI numbers if the first
       CI run lands materially lower (154ec27 + 10c0d67 precedent).
       Explain / Doctor / CacheInfo / CacheClear / ReportOpen are not
       gated (line-coverage only); BlastRadius is gated because it

--- a/taskfiles/test.yml
+++ b/taskfiles/test.yml
@@ -97,7 +97,7 @@ tasks:
 
   test:edge-cases:
     desc: >-
-      Edge case suite -- adversarial filesystem + cache + concurrency
+      Edge case suite: adversarial filesystem + cache + concurrency
       tests under spec/edge_cases/. Excluded from the default rspec sweep
       via .rspec --exclude-pattern (note rspec silently ignores that flag
       when explicit positional paths are passed).


### PR DESCRIPTION
## What

- **release.yml**: the "Create GitHub release" stub body interpolated `github.ref_name` into `gem install rspec-tracer -v ...`, and the ref name includes the leading `v`, so the rendered command was the invalid `gem install rspec-tracer -v v2.0.0.rc.1` (observed live on the v2.0.0.rc.1 release before its notes were replaced). A new `version` step strips the leading `v` from `GITHUB_REF_NAME` and the body now references `steps.version.outputs.value`. The stub is otherwise unchanged. A YAML comment notes the workflow only fires on tag pushes, so the fix is empirically testable at the next tag cut.
- **example-tracer-cache.yml**: the lifecycle comment still said the post-step save is "built into actions/cache@v5"; the v5-to-v6 bump (#260) updated the `uses:` line and two other comment mentions but missed this one. Rewritten in version-agnostic terms (the save is part of the same actions/cache restore step) so future major bumps cannot strand it again.

## Checks

- `task lint:yaml`
- `task lint:actions`
- `task docs:leak-check`

## Notes

Stacked on #275 (the double-hyphen prose sweep): merges after that PR, GitHub retargets the base to `main` automatically.